### PR TITLE
Feature/create new i dot targets for enumerations #1827

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ## June 2026
 
 ### Added
-
+- Operatore 'isNot' and 'isNotIn' have been introduced for enumerations. The first checks if a given enumeration element is not equal to another one. The second checks whether this element is not contained in a list.
 - Variability: For the filtering of 150% models, a new API for `IRenamer` is provided. It allows renaming all clones of an instantiated element in one step. The old API which allows renaming only one-by-one is still available - this is not a breaking change.
 - Variability: Introduced extension point `configCombinationLogicExtPoint` (interface `IConfigCombinationLogic`) to make the logic of combining configurations (via `extends`, `abstract` and referenced sub-configurations) configurable per application.
 - Variability: Configuration checking for referenced abstract sub-configurations now respects the active combination logic, and configuration hashing was extended to cover a configuration together with all configurations reachable from it.

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/org.iets3.components.core.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/org.iets3.components.core.mpl
@@ -136,7 +136,7 @@
     <module reference="fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)" version="8" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="cd87ddab-6434-448e-a011-1e1c898de18e(org.iets3.core.expr.statemachines)" version="4" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)</dependency>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/org.iets3.components.functional.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/org.iets3.components.functional.mpl
@@ -140,7 +140,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8e4e17de-bc10-4a34-a376-a243fbde540e(org.iets3.glossary)" version="0" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.hardware/org.iets3.components.hardware.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.hardware/org.iets3.components.hardware.mpl
@@ -122,7 +122,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)</dependency>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.plugin/org.iets3.components.plugin.msd
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.plugin/org.iets3.components.plugin.msd
@@ -77,7 +77,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="07e2118e-763f-4d93-8ae6-23cf5ede3d59(org.iets3.core.plugin)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.req/org.iets3.components.req.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.req/org.iets3.components.req.mpl
@@ -91,7 +91,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="a3c6f642-41b7-44cb-951b-463b8427a245(org.iets3.req.core)" version="0" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.toplevel.adapter/org.iets3.components.toplevel.adapter.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.toplevel.adapter/org.iets3.components.toplevel.adapter.mpl
@@ -107,7 +107,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/org.iets3.core.expr.adt.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/org.iets3.core.expr.adt.mpl
@@ -124,7 +124,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/org.iets3.core.expr.data.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/org.iets3.core.expr.data.mpl
@@ -124,7 +124,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/org.iets3.core.expr.dataflow.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/org.iets3.core.expr.dataflow.mpl
@@ -117,7 +117,7 @@
     <module reference="cee4aa62-aca9-4f26-9602-75129cd457c9(org.iets3.core.expr.dataflow)" version="2" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/org.iets3.core.expr.doc.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/org.iets3.core.expr.doc.mpl
@@ -113,7 +113,7 @@
     <module reference="32190be6-23f7-4e17-aad4-fb739bb3569f(org.iets3.core.expr.doc)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/org.iets3.core.expr.genjava.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/org.iets3.core.expr.genjava.base.mpl
@@ -119,7 +119,7 @@
         <module reference="fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)" version="8" />
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
         <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.data/org.iets3.core.expr.genjava.data.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.data/org.iets3.core.expr.genjava.data.mpl
@@ -97,7 +97,7 @@
         <module reference="646d63c6-d580-4c19-8759-e3a3123f5424(org.iets3.core.expr.genjava.messages.rt)" version="0" />
         <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/org.iets3.core.expr.genjava.messages.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/org.iets3.core.expr.genjava.messages.mpl
@@ -103,7 +103,7 @@
         <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
         <module reference="553a35c5-ccd6-40ba-9923-5e3b354d0c76(org.iets3.core.expr.messages)" version="4" />
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stringvalidation/org.iets3.core.expr.genjava.stringvalidation.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stringvalidation/org.iets3.core.expr.genjava.stringvalidation.mpl
@@ -99,7 +99,7 @@
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
         <module reference="f003a0fe-c140-41d7-a145-ea42368e581c(org.iets3.core.expr.stringvalidation)" version="1" />
         <module reference="f38b69a3-1d33-4f9b-84e0-ac1095df2998(org.iets3.core.expr.stringvalidation.runtime)" version="0" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.tests/org.iets3.core.expr.genjava.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.tests/org.iets3.core.expr.genjava.tests.mpl
@@ -109,7 +109,7 @@
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
         <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
         <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -33,7 +33,7 @@
     <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
     <import index="qt06" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.builder(org.apache.commons/)" />
     <import index="hnhi" ref="r:d354209e-0bea-497f-b905-d66f72900fa8(org.iets3.analysis.base.plugin)" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" implicit="true" />
     <import index="lmd" ref="r:a6074908-e483-4c8e-80b5-5dbf8b24df4c(org.iets3.core.expr.path.structure)" implicit="true" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
@@ -361,6 +361,7 @@
       </concept>
       <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
       <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
+        <child id="1194989344771" name="alternativeConsequence" index="UU_$l" />
         <child id="1167945861827" name="conditionFunction" index="3IZSJc" />
       </concept>
       <concept id="1118786554307" name="jetbrains.mps.lang.generator.structure.LoopMacro" flags="ln" index="1WS0z7">
@@ -4218,7 +4219,7 @@
               </node>
               <node concept="1mIQ4w" id="3l6HSXhHiml" role="2OqNvi">
                 <node concept="chp4Y" id="3l6HSXhHiz0" role="cj9EA">
-                  <ref role="cht4Q" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
+                  <ref role="cht4Q" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
                 </node>
               </node>
             </node>
@@ -4293,7 +4294,7 @@
                                                   <node concept="2OqwBi" id="7hc$_$CPDE1" role="2Oq$k0">
                                                     <node concept="1PxgMI" id="7hc$_$CPDE2" role="2Oq$k0">
                                                       <node concept="chp4Y" id="7hc$_$CPDE3" role="3oSUPX">
-                                                        <ref role="cht4Q" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
+                                                        <ref role="cht4Q" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
                                                       </node>
                                                       <node concept="2OqwBi" id="7hc$_$CPDE4" role="1m5AlR">
                                                         <node concept="30H73N" id="7hc$_$CPDE5" role="2Oq$k0" />
@@ -4302,8 +4303,8 @@
                                                         </node>
                                                       </node>
                                                     </node>
-                                                    <node concept="3TrEf2" id="7hc$_$CPDE7" role="2OqNvi">
-                                                      <ref role="3Tt5mk" to="yv47:5ElkanPSLzu" resolve="literal" />
+                                                    <node concept="3TrEf2" id="3meuf2aW3Dm" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
                                                     </node>
                                                   </node>
                                                   <node concept="1mfA1w" id="7hc$_$CPDE8" role="2OqNvi" />
@@ -4329,7 +4330,7 @@
                                           <node concept="2OqwBi" id="7hc$_$CPDEf" role="2Oq$k0">
                                             <node concept="1PxgMI" id="7hc$_$CPDEg" role="2Oq$k0">
                                               <node concept="chp4Y" id="7hc$_$CPDEh" role="3oSUPX">
-                                                <ref role="cht4Q" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
+                                                <ref role="cht4Q" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
                                               </node>
                                               <node concept="2OqwBi" id="7hc$_$CPDEi" role="1m5AlR">
                                                 <node concept="30H73N" id="7hc$_$CPDEj" role="2Oq$k0" />
@@ -4338,8 +4339,8 @@
                                                 </node>
                                               </node>
                                             </node>
-                                            <node concept="3TrEf2" id="7hc$_$CPDEl" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="yv47:5ElkanPSLzu" resolve="literal" />
+                                            <node concept="3TrEf2" id="3meuf2aW5my" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
                                             </node>
                                           </node>
                                           <node concept="3TrcHB" id="7hc$_$CPDEm" role="2OqNvi">
@@ -4383,9 +4384,37 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3cpWs6" id="3l6HSXhKGya" role="3cqZAp">
-                        <node concept="37vLTw" id="7hc$_$CPEEo" role="3cqZAk">
+                      <node concept="3cpWs6" id="3fg81r5KlVD" role="3cqZAp">
+                        <node concept="37vLTw" id="3fg81r5KlVE" role="3cqZAk">
                           <ref role="3cqZAo" node="7hc$_$CPBuD" resolve="b" />
+                          <node concept="1W57fq" id="3fg81r5KlVF" role="lGtFl">
+                            <node concept="3IZrLx" id="3fg81r5KlVG" role="3IZSJc">
+                              <node concept="3clFbS" id="3fg81r5KlVH" role="2VODD2">
+                                <node concept="3clFbF" id="3fg81r5KlVI" role="3cqZAp">
+                                  <node concept="2OqwBi" id="3fg81r5KlVJ" role="3clFbG">
+                                    <node concept="2OqwBi" id="3fg81r5KlVK" role="2Oq$k0">
+                                      <node concept="30H73N" id="3fg81r5KlVL" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="3fg81r5KlVM" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                      </node>
+                                    </node>
+                                    <node concept="1mIQ4w" id="3fg81r5KlVN" role="2OqNvi">
+                                      <node concept="chp4Y" id="3fg81r5KlVO" role="cj9EA">
+                                        <ref role="cht4Q" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gft3U" id="3fg81r5KlVP" role="UU_$l">
+                              <node concept="3fqX7Q" id="3fg81r5N14W" role="gfFT$">
+                                <node concept="37vLTw" id="3fg81r5N14X" role="3fr31v">
+                                  <ref role="3cqZAo" node="7hc$_$CPBuD" resolve="b" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -6606,45 +6635,45 @@
         </node>
       </node>
     </node>
-    <node concept="3aamgX" id="3l6HSXhHDWK" role="3aUrZf">
+    <node concept="3aamgX" id="6NLFGgCExws" role="3aUrZf">
       <property role="36QftV" value="true" />
-      <ref role="30HIoZ" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
-      <node concept="1Koe21" id="3l6HSXhHHVr" role="1lVwrX">
-        <node concept="3clFb_" id="3l6HSXhHHVI" role="1Koe22">
+      <ref role="30HIoZ" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
+      <node concept="1Koe21" id="6NLFGgCExwt" role="1lVwrX">
+        <node concept="3clFb_" id="6NLFGgCExwu" role="1Koe22">
           <property role="DiZV1" value="false" />
           <property role="od$2w" value="false" />
           <property role="2aFKle" value="false" />
           <property role="TrG5h" value="foo" />
-          <node concept="3Tm1VV" id="3l6HSXhHHVL" role="1B3o_S" />
-          <node concept="10Oyi0" id="3l6HSXhHHW6" role="3clF45" />
-          <node concept="3clFbS" id="3l6HSXhHHVO" role="3clF47">
-            <node concept="3cpWs8" id="3l6HSXhHHWv" role="3cqZAp">
-              <node concept="3cpWsn" id="3l6HSXhHHWy" role="3cpWs9">
+          <node concept="3Tm1VV" id="6NLFGgCExwv" role="1B3o_S" />
+          <node concept="10Oyi0" id="6NLFGgCExww" role="3clF45" />
+          <node concept="3clFbS" id="6NLFGgCExwx" role="3clF47">
+            <node concept="3cpWs8" id="6NLFGgCExwy" role="3cqZAp">
+              <node concept="3cpWsn" id="6NLFGgCExwz" role="3cpWs9">
                 <property role="TrG5h" value="x" />
-                <node concept="10Oyi0" id="3l6HSXhHHWu" role="1tU5fm" />
-                <node concept="3cmrfG" id="3l6HSXhHHX5" role="33vP2m">
+                <node concept="10Oyi0" id="6NLFGgCExw$" role="1tU5fm" />
+                <node concept="3cmrfG" id="6NLFGgCExw_" role="33vP2m">
                   <property role="3cmrfH" value="5" />
                 </node>
               </node>
             </node>
-            <node concept="3cpWs6" id="3l6HSXhHHXE" role="3cqZAp">
-              <node concept="37vLTw" id="3l6HSXhHHYi" role="3cqZAk">
-                <ref role="3cqZAo" node="3l6HSXhHHWy" resolve="x" />
-                <node concept="raruj" id="3l6HSXhHHYA" role="lGtFl" />
-                <node concept="1ZhdrF" id="3l6HSXhHHYB" role="lGtFl">
+            <node concept="3cpWs6" id="6NLFGgCExwA" role="3cqZAp">
+              <node concept="37vLTw" id="6NLFGgCExwB" role="3cqZAk">
+                <ref role="3cqZAo" node="6NLFGgCExwz" resolve="x" />
+                <node concept="raruj" id="6NLFGgCExwC" role="lGtFl" />
+                <node concept="1ZhdrF" id="6NLFGgCExwD" role="lGtFl">
                   <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296/1068581517664" />
                   <property role="2qtEX8" value="variableDeclaration" />
-                  <node concept="3$xsQk" id="3l6HSXhHHYC" role="3$ytzL">
-                    <node concept="3clFbS" id="3l6HSXhHHYD" role="2VODD2">
-                      <node concept="3clFbF" id="3l6HSXhHHZW" role="3cqZAp">
-                        <node concept="2OqwBi" id="3l6HSXhHINI" role="3clFbG">
-                          <node concept="2OqwBi" id="3l6HSXhHIeJ" role="2Oq$k0">
-                            <node concept="30H73N" id="3l6HSXhHHZV" role="2Oq$k0" />
-                            <node concept="3TrEf2" id="3l6HSXhHIoD" role="2OqNvi">
-                              <ref role="3Tt5mk" to="yv47:5ElkanPSLzu" resolve="literal" />
+                  <node concept="3$xsQk" id="6NLFGgCExwE" role="3$ytzL">
+                    <node concept="3clFbS" id="6NLFGgCExwF" role="2VODD2">
+                      <node concept="3clFbF" id="6NLFGgCExwG" role="3cqZAp">
+                        <node concept="2OqwBi" id="6NLFGgCExwH" role="3clFbG">
+                          <node concept="2OqwBi" id="6NLFGgCExwI" role="2Oq$k0">
+                            <node concept="30H73N" id="6NLFGgCExwJ" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="3meuf2aVode" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
                             </node>
                           </node>
-                          <node concept="3TrcHB" id="3l6HSXhHJe1" role="2OqNvi">
+                          <node concept="3TrcHB" id="6NLFGgCExwL" role="2OqNvi">
                             <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                           </node>
                         </node>
@@ -8983,7 +9012,7 @@
               <node concept="1Q6Npb" id="7rdMSLlhOnV" role="2Oq$k0" />
               <node concept="2SmgA7" id="7rdMSLlhOBM" role="2OqNvi">
                 <node concept="chp4Y" id="7rdMSLlhOHX" role="1dBWTz">
-                  <ref role="cht4Q" to="yv47:6WstIz8MK67" resolve="EnumIsInTarget" />
+                  <ref role="cht4Q" to="yv47:4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
                 </node>
               </node>
             </node>
@@ -9004,7 +9033,7 @@
                             <ref role="3cqZAo" node="4z0AnX8179F" resolve="it" />
                           </node>
                           <node concept="2qgKlT" id="7rdMSLlhV5p" role="2OqNvi">
-                            <ref role="37wK5l" to="nu60:4CksDrmwwdX" resolve="reduce" />
+                            <ref role="37wK5l" to="nu60:4L5R3LmDzwi" resolve="reduce" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/org.iets3.core.expr.genjava.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/org.iets3.core.expr.genjava.toplevel.mpl
@@ -111,7 +111,7 @@
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
         <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
         <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/generator/template/org.iets3.core.expr.genjava.util@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/generator/template/org.iets3.core.expr.genjava.util@generator.mps
@@ -8,7 +8,7 @@
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda" version="6" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <use id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext" version="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/org.iets3.core.expr.genjava.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/org.iets3.core.expr.genjava.util.mpl
@@ -65,7 +65,7 @@
         <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
         <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
         <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-        <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+        <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
       </languageVersions>
       <dependencyVersions>
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
@@ -111,7 +111,7 @@
         <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
         <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
         <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
         <module reference="8bb1251e-eae5-47ab-9843-33adfae8edaa(org.iets3.core.expr.util)" version="7" />
       </dependencyVersions>
       <mapping-priorities />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/org.iets3.core.expr.lookup.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/org.iets3.core.expr.lookup.mpl
@@ -112,7 +112,7 @@
     <module reference="0406e4b3-cffd-4d16-8533-6bc50680ab3b(org.iets3.core.expr.lookup)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
@@ -112,7 +112,7 @@
     <module reference="553a35c5-ccd6-40ba-9923-5e3b354d0c76(org.iets3.core.expr.messages)" version="4" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/org.iets3.core.expr.process.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/org.iets3.core.expr.process.mpl
@@ -126,7 +126,7 @@
     <module reference="fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)" version="8" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="50b470e7-14ad-46c3-b540-4586f56d2e9c(org.iets3.core.expr.process)" version="2" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/org.iets3.core.expr.repl.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/org.iets3.core.expr.repl.mpl
@@ -93,7 +93,7 @@
         <module reference="76ac7cd6-5b28-4bc4-9a31-45fa744b6ac9(org.iets3.core.expr.repl#1240669143552786950)" version="0" />
         <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
         <module reference="56959ea0-1a4c-409d-b923-9a5132cecf97(org.iets3.core.expr.tests#543569365052197681)" version="0" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
       </dependencyVersions>
       <mapping-priorities>
         <mapping-priority-rule kind="strictly_before">
@@ -248,7 +248,7 @@
     <module reference="18001c94-33a7-4f68-a7c1-ffddc4b39be1(org.iets3.core.expr.repl)" version="1" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes.tests/org.iets3.core.expr.simpleTypes.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes.tests/org.iets3.core.expr.simpleTypes.tests.mpl
@@ -101,7 +101,7 @@
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="7bcf9284-ca29-484f-a3b3-2855bdd813ad(org.iets3.core.expr.simpleTypes.tests)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/org.iets3.core.expr.statemachines.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/org.iets3.core.expr.statemachines.mpl
@@ -124,7 +124,7 @@
     <module reference="fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)" version="8" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="cd87ddab-6434-448e-a011-1e1c898de18e(org.iets3.core.expr.statemachines)" version="4" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/org.iets3.core.expr.stringvalidation.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/org.iets3.core.expr.stringvalidation.mpl
@@ -102,7 +102,7 @@
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="f003a0fe-c140-41d7-a145-ea42368e581c(org.iets3.core.expr.stringvalidation)" version="1" />
     <module reference="f38b69a3-1d33-4f9b-84e0-ac1095df2998(org.iets3.core.expr.stringvalidation.runtime)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/org.iets3.core.expr.temporal.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/org.iets3.core.expr.temporal.mpl
@@ -132,7 +132,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)" version="4" />
     <module reference="17ecc6b6-d106-4b60-87a9-3fde52f92301(org.iets3.core.expr.temporal.runtime)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -108,7 +108,7 @@
         <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
         <module reference="56959ea0-1a4c-409d-b923-9a5132cecf97(org.iets3.core.expr.tests#543569365052197681)" version="0" />
         <module reference="6effa8ea-ddf9-441a-a29e-80a73b7d0fc7(org.iets3.core.expr.tests.rt)" version="0" />
-        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+        <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
         <module reference="63b449db-0918-4a4a-a891-2c430ab133e4(org.junit.junit5)" version="0" />
       </dependencyVersions>
       <mapping-priorities>
@@ -281,7 +281,7 @@
     <module reference="cbb71b24-470d-4374-b77c-ebd0d3b3bb27(org.iets3.core.expr.plugin)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">6effa8ea-ddf9-441a-a29e-80a73b7d0fc7(org.iets3.core.expr.tests.rt)</dependency>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/migration.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/migration.mps
@@ -14,6 +14,11 @@
         <property id="6911370362349133804" name="isInterface" index="2x4o5l" />
         <child id="6911370362349121514" name="languageIdentity" index="2x4n5j" />
       </concept>
+      <concept id="8415841354032330476" name="jetbrains.mps.lang.smodel.structure.ReferenceLinkId" flags="ng" index="HUanN">
+        <property id="8415841354032330479" name="referenceName" index="HUanK" />
+        <property id="8415841354032330478" name="referenceId" index="HUanL" />
+        <child id="8415841354032330477" name="conceptIdentity" index="HUanM" />
+      </concept>
       <concept id="8415841354032330471" name="jetbrains.mps.lang.smodel.structure.ContainmentLinkId" flags="ng" index="HUanS">
         <property id="8415841354032330474" name="linkName" index="HUanP" />
         <property id="8415841354032330473" name="linkId" index="HUanQ" />
@@ -36,6 +41,10 @@
       <concept id="3116305438947623354" name="jetbrains.mps.lang.migration.structure.MoveContainmentLink" flags="ng" index="7a1rN">
         <child id="8415841354033040054" name="targetId" index="HTpAD" />
         <child id="8415841354033040053" name="sourceId" index="HTpAE" />
+      </concept>
+      <concept id="3116305438947623351" name="jetbrains.mps.lang.migration.structure.MoveReferenceLink" flags="ng" index="7a1rY">
+        <child id="8415841354033040062" name="targetId" index="HTpAx" />
+        <child id="8415841354033040061" name="sourceId" index="HTpAy" />
       </concept>
       <concept id="3116305438947553624" name="jetbrains.mps.lang.migration.structure.RefactoringPart" flags="ng" index="7amoh">
         <property id="3628660716136424362" name="participant" index="hSBgo" />
@@ -229,6 +238,172 @@
             <node concept="2V$Bhx" id="2hueze4PfX3" role="2x4n5j">
               <property role="2V$B1T" value="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" />
               <property role="2V$B1Q" value="org.iets3.core.expr.base" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="W$Crc" id="3meuf2aV0eg">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="4" />
+    <property role="TrG5h" value="Update References: literal-&gt;literal" />
+    <node concept="1w76tK" id="3meuf2aV0eh" role="1w76sc">
+      <node concept="1w76tN" id="3meuf2aV0ei" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateLocalInstances" />
+        <property role="1w7ld4" value="Update instances in current project" />
+      </node>
+      <node concept="1w76tN" id="3meuf2aV0ej" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3meuf2aV0ek" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3meuf2aV0el" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeMigrationScript" />
+        <property role="1w7ld4" value="Write migration script" />
+      </node>
+      <node concept="1w76tN" id="3meuf2aV0em" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3meuf2aV0eo" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3meuf2aV0ed" role="hSBgu">
+        <property role="2pBcoG" value="6527211908668528862" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="literal" />
+      </node>
+      <node concept="2pBcaW" id="3meuf2aV0en" role="hSBgs">
+        <property role="2pBcoG" value="3859154905221301135" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="literal" />
+      </node>
+    </node>
+  </node>
+  <node concept="Z5qvL" id="3meuf2aV0ep">
+    <property role="Z5qvQ" value="6" />
+    <property role="TrG5h" value="Migrate_MoveLinkUp_6" />
+    <property role="1AQGQl" value="Move link `literal` to concept `AbstractEnumSingleInTarget`" />
+    <node concept="Z4OXk" id="3meuf2aV0e$" role="Z5rET">
+      <node concept="2pBcaW" id="3meuf2aV0ey" role="Z5P1v">
+        <property role="2pBcoG" value="6527211908668528862" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="literal_old" />
+      </node>
+      <node concept="2pBcaW" id="3meuf2aV0ez" role="Z5P1t">
+        <property role="2pBcoG" value="3859154905221301135" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="literal" />
+      </node>
+      <node concept="7a1rY" id="3meuf2aV0ex" role="7agGg">
+        <node concept="HUanN" id="3meuf2aV0er" role="HTpAy">
+          <property role="HUanK" value="literal_old" />
+          <property role="HUanL" value="1dl9jij8zwov2" />
+          <node concept="2x4n5u" id="3meuf2aV0es" role="HUanM">
+            <property role="2x4mPI" value="EnumIsTarget" />
+            <property role="2x4n5l" value="1dl9jij8zjxy5" />
+            <node concept="2V$Bhx" id="3meuf2aV0et" role="2x4n5j">
+              <property role="2V$B1T" value="71934284-d7d1-45ee-a054-8c072591085f" />
+              <property role="2V$B1Q" value="org.iets3.core.expr.toplevel" />
+            </node>
+          </node>
+        </node>
+        <node concept="HUanN" id="3meuf2aV0eu" role="HTpAx">
+          <property role="HUanK" value="literal" />
+          <property role="HUanL" value="tbis8ooturgv" />
+          <node concept="2x4n5u" id="3meuf2aV0ev" role="HUanM">
+            <property role="2x4mPI" value="AbstractEnumSingleInTarget" />
+            <property role="2x4n5l" value="sd5q5u38v3ib" />
+            <node concept="2V$Bhx" id="3meuf2aV0ew" role="2x4n5j">
+              <property role="2V$B1T" value="71934284-d7d1-45ee-a054-8c072591085f" />
+              <property role="2V$B1Q" value="org.iets3.core.expr.toplevel" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="W$Crc" id="3meuf2b3h5p">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="5" />
+    <property role="TrG5h" value="Update References: selectors-&gt;selectors" />
+    <node concept="1w76tK" id="3meuf2b3h5q" role="1w76sc">
+      <node concept="1w76tN" id="3meuf2b3h5r" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateLocalInstances" />
+        <property role="1w7ld4" value="Update instances in current project" />
+      </node>
+      <node concept="1w76tN" id="3meuf2b3h5s" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3meuf2b3h5t" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3meuf2b3h5u" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeMigrationScript" />
+        <property role="1w7ld4" value="Write migration script" />
+      </node>
+      <node concept="1w76tN" id="3meuf2b3h5v" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3meuf2b3h5x" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3meuf2b3h5m" role="hSBgu">
+        <property role="2pBcoG" value="8006404979731136906" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="selectors" />
+      </node>
+      <node concept="2pBcaW" id="3meuf2b3h5w" role="hSBgs">
+        <property role="2pBcoG" value="3859154905223467352" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="selectors" />
+      </node>
+    </node>
+  </node>
+  <node concept="Z5qvL" id="3meuf2b3h5y">
+    <property role="Z5qvQ" value="7" />
+    <property role="TrG5h" value="Migrate_MoveLinkUp_7" />
+    <property role="1AQGQl" value="Move link `selectors` to concept `AbstractEnumInTarget`" />
+    <node concept="Z4OXk" id="3meuf2b3h5H" role="Z5rET">
+      <node concept="2pBcaW" id="3meuf2b3h5F" role="Z5P1v">
+        <property role="2pBcoG" value="8006404979731136906" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="selectors_old" />
+      </node>
+      <node concept="2pBcaW" id="3meuf2b3h5G" role="Z5P1t">
+        <property role="2pBcoG" value="3859154905223467352" />
+        <property role="2pBcow" value="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+        <property role="2pBc3U" value="selectors" />
+      </node>
+      <node concept="7a1rN" id="3meuf2b3h5E" role="7agGg">
+        <node concept="HUanS" id="3meuf2b3h5$" role="HTpAE">
+          <property role="HUanP" value="selectors_old" />
+          <property role="HUanQ" value="1otu9p31t9ea2" />
+          <node concept="2x4n5u" id="3meuf2b3h5_" role="HUanR">
+            <property role="2x4mPI" value="EnumIsInTarget" />
+            <property role="2x4n5l" value="1otu9p31t9e9z" />
+            <node concept="2V$Bhx" id="3meuf2b3h5A" role="2x4n5j">
+              <property role="2V$B1T" value="71934284-d7d1-45ee-a054-8c072591085f" />
+              <property role="2V$B1Q" value="org.iets3.core.expr.toplevel" />
+            </node>
+          </node>
+        </node>
+        <node concept="HUanS" id="3meuf2b3h5B" role="HTpAD">
+          <property role="HUanP" value="selectors" />
+          <property role="HUanQ" value="tbis8oov56xk" />
+          <node concept="2x4n5u" id="3meuf2b3h5C" role="HUanR">
+            <property role="2x4mPI" value="AbstractEnumInTarget" />
+            <property role="2x4n5l" value="15r87ykkct5kc" />
+            <node concept="2V$Bhx" id="3meuf2b3h5D" role="2x4n5j">
+              <property role="2V$B1T" value="71934284-d7d1-45ee-a054-8c072591085f" />
+              <property role="2V$B1Q" value="org.iets3.core.expr.toplevel" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -184,7 +184,7 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
-      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
@@ -204,11 +204,22 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
@@ -420,6 +431,9 @@
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1522217801069396578" name="jetbrains.mps.baseLanguage.collections.structure.FoldLeftOperation" flags="nn" index="1MD8d$">
+        <child id="1522217801069421796" name="seed" index="1MDeny" />
+      </concept>
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
@@ -7441,7 +7455,7 @@
                 <node concept="2OqwBi" id="u9itSZVPPQ" role="2Oq$k0">
                   <node concept="13iPFW" id="u9itSZVPDr" role="2Oq$k0" />
                   <node concept="3TrEf2" id="u9itSZVPYz" role="2OqNvi">
-                    <ref role="3Tt5mk" to="yv47:5ElkanPSLzu" resolve="literal" />
+                    <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
                   </node>
                 </node>
                 <node concept="3TrcHB" id="u9itSZVQzE" role="2OqNvi">
@@ -9822,7 +9836,7 @@
                 <node concept="2OqwBi" id="6WstIz8MLa3" role="2Oq$k0">
                   <node concept="13iPFW" id="6WstIz8MLa4" role="2Oq$k0" />
                   <node concept="3Tsc0h" id="6WstIz8MMtP" role="2OqNvi">
-                    <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
+                    <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
                   </node>
                 </node>
                 <node concept="3$u5V9" id="4oS6BnNahqr" role="2OqNvi">
@@ -9860,284 +9874,36 @@
       </node>
       <node concept="17QB3L" id="6WstIz8MLa7" role="3clF45" />
     </node>
-    <node concept="13i0hz" id="4CksDrmwwdX" role="13h7CS">
-      <property role="TrG5h" value="reduce" />
-      <node concept="3Tm1VV" id="4CksDrmwwdY" role="1B3o_S" />
-      <node concept="3Tqbb2" id="4CksDrmwwed" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-      </node>
-      <node concept="3clFbS" id="4CksDrmwwe0" role="3clF47">
-        <node concept="3clFbJ" id="2Q9SoGTlFLk" role="3cqZAp">
-          <node concept="3clFbS" id="2Q9SoGTlFLm" role="3clFbx">
-            <node concept="3cpWs6" id="2Q9SoGTlJho" role="3cqZAp">
-              <node concept="10Nm6u" id="2Q9SoGTlJQK" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="2OqwBi" id="2Q9SoGTlHUm" role="3clFbw">
-            <node concept="2OqwBi" id="2Q9SoGTlG6m" role="2Oq$k0">
-              <node concept="13iPFW" id="2Q9SoGTlFPK" role="2Oq$k0" />
-              <node concept="3Tsc0h" id="2Q9SoGTlGjE" role="2OqNvi">
-                <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
-              </node>
-            </node>
-            <node concept="1v1jN8" id="2Q9SoGTlJgs" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7rdMSLlhcYT" role="3cqZAp">
-          <node concept="3cpWsn" id="7rdMSLlhcYU" role="3cpWs9">
-            <property role="TrG5h" value="ctx" />
-            <node concept="3Tqbb2" id="7rdMSLlhcYQ" role="1tU5fm">
-              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-            </node>
-            <node concept="2OqwBi" id="7rdMSLlmZZt" role="33vP2m">
-              <node concept="1PxgMI" id="7rdMSLlhcYV" role="2Oq$k0">
-                <node concept="chp4Y" id="7rdMSLlmZlU" role="3oSUPX">
-                  <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-                </node>
-                <node concept="2OqwBi" id="7rdMSLlhcYX" role="1m5AlR">
-                  <node concept="13iPFW" id="7rdMSLlhcYY" role="2Oq$k0" />
-                  <node concept="1mfA1w" id="7rdMSLlhcYZ" role="2OqNvi" />
-                </node>
-              </node>
-              <node concept="3TrEf2" id="7rdMSLln0Kr" role="2OqNvi">
-                <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="4CksDrmwA7G" role="3cqZAp">
-          <node concept="3clFbS" id="4CksDrmwA7I" role="3clFbx">
-            <node concept="3cpWs6" id="4CksDrmwNfi" role="3cqZAp">
-              <node concept="BsUDl" id="7rdMSLlhiZ9" role="3cqZAk">
-                <ref role="37wK5l" node="7rdMSLlhiZ5" resolve="single" />
-                <node concept="37vLTw" id="7rdMSLlhiZ8" role="37wK5m">
-                  <ref role="3cqZAo" node="7rdMSLlhcYU" resolve="ctx" />
-                </node>
-                <node concept="2OqwBi" id="7rdMSLlhiWx" role="37wK5m">
-                  <node concept="2OqwBi" id="7rdMSLlhiWy" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7rdMSLlhiWz" role="2Oq$k0">
-                      <node concept="13iPFW" id="7rdMSLlhiW$" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="7rdMSLlhiW_" role="2OqNvi">
-                        <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
-                      </node>
-                    </node>
-                    <node concept="1uHKPH" id="7rdMSLlhiWA" role="2OqNvi" />
-                  </node>
-                  <node concept="3TrEf2" id="7rdMSLlhiWB" role="2OqNvi">
-                    <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="4CksDrmwM$6" role="3clFbw">
-            <node concept="3cmrfG" id="4CksDrmwM$l" role="3uHU7w">
-              <property role="3cmrfH" value="1" />
-            </node>
-            <node concept="2OqwBi" id="4CksDrmwFDh" role="3uHU7B">
-              <node concept="2OqwBi" id="4CksDrmwADb" role="2Oq$k0">
-                <node concept="13iPFW" id="4CksDrmwA7U" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="7rdMSLlh3z_" role="2OqNvi">
-                  <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
-                </node>
-              </node>
-              <node concept="34oBXx" id="4CksDrmwJOg" role="2OqNvi" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="4CksDrmwWMK" role="9aQIa">
-            <node concept="3clFbS" id="4CksDrmwWML" role="9aQI4">
-              <node concept="3cpWs6" id="4CksDrmxgis" role="3cqZAp">
-                <node concept="2pJPEk" id="7rdMSLliDho" role="3cqZAk">
-                  <node concept="2pJPED" id="7rdMSLliDJj" role="2pJPEn">
-                    <ref role="2pJxaS" to="hm2y:4rZeNQ6OJ4v" resolve="ParensExpression" />
-                    <node concept="2pIpSj" id="7rdMSLliEi1" role="2pJxcM">
-                      <ref role="2pIpSl" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                      <node concept="36biLy" id="7rdMSLliEIz" role="28nt2d">
-                        <node concept="BsUDl" id="4CksDrmxgiu" role="36biLW">
-                          <ref role="37wK5l" node="4CksDrmwweS" resolve="process" />
-                          <node concept="37vLTw" id="7rdMSLlhfyP" role="37wK5m">
-                            <ref role="3cqZAo" node="7rdMSLlhcYU" resolve="ctx" />
-                          </node>
-                          <node concept="2OqwBi" id="4CksDrmxgiv" role="37wK5m">
-                            <node concept="13iPFW" id="4CksDrmxgiw" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="7rdMSLlhbQu" role="2OqNvi">
-                              <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="4CksDrmwweS" role="13h7CS">
-      <property role="TrG5h" value="process" />
-      <node concept="3Tm6S6" id="4CksDrmwwfy" role="1B3o_S" />
-      <node concept="3Tqbb2" id="4CksDrmwwfH" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-      </node>
-      <node concept="3clFbS" id="4CksDrmwweV" role="3clF47">
-        <node concept="3clFbJ" id="4CksDrmwwM5" role="3cqZAp">
-          <node concept="3clFbC" id="4CksDrmwz9b" role="3clFbw">
-            <node concept="3cmrfG" id="4CksDrmwzr9" role="3uHU7w">
-              <property role="3cmrfH" value="1" />
-            </node>
-            <node concept="2OqwBi" id="4CksDrmwxqV" role="3uHU7B">
-              <node concept="37vLTw" id="4CksDrmwxdi" role="2Oq$k0">
-                <ref role="3cqZAo" node="4CksDrmwwgh" resolve="remaining" />
-              </node>
-              <node concept="34oBXx" id="4CksDrmwybQ" role="2OqNvi" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="4CksDrmwwM7" role="3clFbx">
-            <node concept="3cpWs6" id="4CksDrmwzGT" role="3cqZAp">
-              <node concept="BsUDl" id="7rdMSLlhmhu" role="3cqZAk">
-                <ref role="37wK5l" node="7rdMSLlhiZ5" resolve="single" />
-                <node concept="37vLTw" id="7rdMSLlhmhv" role="37wK5m">
-                  <ref role="3cqZAo" node="7rdMSLlhg0C" resolve="ctx" />
-                </node>
-                <node concept="2OqwBi" id="7rdMSLlhmhw" role="37wK5m">
-                  <node concept="2OqwBi" id="7rdMSLlhmhx" role="2Oq$k0">
-                    <node concept="37vLTw" id="7rdMSLloH$z" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4CksDrmwwgh" resolve="remaining" />
-                    </node>
-                    <node concept="1uHKPH" id="7rdMSLlhmh_" role="2OqNvi" />
-                  </node>
-                  <node concept="3TrEf2" id="7rdMSLlhmhA" role="2OqNvi">
-                    <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7rdMSLlhqbZ" role="3cqZAp">
-          <node concept="2pJPEk" id="7rdMSLlhqbV" role="3clFbG">
-            <node concept="2pJPED" id="7rdMSLlhqTA" role="2pJPEn">
-              <ref role="2pJxaS" to="hm2y:4rZeNQ6MXMV" resolve="LogicalOrExpression" />
-              <node concept="2pIpSj" id="7rdMSLlhr1f" role="2pJxcM">
-                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
-                <node concept="36biLy" id="7rdMSLlhr6s" role="28nt2d">
-                  <node concept="BsUDl" id="7rdMSLlhrbA" role="36biLW">
-                    <ref role="37wK5l" node="7rdMSLlhiZ5" resolve="single" />
-                    <node concept="37vLTw" id="7rdMSLlhrew" role="37wK5m">
-                      <ref role="3cqZAo" node="7rdMSLlhg0C" resolve="ctx" />
-                    </node>
-                    <node concept="2OqwBi" id="7rdMSLlhuK7" role="37wK5m">
-                      <node concept="2OqwBi" id="7rdMSLlhrmB" role="2Oq$k0">
-                        <node concept="37vLTw" id="7rdMSLlhrmC" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4CksDrmwwgh" resolve="remaining" />
-                        </node>
-                        <node concept="1uHKPH" id="7rdMSLlhrmD" role="2OqNvi" />
-                      </node>
-                      <node concept="3TrEf2" id="7rdMSLlhuYZ" role="2OqNvi">
-                        <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2pIpSj" id="7rdMSLlhr_u" role="2pJxcM">
-                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
-                <node concept="36biLy" id="7rdMSLlhrH0" role="28nt2d">
-                  <node concept="BsUDl" id="7rdMSLlhrJC" role="36biLW">
-                    <ref role="37wK5l" node="4CksDrmwweS" resolve="process" />
-                    <node concept="37vLTw" id="7rdMSLlhs7h" role="37wK5m">
-                      <ref role="3cqZAo" node="7rdMSLlhg0C" resolve="ctx" />
-                    </node>
-                    <node concept="2OqwBi" id="7rdMSLlhrJD" role="37wK5m">
-                      <node concept="37vLTw" id="7rdMSLlhrJE" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4CksDrmwwgh" resolve="remaining" />
-                      </node>
-                      <node concept="2Wx4Xu" id="7rdMSLlhrJF" role="2OqNvi">
-                        <node concept="3cpWsd" id="7rdMSLlhrJG" role="2WvESB">
-                          <node concept="3cmrfG" id="7rdMSLlhrJH" role="3uHU7w">
-                            <property role="3cmrfH" value="1" />
-                          </node>
-                          <node concept="2OqwBi" id="7rdMSLlhrJI" role="3uHU7B">
-                            <node concept="37vLTw" id="7rdMSLlhrJJ" role="2Oq$k0">
-                              <ref role="3cqZAo" node="4CksDrmwwgh" resolve="remaining" />
-                            </node>
-                            <node concept="34oBXx" id="7rdMSLlhrJK" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="7rdMSLlhg0C" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3Tqbb2" id="7rdMSLlhgHN" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="4CksDrmwwgh" role="3clF46">
-        <property role="TrG5h" value="remaining" />
-        <node concept="A3Dl8" id="4CksDrmwwgF" role="1tU5fm">
-          <node concept="3Tqbb2" id="4CksDrmwwgG" role="A3Ik2">
-            <ref role="ehGHo" to="yv47:6WstIz8MKZd" resolve="EnumIsInSelector" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="13hLZK" id="6WstIz8ML9K" role="13h7CW">
       <node concept="3clFbS" id="6WstIz8ML9L" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="7rdMSLlhiZ5" role="13h7CS">
-      <property role="2Ki8OM" value="false" />
-      <property role="TrG5h" value="single" />
-      <node concept="3Tm6S6" id="7rdMSLlhiZ6" role="1B3o_S" />
-      <node concept="3Tqbb2" id="7rdMSLlhiZ7" role="3clF45">
-        <ref role="ehGHo" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-      </node>
-      <node concept="37vLTG" id="7rdMSLlhiWC" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3Tqbb2" id="7rdMSLlhiWD" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="7rdMSLlhjMJ" role="3clF46">
-        <property role="TrG5h" value="lit" />
-        <node concept="3Tqbb2" id="7rdMSLlhkf4" role="1tU5fm">
-          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="7rdMSLlhiTX" role="3clF47">
-        <node concept="3cpWs6" id="7rdMSLlhiWn" role="3cqZAp">
-          <node concept="2pJPEk" id="7rdMSLlhiWo" role="3cqZAk">
-            <node concept="2pJPED" id="7rdMSLlhiWp" role="2pJPEn">
-              <ref role="2pJxaS" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-              <node concept="2pIpSj" id="7rdMSLlhiWq" role="2pJxcM">
-                <ref role="2pIpSl" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                <node concept="36biLy" id="7rdMSLlhiWr" role="28nt2d">
-                  <node concept="2OqwBi" id="7rdMSLlhn8h" role="36biLW">
-                    <node concept="37vLTw" id="7rdMSLlhiWE" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7rdMSLlhiWC" resolve="ctx" />
-                    </node>
-                    <node concept="1$rogu" id="7rdMSLlhni9" role="2OqNvi" />
+    <node concept="13i0hz" id="4L5R3LmJwFl" role="13h7CS">
+      <property role="TrG5h" value="compose" />
+      <ref role="13i0hy" node="4L5R3LmDwOh" resolve="compose" />
+      <node concept="3Tm1VV" id="4L5R3LmJwFm" role="1B3o_S" />
+      <node concept="3clFbS" id="4L5R3LmJwFv" role="3clF47">
+        <node concept="3clFbF" id="4L5R3LmJ$2o" role="3cqZAp">
+          <node concept="2pJPEk" id="4L5R3LmJ$2q" role="3clFbG">
+            <node concept="2pJPED" id="4L5R3LmJ$2r" role="2pJPEn">
+              <ref role="2pJxaS" to="hm2y:4rZeNQ6MXMV" resolve="LogicalOrExpression" />
+              <node concept="2pIpSj" id="4L5R3LmJ$2s" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                <node concept="36biLy" id="4L5R3LmJ$2t" role="28nt2d">
+                  <node concept="37vLTw" id="4L5R3LmJ$2u" role="36biLW">
+                    <ref role="3cqZAo" node="4L5R3LmJwFy" resolve="leftExpr" />
                   </node>
                 </node>
               </node>
-              <node concept="2pIpSj" id="7rdMSLlhiWt" role="2pJxcM">
-                <ref role="2pIpSl" to="hm2y:7NJy08a3O9b" resolve="target" />
-                <node concept="2pJPED" id="7rdMSLlhiWu" role="28nt2d">
-                  <ref role="2pJxaS" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
-                  <node concept="2pIpSj" id="7rdMSLlhiWv" role="2pJxcM">
-                    <ref role="2pIpSl" to="yv47:5ElkanPSLzu" resolve="literal" />
-                    <node concept="36biLy" id="7rdMSLlhiWw" role="28nt2d">
-                      <node concept="37vLTw" id="7rdMSLlhlrh" role="36biLW">
-                        <ref role="3cqZAo" node="7rdMSLlhjMJ" resolve="lit" />
-                      </node>
+              <node concept="2pIpSj" id="4L5R3LmJ$2v" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                <node concept="36biLy" id="4L5R3LmJ$2w" role="28nt2d">
+                  <node concept="BsUDl" id="4L5R3LmJ$2x" role="36biLW">
+                    <ref role="37wK5l" node="3wraVjnnEfa" resolve="single" />
+                    <node concept="37vLTw" id="4L5R3LmJ$2y" role="37wK5m">
+                      <ref role="3cqZAo" node="4L5R3LmJwF$" resolve="ctx" />
+                    </node>
+                    <node concept="37vLTw" id="4L5R3LmJ_yj" role="37wK5m">
+                      <ref role="3cqZAo" node="4L5R3LmJwFw" resolve="literal" />
                     </node>
                   </node>
                 </node>
@@ -10145,6 +9911,58 @@
             </node>
           </node>
         </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmJwFw" role="3clF46">
+        <property role="TrG5h" value="literal" />
+        <node concept="3Tqbb2" id="4L5R3LmJwFx" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmJwFy" role="3clF46">
+        <property role="TrG5h" value="leftExpr" />
+        <node concept="3Tqbb2" id="4L5R3LmJwFz" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmJwF$" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="4L5R3LmJwF_" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="4L5R3LmJwFA" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3wraVjnnSQ5" role="13h7CS">
+      <property role="TrG5h" value="singleOp" />
+      <ref role="13i0hy" node="3wraVjnnC5i" resolve="singleOp" />
+      <node concept="3Tm1VV" id="3wraVjnnSQ6" role="1B3o_S" />
+      <node concept="3clFbS" id="3wraVjnnSQ7" role="3clF47">
+        <node concept="3clFbF" id="3wraVjnnSQ8" role="3cqZAp">
+          <node concept="2pJPEk" id="3wraVjnnSQ9" role="3clFbG">
+            <node concept="2pJPED" id="3wraVjnnSQa" role="2pJPEn">
+              <ref role="2pJxaS" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
+              <node concept="2pIpSj" id="3wraVjnnU6d" role="2pJxcM">
+                <ref role="2pIpSl" to="yv47:3meuf2aV0ef" resolve="literal" />
+                <node concept="36biLy" id="3wraVjnnUde" role="28nt2d">
+                  <node concept="37vLTw" id="3wraVjnnV48" role="36biLW">
+                    <ref role="3cqZAo" node="3wraVjnnSQe" resolve="literal" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3wraVjnnSQe" role="3clF46">
+        <property role="TrG5h" value="literal" />
+        <node concept="3Tqbb2" id="3wraVjnnSQf" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="3wraVjnnSQg" role="3clF45">
+        <ref role="ehGHo" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
       </node>
     </node>
   </node>
@@ -10258,6 +10076,532 @@
         </node>
       </node>
       <node concept="17QB3L" id="4oS6BnMEBG0" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3WZ76l1FQTM">
+    <property role="3GE5qa" value="enum" />
+    <ref role="13h7C2" to="yv47:3WZ76l1FQSK" resolve="EnumIsNotTarget" />
+    <node concept="13hLZK" id="3WZ76l1FQTN" role="13h7CW">
+      <node concept="3clFbS" id="3WZ76l1FQTO" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="3WZ76l1FQTP" role="13h7CS">
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="3WZ76l1FQTQ" role="1B3o_S" />
+      <node concept="17QB3L" id="3WZ76l1FQTR" role="3clF45" />
+      <node concept="3clFbS" id="3WZ76l1FQTS" role="3clF47">
+        <node concept="3clFbF" id="3WZ76l1FQTT" role="3cqZAp">
+          <node concept="3cpWs3" id="3WZ76l1FQTU" role="3clFbG">
+            <node concept="3cpWs3" id="3WZ76l1FQTV" role="3uHU7B">
+              <node concept="Xl_RD" id="3WZ76l1FQTW" role="3uHU7B">
+                <property role="Xl_RC" value="is not(" />
+              </node>
+              <node concept="2OqwBi" id="3WZ76l1FQTX" role="3uHU7w">
+                <node concept="2OqwBi" id="3WZ76l1FQTY" role="2Oq$k0">
+                  <node concept="13iPFW" id="3WZ76l1FQTZ" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="3WZ76l1FQU0" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
+                  </node>
+                </node>
+                <node concept="3TrcHB" id="3WZ76l1FQU1" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+            <node concept="Xl_RD" id="3WZ76l1FQU2" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="6NLFGgDxml3">
+    <property role="3GE5qa" value="enum.oneof" />
+    <ref role="13h7C2" to="yv47:6NLFGgDxmkC" resolve="EnumIsNotInTarget" />
+    <node concept="13hLZK" id="6NLFGgDxml4" role="13h7CW">
+      <node concept="3clFbS" id="6NLFGgDxml5" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6NLFGgDxml6" role="13h7CS">
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
+      <node concept="17QB3L" id="6NLFGgDxml7" role="3clF45" />
+      <node concept="3clFbS" id="6NLFGgDxml8" role="3clF47">
+        <node concept="3clFbF" id="6NLFGgDxml9" role="3cqZAp">
+          <node concept="3cpWs3" id="6NLFGgDxmla" role="3clFbG">
+            <node concept="3cpWs3" id="6NLFGgDxmlb" role="3uHU7B">
+              <node concept="3cpWs3" id="6NLFGgDxmlc" role="3uHU7B">
+                <node concept="2OqwBi" id="6NLFGgDxmld" role="3uHU7B">
+                  <node concept="2OqwBi" id="6NLFGgDxmle" role="2Oq$k0">
+                    <node concept="13iPFW" id="6NLFGgDxmlf" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="6NLFGgDxmlg" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="6NLFGgDxmlh" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="6NLFGgDxmli" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6NLFGgDxmlj" role="3uHU7w">
+                <node concept="2OqwBi" id="6NLFGgDxmlk" role="2Oq$k0">
+                  <node concept="13iPFW" id="6NLFGgDxmll" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="6NLFGgDxmlm" role="2OqNvi">
+                    <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="6NLFGgDxmln" role="2OqNvi">
+                  <node concept="1bVj0M" id="6NLFGgDxmlo" role="23t8la">
+                    <node concept="gl6BB" id="6NLFGgDxmlp" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6NLFGgDxmlq" role="1tU5fm" />
+                    </node>
+                    <node concept="3clFbS" id="6NLFGgDxmlr" role="1bW5cS">
+                      <node concept="3clFbF" id="6NLFGgDxmls" role="3cqZAp">
+                        <node concept="2OqwBi" id="6NLFGgDxmlt" role="3clFbG">
+                          <node concept="2OqwBi" id="6NLFGgDxmlu" role="2Oq$k0">
+                            <node concept="37vLTw" id="6NLFGgDxmlv" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6NLFGgDxmlp" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="6NLFGgDxmlw" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
+                          </node>
+                          <node concept="2PDubS" id="6NLFGgDxmlx" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.join(java.lang.CharSequence,java.lang.CharSequence...)" resolve="join" />
+                            <node concept="Xl_RD" id="6NLFGgDxmly" role="37wK5m">
+                              <property role="Xl_RC" value="," />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="Xl_RD" id="6NLFGgDxmlz" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6NLFGgDxml$" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="4L5R3LmHePL" role="13h7CS">
+      <property role="TrG5h" value="compose" />
+      <ref role="13i0hy" node="4L5R3LmDwOh" resolve="compose" />
+      <node concept="3Tm1VV" id="4L5R3LmHePM" role="1B3o_S" />
+      <node concept="3clFbS" id="4L5R3LmHePV" role="3clF47">
+        <node concept="3clFbF" id="4L5R3LmHhqS" role="3cqZAp">
+          <node concept="2pJPEk" id="4L5R3LmHhqT" role="3clFbG">
+            <node concept="2pJPED" id="4L5R3LmHhqU" role="2pJPEn">
+              <ref role="2pJxaS" to="hm2y:4rZeNQ6MXOT" resolve="LogicalAndExpression" />
+              <node concept="2pIpSj" id="4L5R3LmHhqV" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                <node concept="36biLy" id="4L5R3LmHhqW" role="28nt2d">
+                  <node concept="37vLTw" id="4L5R3LmHhqX" role="36biLW">
+                    <ref role="3cqZAo" node="4L5R3LmHePY" resolve="leftExpr" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2pIpSj" id="4L5R3LmHhqY" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                <node concept="36biLy" id="4L5R3LmHhqZ" role="28nt2d">
+                  <node concept="BsUDl" id="4L5R3LmHhr0" role="36biLW">
+                    <ref role="37wK5l" node="3wraVjnnEfa" resolve="single" />
+                    <node concept="37vLTw" id="4L5R3LmHhr1" role="37wK5m">
+                      <ref role="3cqZAo" node="4L5R3LmHeQ0" resolve="ctx" />
+                    </node>
+                    <node concept="37vLTw" id="4L5R3LmHibh" role="37wK5m">
+                      <ref role="3cqZAo" node="4L5R3LmHePW" resolve="literal" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmHePW" role="3clF46">
+        <property role="TrG5h" value="literal" />
+        <node concept="3Tqbb2" id="4L5R3LmHePX" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmHePY" role="3clF46">
+        <property role="TrG5h" value="leftExpr" />
+        <node concept="3Tqbb2" id="4L5R3LmHePZ" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmHeQ0" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="4L5R3LmHeQ1" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="4L5R3LmHeQ2" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3wraVjnnK24" role="13h7CS">
+      <property role="TrG5h" value="singleOp" />
+      <ref role="13i0hy" node="3wraVjnnC5i" resolve="singleOp" />
+      <node concept="3Tm1VV" id="3wraVjnnK27" role="1B3o_S" />
+      <node concept="3clFbS" id="3wraVjnnK2a" role="3clF47">
+        <node concept="3clFbF" id="3wraVjnnMq9" role="3cqZAp">
+          <node concept="2pJPEk" id="3wraVjnnMq7" role="3clFbG">
+            <node concept="2pJPED" id="3wraVjnnMq8" role="2pJPEn">
+              <ref role="2pJxaS" to="yv47:3WZ76l1FQSK" resolve="EnumIsNotTarget" />
+              <node concept="2pIpSj" id="3wraVjnnPg2" role="2pJxcM">
+                <ref role="2pIpSl" to="yv47:3meuf2aV0ef" resolve="literal" />
+                <node concept="36biLy" id="3wraVjnnQ45" role="28nt2d">
+                  <node concept="37vLTw" id="3wraVjnnQfU" role="36biLW">
+                    <ref role="3cqZAo" node="3wraVjnnK2b" resolve="literal" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3wraVjnnK2b" role="3clF46">
+        <property role="TrG5h" value="literal" />
+        <node concept="3Tqbb2" id="3wraVjnnK2c" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="3wraVjnnK2d" role="3clF45">
+        <ref role="ehGHo" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4L5R3LmDtPI">
+    <property role="3GE5qa" value="enum.oneof" />
+    <ref role="13h7C2" to="yv47:4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
+    <node concept="13i0hz" id="3wraVjnnC5i" role="13h7CS">
+      <property role="TrG5h" value="singleOp" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <node concept="37vLTG" id="3wraVjnnIla" role="3clF46">
+        <property role="TrG5h" value="literal" />
+        <node concept="3Tqbb2" id="3wraVjnnIx$" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3wraVjnnC5j" role="1B3o_S" />
+      <node concept="3Tqbb2" id="3wraVjnnCFa" role="3clF45">
+        <ref role="ehGHo" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+      </node>
+      <node concept="3clFbS" id="3wraVjnnC5l" role="3clF47" />
+      <node concept="P$JXv" id="lJ6hiUJYr6" role="lGtFl">
+        <node concept="TZ5HA" id="lJ6hiUJYr7" role="TZ5H$">
+          <node concept="1dT_AC" id="lJ6hiUJYr8" role="1dT_Ay">
+            <property role="1dT_AB" value="Wrap the literal in a custom 'IDotTarget' handling a single enum literal" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="lJ6hiUJYr9" role="3nqlJM">
+          <property role="TUZQ4" value=" " />
+          <node concept="zr_55" id="lJ6hiUJYrb" role="zr_5Q">
+            <ref role="zr_51" node="3wraVjnnIla" resolve="literal" />
+          </node>
+        </node>
+        <node concept="x79VA" id="lJ6hiUJYrc" role="3nqlJM">
+          <property role="x79VB" value=" " />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4L5R3LmDwOh" role="13h7CS">
+      <property role="TrG5h" value="compose" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <node concept="3Tm1VV" id="4L5R3LmDxTU" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4L5R3LmDwOj" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+      <node concept="37vLTG" id="4L5R3LmDwOk" role="3clF46">
+        <property role="TrG5h" value="literal" />
+        <node concept="3Tqbb2" id="4L5R3LmDxeH" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmDwOm" role="3clF46">
+        <property role="TrG5h" value="currExpression" />
+        <node concept="3Tqbb2" id="4L5R3LmDwOn" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4L5R3LmDwOo" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="4L5R3LmDwOp" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4L5R3LmDwOq" role="3clF47" />
+      <node concept="P$JXv" id="lJ6hiUK3oA" role="lGtFl">
+        <node concept="TZ5HA" id="lJ6hiUK3oB" role="TZ5H$">
+          <node concept="1dT_AC" id="lJ6hiUK3oC" role="1dT_Ay">
+            <property role="1dT_AB" value="compose the current expression with a enum literal" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="lJ6hiUK3oD" role="3nqlJM">
+          <property role="TUZQ4" value=" " />
+          <node concept="zr_55" id="lJ6hiUK3oF" role="zr_5Q">
+            <ref role="zr_51" node="4L5R3LmDwOk" resolve="literal" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="lJ6hiUK3oG" role="3nqlJM">
+          <property role="TUZQ4" value=" " />
+          <node concept="zr_55" id="lJ6hiUK3oI" role="zr_5Q">
+            <ref role="zr_51" node="4L5R3LmDwOm" resolve="currExpression" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="lJ6hiUK3oJ" role="3nqlJM">
+          <property role="TUZQ4" value=" " />
+          <node concept="zr_55" id="lJ6hiUK3oL" role="zr_5Q">
+            <ref role="zr_51" node="4L5R3LmDwOo" resolve="ctx" />
+          </node>
+        </node>
+        <node concept="x79VA" id="lJ6hiUK3oM" role="3nqlJM">
+          <property role="x79VB" value=" " />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4L5R3LmDzwi" role="13h7CS">
+      <property role="TrG5h" value="reduce" />
+      <node concept="3Tqbb2" id="4L5R3LmDzwj" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+      <node concept="3clFbS" id="4L5R3LmDzwk" role="3clF47">
+        <node concept="3clFbJ" id="4L5R3LmDzwl" role="3cqZAp">
+          <node concept="2OqwBi" id="4L5R3LmDzwm" role="3clFbw">
+            <node concept="2OqwBi" id="lJ6hiUGofd" role="2Oq$k0">
+              <node concept="13iPFW" id="lJ6hiUGofe" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="lJ6hiUGoff" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+              </node>
+            </node>
+            <node concept="1v1jN8" id="4L5R3LmDzwq" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="4L5R3LmDzwr" role="3clFbx">
+            <node concept="3cpWs6" id="4L5R3LmDzws" role="3cqZAp">
+              <node concept="10Nm6u" id="4L5R3LmDzwt" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4L5R3LmDzwu" role="3cqZAp">
+          <node concept="3cpWsn" id="4L5R3LmDzwv" role="3cpWs9">
+            <property role="TrG5h" value="ctx" />
+            <node concept="2OqwBi" id="4L5R3LmDzww" role="33vP2m">
+              <node concept="1PxgMI" id="4L5R3LmDzwx" role="2Oq$k0">
+                <node concept="2OqwBi" id="4L5R3LmDzwy" role="1m5AlR">
+                  <node concept="13iPFW" id="4L5R3LmDzwz" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="4L5R3LmDzw$" role="2OqNvi" />
+                </node>
+                <node concept="chp4Y" id="4L5R3LmDzw_" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="4L5R3LmDzwA" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3Tqbb2" id="4L5R3LmDzwB" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4L5R3LmDzwC" role="3cqZAp">
+          <node concept="3cpWsn" id="4L5R3LmDzwD" role="3cpWs9">
+            <property role="TrG5h" value="start" />
+            <node concept="3Tqbb2" id="4L5R3LmDzwE" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="BsUDl" id="4L5R3LmDzwF" role="33vP2m">
+              <ref role="37wK5l" node="3wraVjnnEfa" resolve="single" />
+              <node concept="37vLTw" id="4L5R3LmDzwG" role="37wK5m">
+                <ref role="3cqZAo" node="4L5R3LmDzwv" resolve="ctx" />
+              </node>
+              <node concept="2OqwBi" id="4L5R3LmDzwH" role="37wK5m">
+                <node concept="2OqwBi" id="4L5R3LmDzwI" role="2Oq$k0">
+                  <node concept="2OqwBi" id="lJ6hiUGofq" role="2Oq$k0">
+                    <node concept="13iPFW" id="lJ6hiUGofr" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="lJ6hiUGofs" role="2OqNvi">
+                      <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="4L5R3LmDzwM" role="2OqNvi" />
+                </node>
+                <node concept="3TrEf2" id="4L5R3LmDzwN" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4L5R3LmDzwO" role="3cqZAp">
+          <node concept="3cpWsn" id="4L5R3LmDzwP" role="3cpWs9">
+            <property role="TrG5h" value="logicalExpr" />
+            <node concept="3Tqbb2" id="4L5R3LmDzwQ" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="2OqwBi" id="4L5R3LmDzwR" role="33vP2m">
+              <node concept="2OqwBi" id="4L5R3LmDzwS" role="2Oq$k0">
+                <node concept="2OqwBi" id="lJ6hiUGofB" role="2Oq$k0">
+                  <node concept="13iPFW" id="lJ6hiUGofC" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="lJ6hiUGofD" role="2OqNvi">
+                    <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+                  </node>
+                </node>
+                <node concept="2Wx4Xu" id="4L5R3LmDzwW" role="2OqNvi">
+                  <node concept="3cpWsd" id="4L5R3LmDzwX" role="2WvESB">
+                    <node concept="3cmrfG" id="4L5R3LmDzwY" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="4L5R3LmDzwZ" role="3uHU7B">
+                      <node concept="2OqwBi" id="lJ6hiUGofO" role="2Oq$k0">
+                        <node concept="13iPFW" id="lJ6hiUGofP" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="lJ6hiUGofQ" role="2OqNvi">
+                          <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+                        </node>
+                      </node>
+                      <node concept="34oBXx" id="4L5R3LmDzx3" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1MD8d$" id="4L5R3LmDzx4" role="2OqNvi">
+                <node concept="1bVj0M" id="4L5R3LmDzx5" role="23t8la">
+                  <node concept="3clFbS" id="4L5R3LmDzx6" role="1bW5cS">
+                    <node concept="3cpWs6" id="4L5R3LmDzx7" role="3cqZAp">
+                      <node concept="BsUDl" id="4L5R3LmDzx8" role="3cqZAk">
+                        <ref role="37wK5l" node="4L5R3LmDwOh" resolve="compose" />
+                        <node concept="2OqwBi" id="4L5R3LmDDr_" role="37wK5m">
+                          <node concept="37vLTw" id="4L5R3LmDzx9" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4L5R3LmDzxe" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="4L5R3LmDEjy" role="2OqNvi">
+                            <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="4L5R3LmDzxa" role="37wK5m">
+                          <ref role="3cqZAo" node="4L5R3LmDzxc" resolve="s" />
+                        </node>
+                        <node concept="37vLTw" id="4L5R3LmDzxb" role="37wK5m">
+                          <ref role="3cqZAo" node="4L5R3LmDzwv" resolve="ctx" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="4L5R3LmDzxc" role="1bW2Oz">
+                    <property role="TrG5h" value="s" />
+                    <node concept="2jxLKc" id="4L5R3LmDzxd" role="1tU5fm" />
+                  </node>
+                  <node concept="gl6BB" id="4L5R3LmDzxe" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4L5R3LmDzxf" role="1tU5fm" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4L5R3LmDzxg" role="1MDeny">
+                  <ref role="3cqZAo" node="4L5R3LmDzwD" resolve="start" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4L5R3LmDzxh" role="3cqZAp" />
+        <node concept="3clFbF" id="4L5R3LmDzxi" role="3cqZAp">
+          <node concept="2pJPEk" id="4L5R3LmDzxj" role="3clFbG">
+            <node concept="2pJPED" id="4L5R3LmDzxk" role="2pJPEn">
+              <ref role="2pJxaS" to="hm2y:4rZeNQ6OJ4v" resolve="ParensExpression" />
+              <node concept="2pIpSj" id="4L5R3LmDzxl" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                <node concept="36biLy" id="4L5R3LmDzxm" role="28nt2d">
+                  <node concept="37vLTw" id="4L5R3LmDzxn" role="36biLW">
+                    <ref role="3cqZAo" node="4L5R3LmDzwP" resolve="logicalExpr" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4L5R3LmDzxo" role="1B3o_S" />
+      <node concept="P$JXv" id="lJ6hiUK45R" role="lGtFl">
+        <node concept="TZ5HA" id="lJ6hiUK45S" role="TZ5H$">
+          <node concept="1dT_AC" id="lJ6hiUK45T" role="1dT_Ay">
+            <property role="1dT_AB" value="Composes the enum literals of the selector into a equivalent logical expression based." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="3wraVjnnEfa" role="13h7CS">
+      <property role="2Ki8OM" value="false" />
+      <property role="TrG5h" value="single" />
+      <node concept="3Tmbuc" id="3wraVjnnYD1" role="1B3o_S" />
+      <node concept="3clFbS" id="3wraVjnnEfc" role="3clF47">
+        <node concept="3cpWs6" id="3wraVjnnEfd" role="3cqZAp">
+          <node concept="2pJPEk" id="3wraVjnnEfe" role="3cqZAk">
+            <node concept="2pJPED" id="3wraVjnnEff" role="2pJPEn">
+              <ref role="2pJxaS" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              <node concept="2pIpSj" id="3wraVjnnEfg" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                <node concept="36biLy" id="3wraVjnnEfh" role="28nt2d">
+                  <node concept="2OqwBi" id="3wraVjnnEfi" role="36biLW">
+                    <node concept="37vLTw" id="3wraVjnnEfj" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3wraVjnnEfq" resolve="ctx" />
+                    </node>
+                    <node concept="1$rogu" id="3wraVjnnEfk" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2pIpSj" id="3wraVjnnEfl" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:7NJy08a3O9b" resolve="target" />
+                <node concept="36biLy" id="3wraVjnnFAQ" role="28nt2d">
+                  <node concept="2OqwBi" id="3wraVjnnFNq" role="36biLW">
+                    <node concept="13iPFW" id="3wraVjnnFD7" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="3wraVjnnHWd" role="2OqNvi">
+                      <ref role="37wK5l" node="3wraVjnnC5i" resolve="singleOp" />
+                      <node concept="37vLTw" id="3wraVjnnI5v" role="37wK5m">
+                        <ref role="3cqZAo" node="3wraVjnnEfs" resolve="lit" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3wraVjnnEfq" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="3wraVjnnEfr" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3wraVjnnEfs" role="3clF46">
+        <property role="TrG5h" value="lit" />
+        <node concept="3Tqbb2" id="3wraVjnnEft" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="3wraVjnnEfu" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="4L5R3LmDtPJ" role="13h7CW">
+      <node concept="3clFbS" id="4L5R3LmDtPK" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3fg81r5z3u4">
+    <property role="3GE5qa" value="enum" />
+    <ref role="13h7C2" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
+    <node concept="13hLZK" id="3fg81r5z3u5" role="13h7CW">
+      <node concept="3clFbS" id="3fg81r5z3u6" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
@@ -1544,84 +1544,6 @@
       </node>
     </node>
   </node>
-  <node concept="1M2fIO" id="5ElkanPQwuW">
-    <property role="3GE5qa" value="enum" />
-    <ref role="1M2myG" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
-    <node concept="1N5Pfh" id="5ElkanPSMF3" role="1Mr941">
-      <ref role="1N5Vy1" to="yv47:5ElkanPSLzu" resolve="literal" />
-      <node concept="3dgokm" id="5ElkanPSMTF" role="1N6uqs">
-        <node concept="3clFbS" id="1F1F0IUZBh$" role="2VODD2">
-          <node concept="3clFbF" id="1F1F0IUZBh_" role="3cqZAp">
-            <node concept="2YIFZM" id="1F1F0IUZBlc" role="3clFbG">
-              <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="2OqwBi" id="1F1F0IUZBld" role="37wK5m">
-                <node concept="2OqwBi" id="1F1F0IUZBle" role="2Oq$k0">
-                  <node concept="1PxgMI" id="1F1F0IUZBlf" role="2Oq$k0">
-                    <node concept="2OqwBi" id="1F1F0IUZBlg" role="1m5AlR">
-                      <node concept="1PxgMI" id="1F1F0IUZBlh" role="2Oq$k0">
-                        <node concept="1eOMI4" id="1F1F0IUZBli" role="1m5AlR">
-                          <node concept="3K4zz7" id="1F1F0IUZBlj" role="1eOMHV">
-                            <node concept="2rP1CM" id="1F1F0IUZBlk" role="3K4E3e" />
-                            <node concept="2OqwBi" id="1F1F0IUZBll" role="3K4Cdx">
-                              <node concept="3kakTB" id="1F1F0IUZBlm" role="2Oq$k0" />
-                              <node concept="3w_OXm" id="1F1F0IUZBln" role="2OqNvi" />
-                            </node>
-                            <node concept="2OqwBi" id="1F1F0IUZBlo" role="3K4GZi">
-                              <node concept="3kakTB" id="1F1F0IUZBlp" role="2Oq$k0" />
-                              <node concept="1mfA1w" id="1F1F0IUZBlq" role="2OqNvi" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="chp4Y" id="1F1F0IUZBlr" role="3oSUPX">
-                          <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-                        </node>
-                      </node>
-                      <node concept="2qgKlT" id="1F1F0IUZBls" role="2OqNvi">
-                        <ref role="37wK5l" to="pbu6:5WNmJ7Ez2mW" resolve="extractContextBaseType" />
-                      </node>
-                    </node>
-                    <node concept="chp4Y" id="1F1F0IUZBlt" role="3oSUPX">
-                      <ref role="cht4Q" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
-                    </node>
-                  </node>
-                  <node concept="3TrEf2" id="1F1F0IUZBlu" role="2OqNvi">
-                    <ref role="3Tt5mk" to="yv47:67Y8mp$DN3N" resolve="enum" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="olugnm0T$S" role="2OqNvi">
-                  <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="9S07l" id="6b_jefnKzhp" role="9Vyp8">
-      <node concept="3clFbS" id="6b_jefnKzhq" role="2VODD2">
-        <node concept="3clFbF" id="6b_jefnKzhr" role="3cqZAp">
-          <node concept="2OqwBi" id="6b_jefnKzhs" role="3clFbG">
-            <node concept="1PxgMI" id="6b_jefnKzht" role="2Oq$k0">
-              <node concept="nLn13" id="6b_jefnKzhu" role="1m5AlR" />
-              <node concept="chp4Y" id="6b_jefnKzkP" role="3oSUPX">
-                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-              </node>
-            </node>
-            <node concept="2qgKlT" id="6b_jefnKzhv" role="2OqNvi">
-              <ref role="37wK5l" to="pbu6:5WNmJ7DokMG" resolve="expectType" />
-              <node concept="35c_gC" id="6b_jefnKzhw" role="37wK5m">
-                <ref role="35c_gD" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
-              </node>
-              <node concept="3clFbT" id="6b_jefnKzhx" role="37wK5m">
-                <property role="3clFbU" value="true" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="1M2fIO" id="6vIMss7od46">
     <property role="3GE5qa" value="record" />
     <ref role="1M2myG" to="yv47:7D7uZV2dYyQ" resolve="RecordDeclaration" />
@@ -1882,33 +1804,6 @@
                 <node concept="2qgKlT" id="olugnm0US8" role="2OqNvi">
                   <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1M2fIO" id="6WstIz8MKEg">
-    <property role="3GE5qa" value="enum.oneof" />
-    <ref role="1M2myG" to="yv47:6WstIz8MK67" resolve="EnumIsInTarget" />
-    <node concept="9S07l" id="6WstIz8MKEh" role="9Vyp8">
-      <node concept="3clFbS" id="6WstIz8MKEi" role="2VODD2">
-        <node concept="3clFbF" id="6WstIz8MKEq" role="3cqZAp">
-          <node concept="2OqwBi" id="6WstIz8MKEr" role="3clFbG">
-            <node concept="1PxgMI" id="6WstIz8MKEs" role="2Oq$k0">
-              <node concept="nLn13" id="6WstIz8MKEt" role="1m5AlR" />
-              <node concept="chp4Y" id="6WstIz8MKEu" role="3oSUPX">
-                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-              </node>
-            </node>
-            <node concept="2qgKlT" id="6WstIz8MKEv" role="2OqNvi">
-              <ref role="37wK5l" to="pbu6:5WNmJ7DokMG" resolve="expectType" />
-              <node concept="35c_gC" id="6WstIz8MKEw" role="37wK5m">
-                <ref role="35c_gD" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
-              </node>
-              <node concept="3clFbT" id="6WstIz8MKEx" role="37wK5m">
-                <property role="3clFbU" value="true" />
               </node>
             </node>
           </node>
@@ -2191,6 +2086,111 @@
                 <node concept="chp4Y" id="wlV$3ktsMd" role="cj9EA">
                   <ref role="cht4Q" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4L5R3LnUzsb">
+    <property role="3GE5qa" value="enum.oneof" />
+    <ref role="1M2myG" to="yv47:4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
+    <node concept="9S07l" id="4L5R3LnU$TW" role="9Vyp8">
+      <node concept="3clFbS" id="4L5R3LnU$TX" role="2VODD2">
+        <node concept="3clFbF" id="4L5R3LnU_7t" role="3cqZAp">
+          <node concept="2OqwBi" id="4L5R3LnU_7u" role="3clFbG">
+            <node concept="1PxgMI" id="4L5R3LnU_7v" role="2Oq$k0">
+              <node concept="nLn13" id="4L5R3LnU_7w" role="1m5AlR" />
+              <node concept="chp4Y" id="4L5R3LnU_7x" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4L5R3LnU_7y" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:5WNmJ7DokMG" resolve="expectType" />
+              <node concept="35c_gC" id="4L5R3LnU_7z" role="37wK5m">
+                <ref role="35c_gD" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
+              </node>
+              <node concept="3clFbT" id="4L5R3LnU_7$" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="3meuf2aVf6T">
+    <property role="3GE5qa" value="enum" />
+    <ref role="1M2myG" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
+    <node concept="1N5Pfh" id="5ElkanPSMF3" role="1Mr941">
+      <ref role="1N5Vy1" to="yv47:3meuf2aV0ef" resolve="literal" />
+      <node concept="3dgokm" id="5ElkanPSMTF" role="1N6uqs">
+        <node concept="3clFbS" id="1F1F0IUZBh$" role="2VODD2">
+          <node concept="3clFbF" id="1F1F0IUZBh_" role="3cqZAp">
+            <node concept="2YIFZM" id="1F1F0IUZBlc" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="1F1F0IUZBld" role="37wK5m">
+                <node concept="2OqwBi" id="1F1F0IUZBle" role="2Oq$k0">
+                  <node concept="1PxgMI" id="1F1F0IUZBlf" role="2Oq$k0">
+                    <node concept="2OqwBi" id="1F1F0IUZBlg" role="1m5AlR">
+                      <node concept="1PxgMI" id="1F1F0IUZBlh" role="2Oq$k0">
+                        <node concept="1eOMI4" id="1F1F0IUZBli" role="1m5AlR">
+                          <node concept="3K4zz7" id="1F1F0IUZBlj" role="1eOMHV">
+                            <node concept="2rP1CM" id="1F1F0IUZBlk" role="3K4E3e" />
+                            <node concept="2OqwBi" id="1F1F0IUZBll" role="3K4Cdx">
+                              <node concept="3kakTB" id="1F1F0IUZBlm" role="2Oq$k0" />
+                              <node concept="3w_OXm" id="1F1F0IUZBln" role="2OqNvi" />
+                            </node>
+                            <node concept="2OqwBi" id="1F1F0IUZBlo" role="3K4GZi">
+                              <node concept="3kakTB" id="1F1F0IUZBlp" role="2Oq$k0" />
+                              <node concept="1mfA1w" id="1F1F0IUZBlq" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="chp4Y" id="1F1F0IUZBlr" role="3oSUPX">
+                          <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="1F1F0IUZBls" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:5WNmJ7Ez2mW" resolve="extractContextBaseType" />
+                      </node>
+                    </node>
+                    <node concept="chp4Y" id="1F1F0IUZBlt" role="3oSUPX">
+                      <ref role="cht4Q" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="1F1F0IUZBlu" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:67Y8mp$DN3N" resolve="enum" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="olugnm0T$S" role="2OqNvi">
+                  <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9S07l" id="3meuf2aVf6U" role="9Vyp8">
+      <node concept="3clFbS" id="3meuf2aVf6V" role="2VODD2">
+        <node concept="3clFbF" id="3meuf2aVf6W" role="3cqZAp">
+          <node concept="2OqwBi" id="3meuf2aVf6X" role="3clFbG">
+            <node concept="1PxgMI" id="3meuf2aVf6Y" role="2Oq$k0">
+              <node concept="nLn13" id="3meuf2aVf6Z" role="1m5AlR" />
+              <node concept="chp4Y" id="3meuf2aVf70" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="3meuf2aVf71" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:5WNmJ7DokMG" resolve="expectType" />
+              <node concept="35c_gC" id="3meuf2aVf72" role="37wK5m">
+                <ref role="35c_gD" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
+              </node>
+              <node concept="3clFbT" id="3meuf2aVf73" role="37wK5m">
+                <property role="3clFbU" value="true" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -2850,46 +2850,6 @@
       <property role="3F0ifm" value="value" />
     </node>
   </node>
-  <node concept="24kQdi" id="5ElkanPQwno">
-    <property role="3GE5qa" value="enum" />
-    <ref role="1XX52x" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
-    <node concept="3EZMnI" id="5ElkanPQwnt" role="2wV5jI">
-      <node concept="l2Vlx" id="5ElkanPQwnu" role="2iSdaV" />
-      <node concept="PMmxH" id="1znK7yZjSrS" role="3EZMnx">
-        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
-      </node>
-      <node concept="3F0ifn" id="5ElkanPQwnA" role="3EZMnx">
-        <property role="3F0ifm" value="(" />
-        <node concept="11L4FC" id="5ElkanPQws1" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="11LMrY" id="5ElkanPQwuc" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="1iCGBv" id="5ElkanPTg6m" role="3EZMnx">
-        <ref role="1NtTu8" to="yv47:5ElkanPSLzu" resolve="literal" />
-        <node concept="1sVBvm" id="5ElkanPTg6o" role="1sWHZn">
-          <node concept="3F0A7n" id="5ElkanPTg6C" role="2wV5jI">
-            <property role="1Intyy" value="true" />
-            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-            <node concept="Vb9p2" id="5ElkanPTg6L" role="3F10Kt">
-              <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
-            </node>
-            <node concept="VechU" id="5ElkanPTg6M" role="3F10Kt">
-              <property role="Vb096" value="fLJRk5B/darkGray" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3F0ifn" id="5ElkanPQwnI" role="3EZMnx">
-        <property role="3F0ifm" value=")" />
-        <node concept="11L4FC" id="5ElkanPQwpT" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="24kQdi" id="5VEHrQcTA57">
     <ref role="1XX52x" to="yv47:ub9nkyK62f" resolve="Library" />
     <node concept="3EZMnI" id="ub9nkyK63c" role="2wV5jI">
@@ -4099,69 +4059,6 @@
           </node>
         </node>
       </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="6WstIz8MK6A">
-    <property role="3GE5qa" value="enum.oneof" />
-    <ref role="1XX52x" to="yv47:6WstIz8MK67" resolve="EnumIsInTarget" />
-    <node concept="3EZMnI" id="6WstIz8MK6C" role="2wV5jI">
-      <node concept="l2Vlx" id="6WstIz8MK6D" role="2iSdaV" />
-      <node concept="PMmxH" id="1znK7yZjPlf" role="3EZMnx">
-        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
-      </node>
-      <node concept="3F0ifn" id="6WstIz8MK6F" role="3EZMnx">
-        <property role="3F0ifm" value="(" />
-        <node concept="11L4FC" id="6WstIz8MK6G" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="11LMrY" id="6WstIz8MK6H" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="3F2HdR" id="6WstIz8MK7E" role="3EZMnx">
-        <property role="2czwfO" value="," />
-        <ref role="1NtTu8" to="yv47:6WstIz8MK6a" resolve="selectors" />
-        <node concept="l2Vlx" id="6WstIz8MK7G" role="2czzBx" />
-        <node concept="3F0ifn" id="6WstIz8MK7X" role="2czzBI">
-          <property role="3F0ifm" value="" />
-          <node concept="VPxyj" id="6WstIz8MK80" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-      </node>
-      <node concept="3F0ifn" id="6WstIz8MK6N" role="3EZMnx">
-        <property role="3F0ifm" value=")" />
-        <node concept="11L4FC" id="6WstIz8MK6O" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-    </node>
-    <node concept="3EZMnI" id="7rdMSLlhFCc" role="6VMZX">
-      <node concept="3F0ifn" id="7rdMSLlhFKZ" role="3EZMnx">
-        <property role="3F0ifm" value="reduced:" />
-      </node>
-      <node concept="1HlG4h" id="7rdMSLlhFvz" role="3EZMnx">
-        <node concept="1HfYo3" id="7rdMSLlhFv$" role="1HlULh">
-          <node concept="3TQlhw" id="7rdMSLlhFv_" role="1Hhtcw">
-            <node concept="3clFbS" id="7rdMSLlhFvA" role="2VODD2">
-              <node concept="3clFbF" id="7rdMSLlhM3X" role="3cqZAp">
-                <node concept="2OqwBi" id="7rdMSLlhN2I" role="3clFbG">
-                  <node concept="2OqwBi" id="7rdMSLlhMiA" role="2Oq$k0">
-                    <node concept="pncrf" id="7rdMSLlhM3W" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="7rdMSLlhMFB" role="2OqNvi">
-                      <ref role="37wK5l" to="nu60:4CksDrmwwdX" resolve="reduce" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="7rdMSLlhNOm" role="2OqNvi">
-                    <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="l2Vlx" id="1ASK_HedIv3" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6WstIz8MKZE">
@@ -5740,6 +5637,109 @@
           <ref role="Ul1FP" to="yv47:2uR5X5ayM7T" resolve="IToplevelExprContent" />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="3meuf2aZHdd">
+    <property role="3GE5qa" value="enum" />
+    <ref role="1XX52x" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
+    <node concept="3EZMnI" id="3meuf2aZHdf" role="2wV5jI">
+      <node concept="l2Vlx" id="3meuf2aZHdg" role="2iSdaV" />
+      <node concept="PMmxH" id="3meuf2aZHdh" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="3meuf2aZHdi" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="3meuf2aZHdj" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="3meuf2aZHdk" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="1iCGBv" id="3meuf2aZHdl" role="3EZMnx">
+        <ref role="1NtTu8" to="yv47:3meuf2aV0ef" resolve="literal" />
+        <node concept="1sVBvm" id="3meuf2aZHdm" role="1sWHZn">
+          <node concept="3F0A7n" id="3meuf2aZHdn" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+            <node concept="Vb9p2" id="3meuf2aZHdo" role="3F10Kt">
+              <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
+            </node>
+            <node concept="VechU" id="3meuf2aZHdp" role="3F10Kt">
+              <property role="Vb096" value="fLJRk5B/darkGray" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="3meuf2aZHdq" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11L4FC" id="3meuf2aZHdr" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="3meuf2b7gAL">
+    <property role="3GE5qa" value="enum.oneof" />
+    <ref role="1XX52x" to="yv47:4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
+    <node concept="3EZMnI" id="3meuf2b7gE8" role="2wV5jI">
+      <node concept="l2Vlx" id="3meuf2b7gE9" role="2iSdaV" />
+      <node concept="PMmxH" id="3meuf2b7gEa" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="3meuf2b7gEb" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="3meuf2b7gEc" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="3meuf2b7gEd" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F2HdR" id="3meuf2b7gEe" role="3EZMnx">
+        <property role="2czwfO" value="," />
+        <ref role="1NtTu8" to="yv47:3meuf2b3h5o" resolve="selectors" />
+        <node concept="l2Vlx" id="3meuf2b7gEf" role="2czzBx" />
+        <node concept="3F0ifn" id="3meuf2b7gEg" role="2czzBI">
+          <property role="3F0ifm" value="" />
+          <node concept="VPxyj" id="3meuf2b7gEh" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="3meuf2b7gEi" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11L4FC" id="3meuf2b7gEj" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+    <node concept="3EZMnI" id="3meuf2b7h47" role="6VMZX">
+      <node concept="3F0ifn" id="3meuf2b7h48" role="3EZMnx">
+        <property role="3F0ifm" value="reduced:" />
+      </node>
+      <node concept="1HlG4h" id="3meuf2b7h49" role="3EZMnx">
+        <node concept="1HfYo3" id="3meuf2b7h4a" role="1HlULh">
+          <node concept="3TQlhw" id="3meuf2b7h4b" role="1Hhtcw">
+            <node concept="3clFbS" id="3meuf2b7h4c" role="2VODD2">
+              <node concept="3clFbF" id="3meuf2b7h4d" role="3cqZAp">
+                <node concept="2OqwBi" id="3meuf2b7h4e" role="3clFbG">
+                  <node concept="2OqwBi" id="3meuf2b7h4f" role="2Oq$k0">
+                    <node concept="pncrf" id="3meuf2b7h4g" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="3meuf2b7h4h" role="2OqNvi">
+                      <ref role="37wK5l" to="nu60:4L5R3LmDzwi" resolve="reduce" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="3meuf2b7h4i" role="2OqNvi">
+                    <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="l2Vlx" id="3meuf2b7h4j" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -31,6 +31,7 @@
         <property id="7862711839422615217" name="text" index="t5JxN" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="9005308665739310115" name="languageId" index="2eQzMB" />
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
         <property id="4628067390765956807" name="final" index="R5$K2" />
@@ -797,15 +798,14 @@
     <property role="TrG5h" value="EnumIsTarget" />
     <property role="34LRSv" value="is" />
     <property role="R4oN_" value="check the enumeration literal against another literal" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="5ElkanPQwmu" role="PzmwI">
-      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-    </node>
+    <ref role="1TJDcQ" node="3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
     <node concept="1TJgyj" id="5ElkanPSLzu" role="1TKVEi">
       <property role="IQ2ns" value="6527211908668528862" />
-      <property role="20kJfa" value="literal" />
-      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20kJfa" value="literal_old" />
       <ref role="20lvS9" node="67Y8mp$DMVh" resolve="EnumLiteral" />
+      <node concept="asaX9" id="3meuf2aV0eq" role="lGtFl">
+        <property role="YLQ7P" value="The link was moved to concept &quot;org.iets3.core.expr.toplevel.structure.AbstractEnumSingleInTarget&quot;" />
+      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="ub9nkyK62f">
@@ -1199,16 +1199,16 @@
     <property role="TrG5h" value="EnumIsInTarget" />
     <property role="34LRSv" value="isIn" />
     <property role="R4oN_" value="check the enumeration literal against several literals" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="6WstIz8MK68" role="PzmwI">
-      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-    </node>
+    <ref role="1TJDcQ" node="4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
     <node concept="1TJgyj" id="6WstIz8MK6a" role="1TKVEi">
       <property role="IQ2ns" value="8006404979731136906" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="selectors" />
-      <property role="20lbJX" value="fLJekj6/_1__n" />
+      <property role="20kJfa" value="selectors_old" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="6WstIz8MKZd" resolve="EnumIsInSelector" />
+      <node concept="asaX9" id="3meuf2b3h5z" role="lGtFl">
+        <property role="YLQ7P" value="The link was moved to concept &quot;org.iets3.core.expr.toplevel.structure.AbstractEnumInTarget&quot;" />
+      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="6WstIz8MKZd">
@@ -1318,6 +1318,57 @@
     <property role="TrG5h" value="EnumSortByLiteral" />
     <property role="34LRSv" value="by literal" />
     <ref role="1TJDcQ" node="wlV$3kt3Ry" resolve="AbstractEnumSortOrder" />
+  </node>
+  <node concept="1TIwiD" id="3WZ76l1FQSK">
+    <property role="TrG5h" value="EnumIsNotTarget" />
+    <property role="34LRSv" value="isNot" />
+    <property role="R4oN_" value="check the enumeration literal is NOT equal to another literal" />
+    <property role="3GE5qa" value="enum" />
+    <property role="EcuMT" value="4557392569141521968" />
+    <property role="2eQzMB" value="71934284-d7d1-45ee-a054-8c072591085f" />
+    <ref role="1TJDcQ" node="3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
+  </node>
+  <node concept="1TIwiD" id="6NLFGgDxmkC">
+    <property role="TrG5h" value="EnumIsNotInTarget" />
+    <property role="34LRSv" value="isNotIn" />
+    <property role="R4oN_" value="check the enumeration literal is NOT in several literals" />
+    <property role="3GE5qa" value="enum.oneof" />
+    <property role="EcuMT" value="7850247783016916264" />
+    <property role="2eQzMB" value="71934284-d7d1-45ee-a054-8c072591085f" />
+    <ref role="1TJDcQ" node="4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
+  </node>
+  <node concept="1TIwiD" id="4L5R3LmDtPG">
+    <property role="EcuMT" value="5496041071985417580" />
+    <property role="TrG5h" value="AbstractEnumInTarget" />
+    <property role="R5$K7" value="true" />
+    <property role="3GE5qa" value="enum.oneof" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="3meuf2aNc25" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
+    <node concept="1TJgyj" id="3meuf2b3h5o" role="1TKVEi">
+      <property role="IQ2ns" value="3859154905223467352" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="selectors" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
+      <ref role="20lvS9" node="6WstIz8MKZd" resolve="EnumIsInSelector" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="3fg81r5z3u3">
+    <property role="EcuMT" value="3733519373265811331" />
+    <property role="TrG5h" value="AbstractEnumSingleInTarget" />
+    <property role="3GE5qa" value="enum" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="3meuf2aRmCC" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
+    <node concept="1TJgyj" id="3meuf2aV0ef" role="1TKVEi">
+      <property role="IQ2ns" value="3859154905221301135" />
+      <property role="20kJfa" value="literal" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="67Y8mp$DMVh" resolve="EnumLiteral" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -2206,31 +2206,6 @@
       </node>
     </node>
   </node>
-  <node concept="1YbPZF" id="5ElkanPQ$0Y">
-    <property role="TrG5h" value="typeof_EnumIsTarget" />
-    <property role="3GE5qa" value="enum" />
-    <node concept="3clFbS" id="5ElkanPQ$0Z" role="18ibNy">
-      <node concept="1Z5TYs" id="5ElkanPQ$el" role="3cqZAp">
-        <node concept="mw_s8" id="5ElkanPQ$eA" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zqS" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQco" resolve="createBooleanType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="5ElkanPQ$eo" role="1ZfhK$">
-          <node concept="1Z2H0r" id="5ElkanPQ$1b" role="mwGJk">
-            <node concept="1YBJjd" id="5ElkanPQ$2V" role="1Z2MuG">
-              <ref role="1YBMHb" node="5ElkanPQ$11" resolve="et" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="5ElkanPQ$11" role="1YuTPh">
-      <property role="TrG5h" value="et" />
-      <ref role="1YaFvo" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
-    </node>
-  </node>
   <node concept="35pCF_" id="29BBztTT4Gl">
     <property role="3GE5qa" value="typedef" />
     <property role="TrG5h" value="replaceTypedefType2" />
@@ -4111,31 +4086,6 @@
       <ref role="1YaFvo" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
     </node>
   </node>
-  <node concept="1YbPZF" id="6WstIz8MQ1T">
-    <property role="TrG5h" value="typeof_EnumIsOneOfTarget" />
-    <property role="3GE5qa" value="enum.oneof" />
-    <node concept="3clFbS" id="6WstIz8MQ1U" role="18ibNy">
-      <node concept="1Z5TYs" id="6WstIz8MQaQ" role="3cqZAp">
-        <node concept="mw_s8" id="6WstIz8MQbf" role="1ZfhKB">
-          <node concept="2YIFZM" id="6WstIz8MQcO" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQco" resolve="createBooleanType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="6WstIz8MQaT" role="1ZfhK$">
-          <node concept="1Z2H0r" id="6WstIz8MQ26" role="mwGJk">
-            <node concept="1YBJjd" id="6WstIz8MQ3V" role="1Z2MuG">
-              <ref role="1YBMHb" node="6WstIz8MQ1W" resolve="eio" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="6WstIz8MQ1W" role="1YuTPh">
-      <property role="TrG5h" value="eio" />
-      <ref role="1YaFvo" to="yv47:6WstIz8MK67" resolve="EnumIsInTarget" />
-    </node>
-  </node>
   <node concept="1YbPZF" id="2zwra1$Qju3">
     <property role="TrG5h" value="typeof_AllLitList" />
     <property role="3GE5qa" value="enum" />
@@ -4461,6 +4411,56 @@
     <node concept="1YaCAy" id="5QvrxSgK6Qw" role="1YuTPh">
       <property role="TrG5h" value="typedef" />
       <ref role="1YaFvo" to="yv47:6HHp2WngtTC" resolve="Typedef" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4L5R3LnUBuz">
+    <property role="TrG5h" value="typeof_AbstractEnumInTarget" />
+    <property role="3GE5qa" value="enum.oneof" />
+    <node concept="3clFbS" id="4L5R3LnUBu$" role="18ibNy">
+      <node concept="1Z5TYs" id="4L5R3LnUBQi" role="3cqZAp">
+        <node concept="mw_s8" id="4L5R3LnUBQj" role="1ZfhKB">
+          <node concept="2YIFZM" id="4L5R3LnUBQk" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQco" resolve="createBooleanType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="4L5R3LnUBQl" role="1ZfhK$">
+          <node concept="1Z2H0r" id="4L5R3LnUBQm" role="mwGJk">
+            <node concept="1YBJjd" id="4L5R3LnUBQn" role="1Z2MuG">
+              <ref role="1YBMHb" node="4L5R3LnUBuA" resolve="enumtarget" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4L5R3LnUBuA" role="1YuTPh">
+      <property role="TrG5h" value="enumtarget" />
+      <ref role="1YaFvo" to="yv47:4L5R3LmDtPG" resolve="AbstractEnumInTarget" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="3oC2VaFL6F1">
+    <property role="TrG5h" value="typeof_AbstractEnumSingleInTarget" />
+    <property role="3GE5qa" value="enum" />
+    <node concept="3clFbS" id="3oC2VaFL6F2" role="18ibNy">
+      <node concept="1Z5TYs" id="3oC2VaFL6Ga" role="3cqZAp">
+        <node concept="mw_s8" id="3oC2VaFL6Gb" role="1ZfhKB">
+          <node concept="2YIFZM" id="3oC2VaFL6Gc" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQco" resolve="createBooleanType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="3oC2VaFL6Gd" role="1ZfhK$">
+          <node concept="1Z2H0r" id="3oC2VaFL6Ge" role="mwGJk">
+            <node concept="1YBJjd" id="3oC2VaFL6Gf" role="1Z2MuG">
+              <ref role="1YBMHb" node="3oC2VaFL6F4" resolve="et" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="3oC2VaFL6F4" role="1YuTPh">
+      <property role="TrG5h" value="et" />
+      <ref role="1YaFvo" to="yv47:3fg81r5z3u3" resolve="AbstractEnumSingleInTarget" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="org.iets3.core.expr.toplevel" uuid="71934284-d7d1-45ee-a054-8c072591085f" languageVersion="6" moduleVersion="4">
+<language namespace="org.iets3.core.expr.toplevel" uuid="71934284-d7d1-45ee-a054-8c072591085f" languageVersion="8" moduleVersion="6">
   <models>
     <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
@@ -139,7 +139,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.bindingtime/org.iets3.core.expr.typetags.bindingtime.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.bindingtime/org.iets3.core.expr.typetags.bindingtime.mpl
@@ -82,7 +82,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d(org.iets3.core.expr.typetags.bindingtime)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/org.iets3.core.expr.typetags.physunits.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/org.iets3.core.expr.typetags.physunits.mpl
@@ -158,7 +158,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="197e2a32-ff26-4358-af5c-731ae2b35f83(org.iets3.core.expr.simpleTypes.interpreter)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="7ee265bd-5986-4709-86ed-2c6daa33cd8c(org.iets3.core.expr.typetags.physunits)" version="1" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units.quantity/org.iets3.core.expr.typetags.units.quantity.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units.quantity/org.iets3.core.expr.typetags.units.quantity.mpl
@@ -93,7 +93,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="cb91a38e-738a-4811-a96d-448d08f526fa(org.iets3.core.expr.typetags.units)" version="1" />
     <module reference="be679007-4312-4db1-9ac0-ab7dfbe66a74(org.iets3.core.expr.typetags.units.quantity)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/org.iets3.core.expr.typetags.units.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/org.iets3.core.expr.typetags.units.mpl
@@ -153,7 +153,7 @@
     <module reference="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0(org.iets3.core.expr.math)" version="6" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="7ee265bd-5986-4709-86ed-2c6daa33cd8c(org.iets3.core.expr.typetags.physunits)" version="0" />
     <module reference="86255e62-4839-480a-a7d0-9ee30f97e2d8(org.iets3.core.expr.typetags.phyunits.si)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/org.iets3.core.expr.typetags.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/org.iets3.core.expr.typetags.mpl
@@ -186,7 +186,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
@@ -144,7 +144,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8bb1251e-eae5-47ab-9843-33adfae8edaa(org.iets3.core.expr.util)" version="7" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.mapping/org.iets3.core.mapping.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.mapping/org.iets3.core.mapping.mpl
@@ -116,7 +116,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8c1ef69a-bcac-4cb5-9619-6b27d0aefc0c(org.iets3.core.mapping)" version="1" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.protocol.transport/org.iets3.protocol.transport.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.protocol.transport/org.iets3.protocol.transport.mpl
@@ -112,7 +112,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8c1ef69a-bcac-4cb5-9619-6b27d0aefc0c(org.iets3.core.mapping)" version="1" />
     <module reference="a50d6290-93d2-42af-9ae0-b2fefc6ee754(org.iets3.protocol.transport)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/org.iets3.variability.artifacts.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/org.iets3.variability.artifacts.base.mpl
@@ -150,7 +150,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5d6c0572-ccc8-4389-af81-29bf43d3db42(org.iets3.util)" version="0" />
     <module reference="f0883503-8eaa-4bc8-8846-eb63220ab1dd(org.iets3.variability.artifacts.base)" version="18" />
     <module reference="c6ff3b3b-aff6-455e-9637-7955ccbfec22(org.iets3.variability.artifacts.vanguard)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.baseline/org.iets3.variability.artifacts.baseline.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.baseline/org.iets3.variability.artifacts.baseline.mpl
@@ -110,7 +110,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="f0883503-8eaa-4bc8-8846-eb63220ab1dd(org.iets3.variability.artifacts.base)" version="18" />
     <module reference="bad8e421-fc94-4104-8c1e-6fc9d2dccf07(org.iets3.variability.artifacts.baseline)" version="0" />
     <module reference="c6ff3b3b-aff6-455e-9637-7955ccbfec22(org.iets3.variability.artifacts.vanguard)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.typesystem/org.iets3.variability.artifacts.typesystem.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.typesystem/org.iets3.variability.artifacts.typesystem.mpl
@@ -191,7 +191,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="f0883503-8eaa-4bc8-8846-eb63220ab1dd(org.iets3.variability.artifacts.base)" version="18" />
     <module reference="9914d82b-ab8a-44d1-9c65-9f2954c3b4df(org.iets3.variability.artifacts.typesystem)" version="0" />
     <module reference="c6ff3b3b-aff6-455e-9637-7955ccbfec22(org.iets3.variability.artifacts.vanguard)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.base/org.iets3.variability.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.base/org.iets3.variability.base.mpl
@@ -96,7 +96,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />
     <module reference="165f1d05-2506-4544-895e-1424f54166ec(org.iets3.variability.featuremodel.base)" version="36" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/org.iets3.variability.configuration.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/org.iets3.variability.configuration.base.mpl
@@ -150,7 +150,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="7ee265bd-5986-4709-86ed-2c6daa33cd8c(org.iets3.core.expr.typetags.physunits)" version="0" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/org.iets3.variability.featuremodel.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/org.iets3.variability.featuremodel.base.mpl
@@ -172,7 +172,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="72d75849-a798-487d-b183-4d97b41c9e68(org.iets3.featuremodel.gen.runtime)" version="0" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />
     <module reference="165f1d05-2506-4544-895e-1424f54166ec(org.iets3.variability.featuremodel.base)" version="36" />

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
@@ -102,7 +102,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="3c910f62-7ca9-45f3-a98a-c6239acaa8f1(test.iest3.component.attribute)" version="0" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.components.core.interpreter/org.iets3.components.core.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.components.core.interpreter/org.iets3.components.core.interpreter.msd
@@ -67,7 +67,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.components.core.sandbox/models/adapter.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.components.core.sandbox/models/adapter.mps
@@ -2,7 +2,7 @@
 <model ref="r:be73923b-d000-4b04-94e6-497003a9b11b(org.iets3.components.core.sandbox.adapter)">
   <persistence version="9" />
   <languages>
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="cd87ddab-6434-448e-a011-1e1c898de18e" name="org.iets3.core.expr.statemachines" version="4" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="f0fd486f-8577-43e9-b671-3d118449c6e7" name="org.iets3.components.core" version="10" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.components.core.sandbox/org.iets3.components.core.sandbox.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.components.core.sandbox/org.iets3.components.core.sandbox.msd
@@ -39,7 +39,7 @@
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
     <language slang="l:cd87ddab-6434-448e-a011-1e1c898de18e:org.iets3.core.expr.statemachines" version="4" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:3c910f62-7ca9-45f3-a98a-c6239acaa8f1:test.iest3.component.attribute" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.adt.interpreter/org.iets3.core.expr.adt.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.adt.interpreter/org.iets3.core.expr.adt.interpreter.msd
@@ -72,7 +72,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
@@ -78,7 +78,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.dataflow.interpreter/org.iets3.core.expr.dataflow.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.dataflow.interpreter/org.iets3.core.expr.dataflow.interpreter.msd
@@ -69,7 +69,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.doc.plugin/org.iets3.core.expr.doc.plugin.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.doc.plugin/org.iets3.core.expr.doc.plugin.msd
@@ -74,7 +74,7 @@
     <module reference="e29ad049-74f8-4f02-9561-62d7477f822a(org.iets3.core.expr.doc.plugin)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lookup.interpreter/org.iets3.core.expr.lookup.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lookup.interpreter/org.iets3.core.expr.lookup.interpreter.msd
@@ -69,7 +69,7 @@
     <module reference="0406e4b3-cffd-4d16-8533-6bc50680ab3b(org.iets3.core.expr.lookup)" version="0" />
     <module reference="847dec6c-8460-4c2a-9e6e-039d9d12e815(org.iets3.core.expr.lookup.interpreter)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.messages.interpreter/org.iets3.core.expr.messages.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.messages.interpreter/org.iets3.core.expr.messages.interpreter.msd
@@ -68,7 +68,7 @@
     <module reference="553a35c5-ccd6-40ba-9923-5e3b354d0c76(org.iets3.core.expr.messages)" version="4" />
     <module reference="2bd330e3-1cae-4049-bed7-7d39e93cece4(org.iets3.core.expr.messages.interpreter)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.process.interpreter/org.iets3.core.expr.process.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.process.interpreter/org.iets3.core.expr.process.interpreter.msd
@@ -75,7 +75,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="50b470e7-14ad-46c3-b540-4586f56d2e9c(org.iets3.core.expr.process)" version="2" />
     <module reference="0a9d9bba-15ce-45fa-ba85-2c2dddcd1ff0(org.iets3.core.expr.process.interpreter)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.interpreter/org.iets3.core.expr.repl.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.interpreter/org.iets3.core.expr.repl.interpreter.msd
@@ -79,7 +79,7 @@
     <module reference="bd5d2f0b-399d-4cb7-b981-7a3f9ce7bc78(org.iets3.core.expr.repl.interpreter)" version="0" />
     <module reference="197e2a32-ff26-4358-af5c-731ae2b35f83(org.iets3.core.expr.simpleTypes.interpreter)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="9c16e638-297e-41f0-b9e1-a1e04a4aea54(org.iets3.core.expr.toplevel.interpreter)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.plugin/org.iets3.core.expr.repl.plugin.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.plugin/org.iets3.core.expr.repl.plugin.msd
@@ -76,7 +76,7 @@
     <module reference="18001c94-33a7-4f68-a7c1-ffddc4b39be1(org.iets3.core.expr.repl)" version="1" />
     <module reference="1157d4c9-6175-4550-96aa-aae0a9fdc06f(org.iets3.core.expr.repl.plugin)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
@@ -68,7 +68,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.statemachines.interpreter/org.iets3.core.expr.statemachines.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.statemachines.interpreter/org.iets3.core.expr.statemachines.interpreter.msd
@@ -73,7 +73,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="cd87ddab-6434-448e-a011-1e1c898de18e(org.iets3.core.expr.statemachines)" version="4" />
     <module reference="b10553c8-9d54-444d-bb92-a27be823b74f(org.iets3.core.expr.statemachines.interpreter)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.stringvalidation.interpreter/org.iets3.core.expr.stringvalidation.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.stringvalidation.interpreter/org.iets3.core.expr.stringvalidation.interpreter.msd
@@ -72,7 +72,7 @@
     <module reference="f003a0fe-c140-41d7-a145-ea42368e581c(org.iets3.core.expr.stringvalidation)" version="1" />
     <module reference="ad2cd2ae-226c-4046-9241-9790f9c3a35e(org.iets3.core.expr.stringvalidation.interpreter)" version="0" />
     <module reference="f38b69a3-1d33-4f9b-84e0-ac1095df2998(org.iets3.core.expr.stringvalidation.runtime)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tests.interpreter/org.iets3.core.expr.tests.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tests.interpreter/org.iets3.core.expr.tests.interpreter.msd
@@ -78,7 +78,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
     <module reference="7a4a0378-45ed-4612-99b5-b72416acc630(org.iets3.core.expr.tests.interpreter)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tests.rt/org.iets3.core.expr.tests.rt.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tests.rt/org.iets3.core.expr.tests.rt.msd
@@ -74,7 +74,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
     <module reference="6effa8ea-ddf9-441a-a29e-80a73b7d0fc7(org.iets3.core.expr.tests.rt)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/models/plugin.mps
@@ -133,7 +133,6 @@
       </concept>
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
@@ -264,6 +263,8 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
@@ -2698,53 +2699,44 @@
               <node concept="3cpWsn" id="3FGeL_$G9Ov" role="3cpWs9">
                 <property role="TrG5h" value="ret" />
                 <node concept="10P_77" id="3FGeL_$G9Oq" role="1tU5fm" />
-                <node concept="3clFbT" id="3FGeL_$Gakx" role="33vP2m" />
-              </node>
-            </node>
-            <node concept="2Gpval" id="6WstIz8RAkE" role="3cqZAp">
-              <node concept="2GrKxI" id="6WstIz8RAkG" role="2Gsz3X">
-                <property role="TrG5h" value="l" />
-              </node>
-              <node concept="2OqwBi" id="6WstIz8RAD4" role="2GsD0m">
-                <node concept="oxGPV" id="6WstIz8RAwt" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="6WstIz8RBuE" role="2OqNvi">
-                  <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="6WstIz8RAkK" role="2LFqv$">
-                <node concept="3clFbJ" id="6WstIz8RBxl" role="3cqZAp">
-                  <node concept="3clFbC" id="6WstIz8RB_7" role="3clFbw">
-                    <node concept="37vLTw" id="6WstIz8RBx$" role="3uHU7B">
-                      <ref role="3cqZAo" node="6WstIz8RA0$" resolve="ctx" />
-                    </node>
-                    <node concept="2YIFZM" id="4$j2$kkixM6" role="3uHU7w">
-                      <ref role="37wK5l" to="pq1l:4$j2$kkfRAe" resolve="getInstance" />
-                      <ref role="1Pybhc" to="pq1l:365yA_OO5FT" resolve="EnumLiteral" />
-                      <node concept="2OqwBi" id="4$j2$kkiyqu" role="37wK5m">
-                        <node concept="2GrUjf" id="4$j2$kkiyih" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="6WstIz8RAkG" resolve="l" />
-                        </node>
-                        <node concept="3TrEf2" id="4$j2$kkiyBl" role="2OqNvi">
-                          <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
-                        </node>
-                      </node>
-                      <node concept="oxNuS" id="4$j2$kkiyNA" role="37wK5m" />
-                      <node concept="3fckFw" id="4$j2$kkiyP7" role="37wK5m" />
-                      <node concept="2dz_u5" id="4$j2$kkiz21" role="37wK5m" />
+                <node concept="2OqwBi" id="7dojahfGqro" role="33vP2m">
+                  <node concept="2OqwBi" id="7dojahfGqrp" role="2Oq$k0">
+                    <node concept="oxGPV" id="7dojahfGqrq" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="7dojahfGqrr" role="2OqNvi">
+                      <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
                     </node>
                   </node>
-                  <node concept="3clFbS" id="6WstIz8RBxn" role="3clFbx">
-                    <node concept="3clFbF" id="3FGeL_$Ga5z" role="3cqZAp">
-                      <node concept="37vLTI" id="3FGeL_$Gak0" role="3clFbG">
-                        <node concept="3clFbT" id="3FGeL_$Gakg" role="37vLTx">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                        <node concept="37vLTw" id="3FGeL_$Ga5y" role="37vLTJ">
-                          <ref role="3cqZAo" node="3FGeL_$G9Ov" resolve="ret" />
+                  <node concept="2HwmR7" id="7dojahfGqrs" role="2OqNvi">
+                    <node concept="1bVj0M" id="7dojahfGqrt" role="23t8la">
+                      <node concept="3clFbS" id="7dojahfGqru" role="1bW5cS">
+                        <node concept="3clFbF" id="7dojahfGqrv" role="3cqZAp">
+                          <node concept="3clFbC" id="7dojahfGqrw" role="3clFbG">
+                            <node concept="37vLTw" id="7dojahfGqrx" role="3uHU7B">
+                              <ref role="3cqZAo" node="6WstIz8RA0$" resolve="ctx" />
+                            </node>
+                            <node concept="2YIFZM" id="7dojahfGqry" role="3uHU7w">
+                              <ref role="37wK5l" to="pq1l:4$j2$kkfRAe" resolve="getInstance" />
+                              <ref role="1Pybhc" to="pq1l:365yA_OO5FT" resolve="EnumLiteral" />
+                              <node concept="2OqwBi" id="7dojahfGqrz" role="37wK5m">
+                                <node concept="37vLTw" id="7dojahfGqr$" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7dojahfGqrD" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="7dojahfGqr_" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
+                                </node>
+                              </node>
+                              <node concept="oxNuS" id="7dojahfGqrA" role="37wK5m" />
+                              <node concept="3fckFw" id="7dojahfGqrB" role="37wK5m" />
+                              <node concept="2dz_u5" id="7dojahfGqrC" role="37wK5m" />
+                            </node>
+                          </node>
                         </node>
                       </node>
+                      <node concept="gl6BB" id="7dojahfGqrD" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7dojahfGqrE" role="1tU5fm" />
+                      </node>
                     </node>
-                    <node concept="3zACq4" id="4$j2$kkizha" role="3cqZAp" />
                   </node>
                 </node>
               </node>
@@ -2756,7 +2748,7 @@
                     <node concept="2OqwBi" id="3FGeL_$GaNM" role="2Oq$k0">
                       <node concept="oxGPV" id="3FGeL_$GaGo" role="2Oq$k0" />
                       <node concept="3Tsc0h" id="3FGeL_$GaZG" role="2OqNvi">
-                        <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
+                        <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
                       </node>
                     </node>
                     <node concept="2es0OD" id="3FGeL_$GdoW" role="2OqNvi">
@@ -2791,6 +2783,131 @@
             <node concept="3cpWs6" id="6WstIz8RA0J" role="3cqZAp">
               <node concept="37vLTw" id="3FGeL_$GakP" role="3cqZAk">
                 <ref role="3cqZAo" node="3FGeL_$G9Ov" resolve="ret" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="6NLFGgDJGAa" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="yv47:6NLFGgDxmkC" resolve="EnumIsNotInTarget" />
+      <node concept="3dA_Gj" id="6NLFGgDJMm8" role="3vQZUl">
+        <node concept="9aQIb" id="6NLFGgDJMma" role="3vcmbn">
+          <node concept="3clFbS" id="6NLFGgDJMmc" role="9aQI4">
+            <node concept="3cpWs8" id="6NLFGgDJMmm" role="3cqZAp">
+              <node concept="3cpWsn" id="6NLFGgDJMmn" role="3cpWs9">
+                <property role="TrG5h" value="ctx" />
+                <node concept="3uibUv" id="6NLFGgDJMmo" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="3EllGN" id="6NLFGgDJMmp" role="33vP2m">
+                  <node concept="2OqwBi" id="6NLFGgDJMmq" role="3ElVtu">
+                    <node concept="1PxgMI" id="6NLFGgDJMmr" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6NLFGgDJMms" role="1m5AlR">
+                        <node concept="oxGPV" id="6NLFGgDJMmt" role="2Oq$k0" />
+                        <node concept="1mfA1w" id="6NLFGgDJMmu" role="2OqNvi" />
+                      </node>
+                      <node concept="chp4Y" id="6NLFGgDJMmv" role="3oSUPX">
+                        <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="6NLFGgDJMmw" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                    </node>
+                  </node>
+                  <node concept="TvHiN" id="6NLFGgDJMmx" role="3ElQJh" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="6NLFGgDJMmy" role="3cqZAp">
+              <node concept="3cpWsn" id="6NLFGgDJMmz" role="3cpWs9">
+                <property role="TrG5h" value="ret" />
+                <node concept="10P_77" id="6NLFGgDJMm$" role="1tU5fm" />
+                <node concept="2OqwBi" id="7dojahfG8VE" role="33vP2m">
+                  <node concept="2OqwBi" id="7dojahfG6eU" role="2Oq$k0">
+                    <node concept="oxGPV" id="7dojahfG5_Y" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="7dojahfG6NK" role="2OqNvi">
+                      <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+                    </node>
+                  </node>
+                  <node concept="2HxqBE" id="7dojahfGyOr" role="2OqNvi">
+                    <node concept="1bVj0M" id="7dojahfGyOt" role="23t8la">
+                      <node concept="3clFbS" id="7dojahfGyOu" role="1bW5cS">
+                        <node concept="3clFbF" id="7dojahfGyOv" role="3cqZAp">
+                          <node concept="3y3z36" id="7dojahfGzIy" role="3clFbG">
+                            <node concept="37vLTw" id="7dojahfGyOx" role="3uHU7B">
+                              <ref role="3cqZAo" node="6NLFGgDJMmn" resolve="ctx" />
+                            </node>
+                            <node concept="2YIFZM" id="7dojahfGyOy" role="3uHU7w">
+                              <ref role="37wK5l" to="pq1l:4$j2$kkfRAe" resolve="getInstance" />
+                              <ref role="1Pybhc" to="pq1l:365yA_OO5FT" resolve="EnumLiteral" />
+                              <node concept="2OqwBi" id="7dojahfGyOz" role="37wK5m">
+                                <node concept="37vLTw" id="7dojahfGyO$" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7dojahfGyOD" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="7dojahfGyO_" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="yv47:6WstIz8MKZe" resolve="literal" />
+                                </node>
+                              </node>
+                              <node concept="oxNuS" id="7dojahfGyOA" role="37wK5m" />
+                              <node concept="3fckFw" id="7dojahfGyOB" role="37wK5m" />
+                              <node concept="2dz_u5" id="7dojahfGyOC" role="37wK5m" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="7dojahfGyOD" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7dojahfGyOE" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6NLFGgDJMmW" role="3cqZAp">
+              <node concept="3clFbS" id="6NLFGgDJMmX" role="3clFbx">
+                <node concept="3clFbF" id="6NLFGgDJMmY" role="3cqZAp">
+                  <node concept="2OqwBi" id="6NLFGgDJMmZ" role="3clFbG">
+                    <node concept="2OqwBi" id="6NLFGgDJMn0" role="2Oq$k0">
+                      <node concept="oxGPV" id="6NLFGgDJMn1" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="6NLFGgDJMn2" role="2OqNvi">
+                        <ref role="3TtcxE" to="yv47:3meuf2b3h5o" resolve="selectors" />
+                      </node>
+                    </node>
+                    <node concept="2es0OD" id="6NLFGgDJMn3" role="2OqNvi">
+                      <node concept="1bVj0M" id="6NLFGgDJMn4" role="23t8la">
+                        <node concept="3clFbS" id="6NLFGgDJMn5" role="1bW5cS">
+                          <node concept="3clFbF" id="6NLFGgDJMn6" role="3cqZAp">
+                            <node concept="2OqwBi" id="6NLFGgDJMn7" role="3clFbG">
+                              <node concept="3fckFw" id="6NLFGgDJMn8" role="2Oq$k0" />
+                              <node concept="liA8E" id="6NLFGgDJMn9" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:RaqQlV4lZg" resolve="coverValue" />
+                                <node concept="37vLTw" id="6NLFGgDJMna" role="37wK5m">
+                                  <ref role="3cqZAo" node="6NLFGgDJMnc" resolve="it" />
+                                </node>
+                                <node concept="10Nm6u" id="6NLFGgDJMnb" role="37wK5m" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gl6BB" id="6NLFGgDJMnc" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="6NLFGgDJMnd" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="6NLFGgDJMne" role="3clFbw">
+                <ref role="3cqZAo" node="6NLFGgDJMmz" resolve="ret" />
+              </node>
+            </node>
+            <node concept="3cpWs6" id="6NLFGgDJMnf" role="3cqZAp">
+              <node concept="37vLTw" id="7dojahfHnhF" role="3cqZAk">
+                <ref role="3cqZAo" node="6NLFGgDJMmz" resolve="ret" />
               </node>
             </node>
           </node>
@@ -2914,12 +3031,67 @@
                   <node concept="2OqwBi" id="4$j2$kkic0a" role="37wK5m">
                     <node concept="oxGPV" id="4$j2$kkibJa" role="2Oq$k0" />
                     <node concept="3TrEf2" id="4$j2$kkicMg" role="2OqNvi">
-                      <ref role="3Tt5mk" to="yv47:5ElkanPSLzu" resolve="literal" />
+                      <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
                     </node>
                   </node>
                   <node concept="oxNuS" id="4$j2$kkibel" role="37wK5m" />
                   <node concept="3fckFw" id="4$j2$kkibem" role="37wK5m" />
                   <node concept="2dz_u5" id="4$j2$kkiben" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="6NLFGgBNeF7" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="yv47:3WZ76l1FQSK" resolve="EnumIsNotTarget" />
+      <node concept="3dA_Gj" id="6NLFGgBNkQc" role="3vQZUl">
+        <node concept="9aQIb" id="6NLFGgBNkQe" role="3vcmbn">
+          <node concept="3clFbS" id="6NLFGgBNkQg" role="9aQI4">
+            <node concept="3cpWs8" id="6NLFGgBNkQq" role="3cqZAp">
+              <node concept="3cpWsn" id="6NLFGgBNkQr" role="3cpWs9">
+                <property role="TrG5h" value="ctx" />
+                <node concept="3uibUv" id="6NLFGgBNkQs" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="3EllGN" id="6NLFGgBNkQt" role="33vP2m">
+                  <node concept="2OqwBi" id="6NLFGgBNkQu" role="3ElVtu">
+                    <node concept="1PxgMI" id="6NLFGgBNkQv" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6NLFGgBNkQw" role="1m5AlR">
+                        <node concept="oxGPV" id="6NLFGgBNkQx" role="2Oq$k0" />
+                        <node concept="1mfA1w" id="6NLFGgBNkQy" role="2OqNvi" />
+                      </node>
+                      <node concept="chp4Y" id="6NLFGgBNkQz" role="3oSUPX">
+                        <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="6NLFGgBNkQ$" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                    </node>
+                  </node>
+                  <node concept="TvHiN" id="6NLFGgBNkQ_" role="3ElQJh" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="6NLFGgBNkQA" role="3cqZAp">
+              <node concept="3y3z36" id="6NLFGgBNrOx" role="3cqZAk">
+                <node concept="37vLTw" id="6NLFGgBNkQC" role="3uHU7B">
+                  <ref role="3cqZAo" node="6NLFGgBNkQr" resolve="ctx" />
+                </node>
+                <node concept="2YIFZM" id="6NLFGgBXFbI" role="3uHU7w">
+                  <ref role="1Pybhc" to="pq1l:365yA_OO5FT" resolve="EnumLiteral" />
+                  <ref role="37wK5l" to="pq1l:4$j2$kkfRAe" resolve="getInstance" />
+                  <node concept="2OqwBi" id="6NLFGgBXFbJ" role="37wK5m">
+                    <node concept="oxGPV" id="6NLFGgBXFbK" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="6NLFGgBXFbL" role="2OqNvi">
+                      <ref role="3Tt5mk" to="yv47:3meuf2aV0ef" resolve="literal" />
+                    </node>
+                  </node>
+                  <node concept="oxNuS" id="6NLFGgBXFbM" role="37wK5m" />
+                  <node concept="3fckFw" id="6NLFGgBXFbN" role="37wK5m" />
+                  <node concept="2dz_u5" id="6NLFGgBXFbO" role="37wK5m" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/org.iets3.core.expr.toplevel.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/org.iets3.core.expr.toplevel.interpreter.msd
@@ -76,7 +76,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="9c16e638-297e-41f0-b9e1-a1e04a4aea54(org.iets3.core.expr.toplevel.interpreter)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/org.iets3.core.expr.tracing.plugin.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/org.iets3.core.expr.tracing.plugin.msd
@@ -94,7 +94,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="cbb71b24-470d-4374-b77c-ebd0d3b3bb27(org.iets3.core.expr.plugin)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="63c1aad1-e2db-439c-a30a-02b5e0bc80f3(org.iets3.core.expr.tracing)" version="0" />
     <module reference="b0e7c6a8-b47d-4637-b0e8-e5bfd486c4e8(org.iets3.core.expr.tracing.plugin)" version="0" />
     <module reference="07e2118e-763f-4d93-8ae6-23cf5ede3d59(org.iets3.core.plugin)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.physunits.documentation/models/org.iets3.core.expr.typetags.physunits.documentation.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.physunits.documentation/models/org.iets3.core.expr.typetags.physunits.documentation.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="5186c6ce-428c-4f09-a9df-73d9e86c27d3" name="org.iets3.core.expr.typetags" version="1" />
     <use id="38a074ed-e5ad-4b2d-be31-ca436911b8aa" name="com.mbeddr.doc.aspect" version="0" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
     <use id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker" version="0" />
     <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="6" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.physunits.documentation/org.iets3.core.expr.typetags.physunits.documentation.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.physunits.documentation/org.iets3.core.expr.typetags.physunits.documentation.msd
@@ -43,7 +43,7 @@
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="6" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:7ee265bd-5986-4709-86ed-2c6daa33cd8c:org.iets3.core.expr.typetags.physunits" version="0" />
   </languageVersions>
@@ -89,7 +89,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="7ee265bd-5986-4709-86ed-2c6daa33cd8c(org.iets3.core.expr.typetags.physunits)" version="0" />
     <module reference="9002631e-7e42-46da-88df-6577409bb437(org.iets3.core.expr.typetags.physunits.documentation)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
@@ -2,7 +2,7 @@
 <model ref="r:4134cae9-4017-4808-bf1c-768cb21cb9ea(org.iets3.core.expr.typetags.phyunits.si.units)">
   <persistence version="9" />
   <languages>
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="7ee265bd-5986-4709-86ed-2c6daa33cd8c" name="org.iets3.core.expr.typetags.physunits" version="0" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
   </languages>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/org.iets3.core.expr.typetags.phyunits.si.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/org.iets3.core.expr.typetags.phyunits.si.msd
@@ -34,7 +34,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:7ee265bd-5986-4709-86ed-2c6daa33cd8c:org.iets3.core.expr.typetags.physunits" version="0" />
   </languageVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.interpreter/org.iets3.core.expr.typetags.units.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.interpreter/org.iets3.core.expr.typetags.units.interpreter.msd
@@ -76,7 +76,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="197e2a32-ff26-4358-af5c-731ae2b35f83(org.iets3.core.expr.simpleTypes.interpreter)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="cb91a38e-738a-4811-a96d-448d08f526fa(org.iets3.core.expr.typetags.units)" version="1" />
     <module reference="616c1a94-9ced-468d-8c3a-fbdcf9734823(org.iets3.core.expr.typetags.units.interpreter)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.si/models/units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.si/models/units.mps
@@ -2,7 +2,7 @@
 <model ref="r:1881124b-7ac4-4b0f-a7dd-12953ac3263b(org.iets3.core.expr.typetags.units.si.units)">
   <persistence version="9" />
   <languages>
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="cb91a38e-738a-4811-a96d-448d08f526fa" name="org.iets3.core.expr.typetags.units" version="1" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
   </languages>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.si/org.iets3.core.expr.typetags.units.si.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.si/org.iets3.core.expr.typetags.units.si.msd
@@ -34,7 +34,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:cb91a38e-738a-4811-a96d-448d08f526fa:org.iets3.core.expr.typetags.units" version="1" />
   </languageVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.util.interpreter/org.iets3.core.expr.util.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.util.interpreter/org.iets3.core.expr.util.interpreter.msd
@@ -76,7 +76,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="197e2a32-ff26-4358-af5c-731ae2b35f83(org.iets3.core.expr.simpleTypes.interpreter)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8bb1251e-eae5-47ab-9843-33adfae8edaa(org.iets3.core.expr.util)" version="7" />
     <module reference="4289e037-cc03-4bfe-bf89-2db268aec73a(org.iets3.core.expr.util.interpreter)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/org.iets3.core.junit.interpreter.run.configuration.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/org.iets3.core.junit.interpreter.run.configuration.msd
@@ -118,7 +118,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="cbb71b24-470d-4374-b77c-ebd0d3b3bb27(org.iets3.core.expr.plugin)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="bacb5ddc-bd96-4d54-a76e-63aeb598f7fb(org.iets3.core.junit.interpreter.run.configuration)" version="0" />
     <module reference="63b449db-0918-4a4a-a891-2c430ab133e4(org.junit.junit5)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.variability.artifacts.typesystem.runtime/org.iets3.variability.artifacts.typesystem.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.variability.artifacts.typesystem.runtime/org.iets3.variability.artifacts.typesystem.runtime.msd
@@ -77,7 +77,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="f0883503-8eaa-4bc8-8846-eb63220ab1dd(org.iets3.variability.artifacts.base)" version="18" />
     <module reference="f7909506-a68f-4575-8f79-ef5e0e0ae091(org.iets3.variability.artifacts.typesystem.runtime)" version="0" />
     <module reference="c6ff3b3b-aff6-455e-9637-7955ccbfec22(org.iets3.variability.artifacts.vanguard)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.variability.base.ide/org.iets3.variability.base.ide.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.variability.base.ide/org.iets3.variability.base.ide.msd
@@ -79,7 +79,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="f0883503-8eaa-4bc8-8846-eb63220ab1dd(org.iets3.variability.artifacts.base)" version="18" />
     <module reference="c6ff3b3b-aff6-455e-9637-7955ccbfec22(org.iets3.variability.artifacts.vanguard)" version="0" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.variability.os.sandbox/org.iets3.variability.os.sandbox.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.variability.os.sandbox/org.iets3.variability.os.sandbox.msd
@@ -36,7 +36,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:f0883503-8eaa-4bc8-8846-eb63220ab1dd:org.iets3.variability.artifacts.base" version="2" />
     <language slang="l:bad8e421-fc94-4104-8c1e-6fc9d2dccf07:org.iets3.variability.artifacts.baseline" version="1" />
     <language slang="l:9914d82b-ab8a-44d1-9c65-9f2954c3b4df:org.iets3.variability.artifacts.typesystem" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/playground/models/playground.bindingtimes.mps
+++ b/code/languages/org.iets3.opensource/solutions/playground/models/playground.bindingtimes.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d" name="org.iets3.core.expr.typetags.bindingtime" version="0" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
   </languages>
   <imports />

--- a/code/languages/org.iets3.opensource/solutions/playground/playground.msd
+++ b/code/languages/org.iets3.opensource/solutions/playground/playground.msd
@@ -40,7 +40,7 @@
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
     <language slang="l:7bcf9284-ca29-484f-a3b3-2855bdd813ad:org.iets3.core.expr.simpleTypes.tests" version="0" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="6" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:63c1aad1-e2db-439c-a30a-02b5e0bc80f3:org.iets3.core.expr.tracing" version="0" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d:org.iets3.core.expr.typetags.bindingtime" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.components.functional/models/mpinterface@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.components.functional/models/mpinterface@tests.mps
@@ -8,7 +8,7 @@
     <use id="25797606-3fb6-47b8-bc3c-b4384df7da44" name="org.iets3.components.functional" version="-1" />
     <use id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base" version="-1" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="1eafb1ad-d782-45f3-97a2-dcc9e9e9e152" name="org.iets3.components.toplevel.adapter" version="-1" />
     <use id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections" version="11" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />

--- a/code/languages/org.iets3.opensource/tests/test.components.functional/test.components.functional.msd
+++ b/code/languages/org.iets3.opensource/tests/test.components.functional/test.components.functional.msd
@@ -46,7 +46,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
@@ -93,7 +93,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="339619e2-78b9-4a69-859d-32ce3eea1939(test.components.functional)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/tests/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="553a35c5-ccd6-40ba-9923-5e3b354d0c76" name="org.iets3.core.expr.messages" version="3" />
     <use id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests" version="6" />
     <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="7" />

--- a/code/languages/org.iets3.opensource/tests/test.ex.core.expr.genjava/test.ex.core.expr.genjava.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ex.core.expr.genjava/test.ex.core.expr.genjava.msd
@@ -51,7 +51,7 @@
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="6" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="7" />
   </languageVersions>
   <dependencyVersions>

--- a/code/languages/org.iets3.opensource/tests/test.iets3.components.toplevel.adapter/models/scopetest@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.iets3.components.toplevel.adapter/models/scopetest@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="1eafb1ad-d782-45f3-97a2-dcc9e9e9e152" name="org.iets3.components.toplevel.adapter" version="0" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="f0fd486f-8577-43e9-b671-3d118449c6e7" name="org.iets3.components.core" version="10" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
   </languages>

--- a/code/languages/org.iets3.opensource/tests/test.iets3.components.toplevel.adapter/test.iets3.components.toplevel.adapter.msd
+++ b/code/languages/org.iets3.opensource/tests/test.iets3.components.toplevel.adapter/test.iets3.components.toplevel.adapter.msd
@@ -41,7 +41,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
   </languageVersions>
   <dependencyVersions>
     <module reference="e58cb7a2-4782-4210-a236-05de0d75c6b2(test.iets3.components.toplevel.adapter)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.iets3.core.mapping/test.iets3.core.mapping.msd
+++ b/code/languages/org.iets3.opensource/tests/test.iets3.core.mapping/test.iets3.core.mapping.msd
@@ -50,7 +50,7 @@
     <language slang="l:2f7e2e35-6e74-4c43-9fa5-2465d68f5996:org.iets3.core.expr.collections" version="11" />
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:8c1ef69a-bcac-4cb5-9619-6b27d0aefc0c:org.iets3.core.mapping" version="2" />
   </languageVersions>
   <dependencyVersions>
@@ -96,7 +96,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8c1ef69a-bcac-4cb5-9619-6b27d0aefc0c(org.iets3.core.mapping)" version="1" />
     <module reference="12ae53bc-0d28-4b54-88e3-48a56519294d(test.iets3.core.mapping)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/tests/test.iets3.core.tracequery/test.iets3.core.tracequery.msd
+++ b/code/languages/org.iets3.opensource/tests/test.iets3.core.tracequery/test.iets3.core.tracequery.msd
@@ -48,7 +48,7 @@
     <language slang="l:2f7e2e35-6e74-4c43-9fa5-2465d68f5996:org.iets3.core.expr.collections" version="11" />
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:7d21cc4b-4c24-41db-9868-8af4a7f3eba9:org.iets3.core.trace" version="0" />
     <language slang="l:9eff3336-14d7-46c5-afe1-dcbad13c14c3:org.iets3.core.trace.test" version="0" />
     <language slang="l:3c910f62-7ca9-45f3-a98a-c6239acaa8f1:test.iest3.component.attribute" version="0" />
@@ -97,7 +97,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="7d21cc4b-4c24-41db-9868-8af4a7f3eba9(org.iets3.core.trace)" version="0" />
     <module reference="785e2843-aa64-4743-afec-47634f9d78a4(test.iets3.core.tracequery)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.applicationExamples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.applicationExamples@tests.mps
@@ -118,9 +118,7 @@
         <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
-      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS">
-        <reference id="6527211908668528862" name="literal" index="2Jt$xV" />
-      </concept>
+      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS" />
       <concept id="8811147530085329320" name="org.iets3.core.expr.toplevel.structure.RecordLiteral" flags="ng" index="2S399m">
         <child id="8811147530085329323" name="memberValues" index="2S399l" />
       </concept>
@@ -136,6 +134,9 @@
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
       <concept id="2861782275883762391" name="org.iets3.core.expr.toplevel.structure.ExtensionFunctionCall" flags="ng" index="1He9k6">
         <reference id="2861782275883762408" name="extFun" index="1He9kT" />
+      </concept>
+      <concept id="3733519373265811331" name="org.iets3.core.expr.toplevel.structure.AbstractEnumSingleInTarget" flags="ng" index="3Qn1ul">
+        <reference id="3859154905221301135" name="literal" index="2ZoBHZ" />
       </concept>
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
@@ -370,7 +371,7 @@
         <node concept="2fGnzd" id="5ElkanPNlNB" role="2fGnxs">
           <node concept="1QScDb" id="5ElkanPSzBx" role="2fGnzS">
             <node concept="2JjPkS" id="5ElkanPTdh4" role="1QScD9">
-              <ref role="2Jt$xV" node="5ElkanPNlNp" resolve="celcius" />
+              <ref role="2ZoBHZ" node="5ElkanPNlNp" resolve="celcius" />
             </node>
             <node concept="1QScDb" id="5ElkanPNlNE" role="2lDidJ">
               <node concept="3o_JK" id="5ElkanPNlNF" role="1QScD9">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.contracts@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.contracts@tests.mps
@@ -173,9 +173,7 @@
         <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
-      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS">
-        <reference id="6527211908668528862" name="literal" index="2Jt$xV" />
-      </concept>
+      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS" />
       <concept id="3315773615451992747" name="org.iets3.core.expr.toplevel.structure.TypedefContractValExpr" flags="ng" index="QCKKy" />
       <concept id="8811147530085329320" name="org.iets3.core.expr.toplevel.structure.RecordLiteral" flags="ng" index="2S399m">
         <child id="8811147530085329323" name="memberValues" index="2S399l" />
@@ -195,6 +193,9 @@
       </concept>
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
+      <concept id="3733519373265811331" name="org.iets3.core.expr.toplevel.structure.AbstractEnumSingleInTarget" flags="ng" index="3Qn1ul">
+        <reference id="3859154905221301135" name="literal" index="2ZoBHZ" />
+      </concept>
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
       </concept>
@@ -1428,7 +1429,7 @@
                   <node concept="3izI60" id="5ipapt3EfFo" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3EfFp" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3EfFq" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3EfFr" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3EfFs" role="1QScD9">
@@ -1505,7 +1506,7 @@
                   <node concept="3izI60" id="5ipapt3EfFT" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3EfFU" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3EfFV" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3EfFW" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3EfFX" role="1QScD9">
@@ -1581,7 +1582,7 @@
                   <node concept="3izI60" id="5ipapt3IJBe" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3IJBf" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3IJBg" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3IJBh" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3IJBi" role="1QScD9">
@@ -1663,7 +1664,7 @@
                   <node concept="3izI60" id="5ipapt3EfGq" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3EfGr" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3EfGs" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3EfGt" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3EfGu" role="1QScD9">
@@ -1735,7 +1736,7 @@
                   <node concept="3izI60" id="5ipapt3EfGT" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3EfGU" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3EfGV" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3EfGW" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3EfGX" role="1QScD9">
@@ -1805,7 +1806,7 @@
                   <node concept="3izI60" id="5ipapt3EfHn" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3EfHo" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3EfHp" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3EfHq" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3EfHr" role="1QScD9">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
@@ -115,6 +115,9 @@
       <concept id="7061117989422577349" name="org.iets3.core.expr.toplevel.structure.EnumLiteralRef" flags="ng" index="5mhuz">
         <reference id="7061117989422577417" name="literal" index="5mhpJ" />
       </concept>
+      <concept id="5496041071985417580" name="org.iets3.core.expr.toplevel.structure.AbstractEnumInTarget" flags="ng" index="qS05g">
+        <child id="3859154905223467352" name="selectors" index="2YwQAC" />
+      </concept>
       <concept id="3980268926893656512" name="org.iets3.core.expr.toplevel.structure.RecordComparisonOrder" flags="ng" index="tekx0">
         <reference id="3980268926893656513" name="member" index="tekx1" />
       </concept>
@@ -123,15 +126,11 @@
         <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
-      <concept id="8006404979731136903" name="org.iets3.core.expr.toplevel.structure.EnumIsInTarget" flags="ng" index="2BPRtJ">
-        <child id="8006404979731136906" name="selectors" index="2BPRty" />
-      </concept>
+      <concept id="8006404979731136903" name="org.iets3.core.expr.toplevel.structure.EnumIsInTarget" flags="ng" index="2BPRtJ" />
       <concept id="8006404979731140557" name="org.iets3.core.expr.toplevel.structure.EnumIsInSelector" flags="ng" index="2BPR$_">
         <reference id="8006404979731140558" name="literal" index="2BPR$A" />
       </concept>
-      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS">
-        <reference id="6527211908668528862" name="literal" index="2Jt$xV" />
-      </concept>
+      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS" />
       <concept id="8811147530085329320" name="org.iets3.core.expr.toplevel.structure.RecordLiteral" flags="ng" index="2S399m">
         <child id="8811147530085329323" name="memberValues" index="2S399l" />
       </concept>
@@ -145,15 +144,20 @@
       <concept id="8811147530084018361" name="org.iets3.core.expr.toplevel.structure.RecordMember" flags="ng" index="2Ss9d7" />
       <concept id="8811147530084018358" name="org.iets3.core.expr.toplevel.structure.RecordDeclaration" flags="ng" index="2Ss9d8" />
       <concept id="4577412849441593498" name="org.iets3.core.expr.toplevel.structure.EnumValueAccessor" flags="ng" index="YK6gA" />
+      <concept id="7850247783016916264" name="org.iets3.core.expr.toplevel.structure.EnumIsNotInTarget" flags="ng" index="15tcJG" />
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
       <concept id="2945473592442820328" name="org.iets3.core.expr.toplevel.structure.AllLitList" flags="ng" index="1cenD8">
         <child id="2945473592442821793" name="enumType" index="1cen01" />
       </concept>
       <concept id="217046401488995528" name="org.iets3.core.expr.toplevel.structure.EnumIndexOp" flags="ng" index="1vx5T5" />
+      <concept id="3733519373265811331" name="org.iets3.core.expr.toplevel.structure.AbstractEnumSingleInTarget" flags="ng" index="3Qn1ul">
+        <reference id="3859154905221301135" name="literal" index="2ZoBHZ" />
+      </concept>
       <concept id="7740953487933794886" name="org.iets3.core.expr.toplevel.structure.SectionMarker" flags="ng" index="1Ws0TD">
         <property id="7740953487933876080" name="label" index="1WsWdv" />
       </concept>
+      <concept id="4557392569141521968" name="org.iets3.core.expr.toplevel.structure.EnumIsNotTarget" flags="ng" index="1Y$79l" />
     </language>
     <language id="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68" name="org.iets3.core.expr.temporal">
       <concept id="5772589292322890249" name="org.iets3.core.expr.temporal.structure.TemporalType" flags="ng" index="Ffn_D">
@@ -287,17 +291,43 @@
     <node concept="_ixoA" id="6WstIz8RJ2o" role="_iOnB" />
     <node concept="_fkuM" id="6WstIz8RJh8" role="_iOnB">
       <property role="TrG5h" value="IsOneOf" />
+      <node concept="_fkuZ" id="3rqhHT4fDB0" role="_fkp5">
+        <node concept="_fku$" id="3rqhHT4fDB1" role="_fkur" />
+        <node concept="1QScDb" id="3rqhHT4fDBt" role="_fkuY">
+          <node concept="2JjPkS" id="3rqhHT4fDGC" role="1QScD9">
+            <ref role="2ZoBHZ" node="67Y8mp$HuG1" resolve="blue" />
+          </node>
+          <node concept="_emDc" id="3rqhHT4fDBd" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+        </node>
+        <node concept="2vmpnb" id="3rqhHT4fDNW" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3rqhHT4fDO5" role="_fkp5">
+        <node concept="_fku$" id="3rqhHT4fDO6" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsAW6" role="_fkuY">
+          <node concept="15tcJG" id="3meuf2bsB0K" role="1QScD9">
+            <node concept="2BPR$_" id="3meuf2bsB0M" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
+            </node>
+          </node>
+          <node concept="_emDc" id="3rqhHT4fDOt" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+        </node>
+        <node concept="2vmpn$" id="3rqhHT4fE1i" role="_fkuS" />
+      </node>
       <node concept="_fkuZ" id="6WstIz8RJnG" role="_fkp5">
         <node concept="_fku$" id="6WstIz8RJnH" role="_fkur" />
         <node concept="1QScDb" id="6WstIz8RJod" role="_fkuY">
           <node concept="2BPRtJ" id="6WstIz8RJxc" role="1QScD9">
-            <node concept="2BPR$_" id="6WstIz8RJyn" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJyn" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
             </node>
-            <node concept="2BPR$_" id="6WstIz8RJ$H" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJ$H" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
             </node>
-            <node concept="2BPR$_" id="6WstIz8RJFZ" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJFZ" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$Gkhk" resolve="red" />
             </node>
           </node>
@@ -311,10 +341,10 @@
         <node concept="_fku$" id="6WstIz8RJHv" role="_fkur" />
         <node concept="1QScDb" id="6WstIz8RJHw" role="_fkuY">
           <node concept="2BPRtJ" id="6WstIz8RJHy" role="1QScD9">
-            <node concept="2BPR$_" id="6WstIz8RJHz" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJHz" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
             </node>
-            <node concept="2BPR$_" id="6WstIz8RJH$" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJH$" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
             </node>
           </node>
@@ -328,7 +358,7 @@
         <node concept="_fku$" id="6WstIz8RJJJ" role="_fkur" />
         <node concept="1QScDb" id="6WstIz8RJJK" role="_fkuY">
           <node concept="2BPRtJ" id="6WstIz8RJJM" role="1QScD9">
-            <node concept="2BPR$_" id="6WstIz8RJJN" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJJN" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
             </node>
           </node>
@@ -342,7 +372,7 @@
         <node concept="_fku$" id="6WstIz8RJMk" role="_fkur" />
         <node concept="1QScDb" id="6WstIz8RJMl" role="_fkuY">
           <node concept="2BPRtJ" id="6WstIz8RJMn" role="1QScD9">
-            <node concept="2BPR$_" id="6WstIz8RJNA" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJNA" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$Gkhk" resolve="red" />
             </node>
           </node>
@@ -356,10 +386,10 @@
         <node concept="_fku$" id="6WstIz8RJPg" role="_fkur" />
         <node concept="1QScDb" id="6WstIz8RJPh" role="_fkuY">
           <node concept="2BPRtJ" id="6WstIz8RJPj" role="1QScD9">
-            <node concept="2BPR$_" id="6WstIz8RJPk" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJPk" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$Gkhk" resolve="red" />
             </node>
-            <node concept="2BPR$_" id="6WstIz8RJYi" role="2BPRty">
+            <node concept="2BPR$_" id="6WstIz8RJYi" role="2YwQAC">
               <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
             </node>
           </node>
@@ -368,6 +398,94 @@
           </node>
         </node>
         <node concept="2vmpn$" id="6WstIz8RK0y" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3rqhHT2ZXI5" role="_fkp5">
+        <node concept="_fku$" id="3rqhHT2ZXI6" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsBtI" role="_fkuY">
+          <node concept="15tcJG" id="3meuf2bsByS" role="1QScD9">
+            <node concept="2BPR$_" id="3meuf2bsByU" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$Gkhk" resolve="red" />
+            </node>
+            <node concept="2BPR$_" id="3meuf2bsBF2" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
+            </node>
+          </node>
+          <node concept="_emDc" id="3rqhHT2ZXIb" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+        </node>
+        <node concept="2vmpnb" id="3rqhHT2ZYFT" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3rqhHT3Dln7" role="_fkp5">
+        <node concept="_fku$" id="3rqhHT3Dln8" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsBVg" role="_fkuY">
+          <node concept="15tcJG" id="3meuf2bsC8G" role="1QScD9">
+            <node concept="2BPR$_" id="3meuf2bsC8I" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
+            </node>
+            <node concept="2BPR$_" id="3meuf2bsCgQ" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
+            </node>
+          </node>
+          <node concept="_emDc" id="3rqhHT3Dlnm" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+        </node>
+        <node concept="2vmpn$" id="3rqhHT4hYcE" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3rqhHT3PibN" role="_fkp5">
+        <node concept="_fku$" id="3rqhHT3PibO" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsCx3" role="_fkuY">
+          <node concept="15tcJG" id="3meuf2bsCAd" role="1QScD9">
+            <node concept="2BPR$_" id="3meuf2bsCAf" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
+            </node>
+          </node>
+          <node concept="_emDc" id="3rqhHT3Pic2" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+        </node>
+        <node concept="2vmpn$" id="3rqhHT3Tz1N" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="4L5R3LmqEjP" role="_fkp5">
+        <node concept="_fku$" id="4L5R3LmqEjQ" role="_fkur" />
+        <node concept="1QScDb" id="4L5R3LmqEkq" role="_fkuY">
+          <node concept="_emDc" id="4L5R3LmqEk9" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+          <node concept="15tcJG" id="3meuf2bsCNu" role="1QScD9">
+            <node concept="2BPR$_" id="3meuf2bsCNw" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
+            </node>
+            <node concept="2BPR$_" id="3meuf2bsCVC" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
+            </node>
+            <node concept="2BPR$_" id="3meuf2bsD3J" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$Gkhk" resolve="red" />
+            </node>
+          </node>
+        </node>
+        <node concept="2vmpn$" id="4L5R3LmqF45" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="4L5R3LmqF4q" role="_fkp5">
+        <node concept="_fku$" id="4L5R3LmqF4r" role="_fkur" />
+        <node concept="1QScDb" id="4L5R3LmqF4X" role="_fkuY">
+          <node concept="2BPRtJ" id="4L5R3LmqFa7" role="1QScD9">
+            <node concept="2BPR$_" id="4L5R3LmqFa9" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuFV" resolve="green" />
+            </node>
+            <node concept="2BPR$_" id="4L5R3LmqFih" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$Gkhk" resolve="red" />
+            </node>
+            <node concept="2BPR$_" id="4L5R3LmqFqo" role="2YwQAC">
+              <ref role="2BPR$A" node="67Y8mp$HuG1" resolve="blue" />
+            </node>
+          </node>
+          <node concept="_emDc" id="4L5R3LmqF4H" role="2lDidJ">
+            <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+          </node>
+        </node>
+        <node concept="2vmpnb" id="4L5R3LmqFyB" role="_fkuS" />
       </node>
     </node>
     <node concept="_ixoA" id="3Y6fbK15FGn" role="_iOnB" />
@@ -378,7 +496,7 @@
         <node concept="_fku$" id="5WNmJ7EzoUu" role="_fkur" />
         <node concept="1QScDb" id="5WNmJ7Ezp35" role="_fkuY">
           <node concept="2JjPkS" id="5WNmJ7EGQ$y" role="1QScD9">
-            <ref role="2Jt$xV" node="67Y8mp$HuG1" resolve="blue" />
+            <ref role="2ZoBHZ" node="67Y8mp$HuG1" resolve="blue" />
           </node>
           <node concept="2nD44o" id="5WNmJ7Ezp0S" role="2lDidJ">
             <node concept="_emDc" id="5WNmJ7Ezp1s" role="2lDidJ">
@@ -392,7 +510,7 @@
         <node concept="_fku$" id="5WNmJ7EGQE2" role="_fkur" />
         <node concept="1QScDb" id="5WNmJ7EGQE3" role="_fkuY">
           <node concept="2JjPkS" id="5WNmJ7EGQE4" role="1QScD9">
-            <ref role="2Jt$xV" node="67Y8mp$HuG1" resolve="blue" />
+            <ref role="2ZoBHZ" node="67Y8mp$HuG1" resolve="blue" />
           </node>
           <node concept="2nGkMB" id="5WNmJ7EGQFH" role="2lDidJ">
             <node concept="_emDc" id="5WNmJ7EGQGT" role="2lDidJ">
@@ -401,6 +519,48 @@
           </node>
         </node>
         <node concept="UmHTt" id="5WNmJ7EGQHl" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="6NLFGgCJ6RQ" role="_fkp5">
+        <node concept="_fku$" id="6NLFGgCJ6RR" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsDjE" role="_fkuY">
+          <node concept="1Y$79l" id="3meuf2bsDp5" role="1QScD9">
+            <ref role="2ZoBHZ" node="67Y8mp$Gkhk" resolve="red" />
+          </node>
+          <node concept="2nD44o" id="6NLFGgCJ6S6" role="2lDidJ">
+            <node concept="_emDc" id="6NLFGgCJ6Sg" role="2lDidJ">
+              <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+            </node>
+          </node>
+        </node>
+        <node concept="2vmpnb" id="6NLFGgCJ75c" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="6NLFGgD3N2q" role="_fkp5">
+        <node concept="_fku$" id="6NLFGgD3N2r" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsE6j" role="_fkuY">
+          <node concept="1Y$79l" id="3meuf2bsEbq" role="1QScD9">
+            <ref role="2ZoBHZ" node="67Y8mp$HuG1" resolve="blue" />
+          </node>
+          <node concept="2nD44o" id="6NLFGgD3N2C" role="2lDidJ">
+            <node concept="_emDc" id="6NLFGgD3N2N" role="2lDidJ">
+              <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+            </node>
+          </node>
+        </node>
+        <node concept="2vmpn$" id="6NLFGgD48RF" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="6NLFGgD4tWQ" role="_fkp5">
+        <node concept="_fku$" id="6NLFGgD4tWR" role="_fkur" />
+        <node concept="1QScDb" id="3meuf2bsEnz" role="_fkuY">
+          <node concept="1Y$79l" id="3meuf2bsEsM" role="1QScD9">
+            <ref role="2ZoBHZ" node="67Y8mp$Gkhk" resolve="red" />
+          </node>
+          <node concept="2nGkMB" id="6NLFGgD4tXu" role="2lDidJ">
+            <node concept="_emDc" id="6NLFGgD4tXL" role="2lDidJ">
+              <ref role="_emDf" node="67Y8mp$IHj_" resolve="ocean" />
+            </node>
+          </node>
+        </node>
+        <node concept="UmHTt" id="6NLFGgD4u8i" role="_fkuS" />
       </node>
     </node>
     <node concept="_ixoA" id="5WNmJ7EzoW4" role="_iOnB" />
@@ -645,7 +805,7 @@
         <node concept="_fku$" id="2zwra1$Tpd$" role="_fkur" />
         <node concept="1QScDb" id="2zwra1$TpqX" role="_fkuY">
           <node concept="2JjPkS" id="2zwra1$Tpt9" role="1QScD9">
-            <ref role="2Jt$xV" node="67Y8mp$Gkhk" resolve="red" />
+            <ref role="2ZoBHZ" node="67Y8mp$Gkhk" resolve="red" />
           </node>
           <node concept="1QScDb" id="2zwra1$Tpd_" role="2lDidJ">
             <node concept="3iB7TU" id="2zwra1$Tpm4" role="1QScD9" />
@@ -660,7 +820,7 @@
         <node concept="_fku$" id="2zwra1$TpJp" role="_fkur" />
         <node concept="1QScDb" id="2zwra1$TpJq" role="_fkuY">
           <node concept="2JjPkS" id="2zwra1$TpJr" role="1QScD9">
-            <ref role="2Jt$xV" node="67Y8mp$HuG1" resolve="blue" />
+            <ref role="2ZoBHZ" node="67Y8mp$HuG1" resolve="blue" />
           </node>
           <node concept="1QScDb" id="2zwra1$TpJs" role="2lDidJ">
             <node concept="3iB7bo" id="2zwra1$TpPH" role="1QScD9" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.stringvalidation@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.stringvalidation@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests" version="6" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="-1" />
     <use id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda" version="6" />
     <use id="553a35c5-ccd6-40ba-9923-5e3b354d0c76" name="org.iets3.core.expr.messages" version="3" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections" version="11" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="-1" />
     <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="6" />
@@ -271,9 +271,7 @@
       <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnV">
         <child id="543569365052711058" name="contents" index="_iOnC" />
       </concept>
-      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS">
-        <reference id="6527211908668528862" name="literal" index="2Jt$xV" />
-      </concept>
+      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS" />
       <concept id="3315773615451992747" name="org.iets3.core.expr.toplevel.structure.TypedefContractValExpr" flags="ng" index="QCKKy" />
       <concept id="8811147530085329320" name="org.iets3.core.expr.toplevel.structure.RecordLiteral" flags="ng" index="2S399m">
         <child id="8811147530085329323" name="memberValues" index="2S399l" />
@@ -315,6 +313,9 @@
       </concept>
       <concept id="1249392911699110107" name="org.iets3.core.expr.toplevel.structure.RecordChangeTarget" flags="ng" index="3vStjw">
         <child id="1249392911699129399" name="setters" index="3vSgwc" />
+      </concept>
+      <concept id="3733519373265811331" name="org.iets3.core.expr.toplevel.structure.AbstractEnumSingleInTarget" flags="ng" index="3Qn1ul">
+        <reference id="3859154905221301135" name="literal" index="2ZoBHZ" />
       </concept>
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
@@ -966,7 +967,7 @@
                   <node concept="3izI60" id="5ipapt3EfHn" role="2lDidJ">
                     <node concept="1QScDb" id="5ipapt3EfHo" role="2lDidJ">
                       <node concept="2JjPkS" id="5ipapt3EfHp" role="1QScD9">
-                        <ref role="2Jt$xV" node="5ipapt3EfET" resolve="male" />
+                        <ref role="2ZoBHZ" node="5ipapt3EfET" resolve="male" />
                       </node>
                       <node concept="1QScDb" id="5ipapt3EfHq" role="2lDidJ">
                         <node concept="3o_JK" id="5ipapt3EfHr" role="1QScD9">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
@@ -95,7 +95,7 @@
     <language slang="l:f003a0fe-c140-41d7-a145-ea42368e581c:org.iets3.core.expr.stringvalidation" version="1" />
     <language slang="l:4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68:org.iets3.core.expr.temporal" version="3" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="6" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:63c1aad1-e2db-439c-a30a-02b5e0bc80f3:org.iets3.core.expr.tracing" version="0" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d:org.iets3.core.expr.typetags.bindingtime" version="0" />
@@ -181,7 +181,7 @@
     <module reference="06aa4a64-087b-49de-99ac-5bfea95ff839(org.iets3.core.expr.temporal.interpreter)" version="0" />
     <module reference="17ecc6b6-d106-4b60-87a9-3fde52f92301(org.iets3.core.expr.temporal.runtime)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="b0e7c6a8-b47d-4637-b0e8-e5bfd486c4e8(org.iets3.core.expr.tracing.plugin)" version="0" />
     <module reference="b4ec5624-2e67-4a4e-9ece-34bcbf966115(org.iets3.core.expr.typetags.lib.interpreter)" version="0" />
     <module reference="86255e62-4839-480a-a7d0-9ee30f97e2d8(org.iets3.core.expr.typetags.phyunits.si)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.common.base/test.org.iets3.common.base.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.common.base/test.org.iets3.common.base.msd
@@ -72,7 +72,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />
     <module reference="71226ee2-bbc4-45d2-a41d-20b97237156c(org.iets3.variability.configuration.base)" version="6" />
     <module reference="165f1d05-2506-4544-895e-1424f54166ec(org.iets3.variability.featuremodel.base)" version="36" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.core.comments/test.org.iets3.core.comments.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.core.comments/test.org.iets3.core.comments.msd
@@ -39,7 +39,7 @@
     <language slang="l:2f7e2e35-6e74-4c43-9fa5-2465d68f5996:org.iets3.core.expr.collections" version="11" />
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
   </languageVersions>
   <dependencyVersions>
     <module reference="5b2a22be-3ce2-4929-be5b-e39b8b142a74(test.org.iets3.core.comments)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.core.expr.typetags.physunits/models/test.org.iets3.core.expr.typetags.physunits.conversion@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.core.expr.typetags.physunits/models/test.org.iets3.core.expr.typetags.physunits.conversion@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="5186c6ce-428c-4f09-a9df-73d9e86c27d3" name="org.iets3.core.expr.typetags" version="1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
     <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="6" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.core.expr.typetags.physunits/test.org.iets3.core.expr.typetags.physunits.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.core.expr.typetags.physunits/test.org.iets3.core.expr.typetags.physunits.msd
@@ -43,7 +43,7 @@
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="6" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:7ee265bd-5986-4709-86ed-2c6daa33cd8c:org.iets3.core.expr.typetags.physunits" version="0" />
   </languageVersions>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.protocol.transport/test.org.iets3.protocol.transport.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.protocol.transport/test.org.iets3.protocol.transport.msd
@@ -45,7 +45,7 @@
     <language slang="l:2f7e2e35-6e74-4c43-9fa5-2465d68f5996:org.iets3.core.expr.collections" version="11" />
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:8c1ef69a-bcac-4cb5-9619-6b27d0aefc0c:org.iets3.core.mapping" version="2" />
     <language slang="l:a50d6290-93d2-42af-9ae0-b2fefc6ee754:org.iets3.protocol.transport" version="1" />
   </languageVersions>
@@ -92,7 +92,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8c1ef69a-bcac-4cb5-9619-6b27d0aefc0c(org.iets3.core.mapping)" version="1" />
     <module reference="a50d6290-93d2-42af-9ae0-b2fefc6ee754(org.iets3.protocol.transport)" version="0" />
     <module reference="5d4bc982-a658-41f9-a32e-1221b26a9dae(test.org.iets3.protocol.transport)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base.ext/test.org.iets3.variability.configuration.base.ext.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base.ext/test.org.iets3.variability.configuration.base.ext.msd
@@ -80,7 +80,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />
     <module reference="71226ee2-bbc4-45d2-a41d-20b97237156c(org.iets3.variability.configuration.base)" version="6" />
     <module reference="165f1d05-2506-4544-895e-1424f54166ec(org.iets3.variability.featuremodel.base)" version="36" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/test.org.iets3.variability.configuration.base.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/test.org.iets3.variability.configuration.base.msd
@@ -54,7 +54,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:9b66c5c9-38bf-4315-a96f-9f4e212c69cb:org.iets3.variability.base" version="0" />
     <language slang="l:71226ee2-bbc4-45d2-a41d-20b97237156c:org.iets3.variability.configuration.base" version="2" />
     <language slang="l:165f1d05-2506-4544-895e-1424f54166ec:org.iets3.variability.featuremodel.base" version="24" />
@@ -111,7 +111,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />
     <module reference="71226ee2-bbc4-45d2-a41d-20b97237156c(org.iets3.variability.configuration.base)" version="6" />
     <module reference="165f1d05-2506-4544-895e-1424f54166ec(org.iets3.variability.featuremodel.base)" version="36" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/test.org.iets3.variability.featuremodel.base.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/test.org.iets3.variability.featuremodel.base.msd
@@ -47,7 +47,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:9b66c5c9-38bf-4315-a96f-9f4e212c69cb:org.iets3.variability.base" version="0" />
     <language slang="l:71226ee2-bbc4-45d2-a41d-20b97237156c:org.iets3.variability.configuration.base" version="2" />
     <language slang="l:165f1d05-2506-4544-895e-1424f54166ec:org.iets3.variability.featuremodel.base" version="24" />
@@ -95,7 +95,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)" version="0" />
     <module reference="71226ee2-bbc4-45d2-a41d-20b97237156c(org.iets3.variability.configuration.base)" version="6" />
     <module reference="165f1d05-2506-4544-895e-1424f54166ec(org.iets3.variability.featuremodel.base)" version="36" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.components.core/test.ts.components.core.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.components.core/test.ts.components.core.msd
@@ -45,7 +45,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:3c910f62-7ca9-45f3-a98a-c6239acaa8f1:test.iest3.component.attribute" version="0" />
   </languageVersions>
   <dependencyVersions>
@@ -91,7 +91,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="8239233b-13cc-4bd1-842b-cf2561ff9a12(test.ts.components.core)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/tests/test.ts.components.hardware/test.ts.components.hardware.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.components.hardware/test.ts.components.hardware.msd
@@ -43,7 +43,7 @@
     <language slang="l:2f7e2e35-6e74-4c43-9fa5-2465d68f5996:org.iets3.core.expr.collections" version="11" />
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
@@ -89,7 +89,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="6992992b-820e-4e23-b697-e246fb887cc9(test.ts.components.hardware)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/models/test.ts.expr.os.comma.m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/models/test.ts.expr.os.comma.m1@tests.mps
@@ -6,7 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
   </languages>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/test.ts.expr.os.comma.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/test.ts.expr.os.comma.msd
@@ -52,7 +52,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="6" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="11" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="cb91a38e-738a-4811-a96d-448d08f526fa" name="org.iets3.core.expr.typetags.units" version="1" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.base@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
   </languages>
   <imports>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.bindingtimes@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.bindingtimes@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d" name="org.iets3.core.expr.typetags.bindingtime" version="0" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="5186c6ce-428c-4f09-a9df-73d9e86c27d3" name="org.iets3.core.expr.typetags" version="1" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.checkManually@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.checkManually@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="5186c6ce-428c-4f09-a9df-73d9e86c27d3" name="org.iets3.core.expr.typetags" version="1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="6" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.records@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.temporal@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="-1" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="-1" />
-    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="6" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68" name="org.iets3.core.expr.temporal" version="3" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -516,6 +516,7 @@
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
+      <concept id="5285810042889815162" name="org.iets3.core.expr.tests.structure.EmptyTestItem" flags="ng" index="3dYjL0" />
       <concept id="4173623957598806325" name="org.iets3.core.expr.tests.structure.TestItemVectorCollection" flags="ng" index="1jlL7l" />
       <concept id="4173623957598806298" name="org.iets3.core.expr.tests.structure.VectorTestItem" flags="ng" index="1jlL7U">
         <child id="4173623957599346846" name="subject" index="1jbP1Y" />
@@ -577,6 +578,9 @@
         <reference id="7061117989422577417" name="literal" index="5mhpJ" />
       </concept>
       <concept id="7782108600709718604" name="org.iets3.core.expr.toplevel.structure.ReferenceableFlag" flags="ng" index="nbNz6" />
+      <concept id="5496041071985417580" name="org.iets3.core.expr.toplevel.structure.AbstractEnumInTarget" flags="ng" index="qS05g">
+        <child id="3859154905223467352" name="selectors" index="2YwQAC" />
+      </concept>
       <concept id="7089558164906249676" name="org.iets3.core.expr.toplevel.structure.Constant" flags="ng" index="2zPypq" />
       <concept id="543569365051789113" name="org.iets3.core.expr.toplevel.structure.ConstantRef" flags="ng" index="_emDc">
         <reference id="543569365051789114" name="constant" index="_emDf" />
@@ -585,9 +589,11 @@
       <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnV">
         <child id="543569365052711058" name="contents" index="_iOnC" />
       </concept>
-      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS">
-        <reference id="6527211908668528862" name="literal" index="2Jt$xV" />
+      <concept id="8006404979731136903" name="org.iets3.core.expr.toplevel.structure.EnumIsInTarget" flags="ng" index="2BPRtJ" />
+      <concept id="8006404979731140557" name="org.iets3.core.expr.toplevel.structure.EnumIsInSelector" flags="ng" index="2BPR$_">
+        <reference id="8006404979731140558" name="literal" index="2BPR$A" />
       </concept>
+      <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS" />
       <concept id="3315773615451992747" name="org.iets3.core.expr.toplevel.structure.TypedefContractValExpr" flags="ng" index="QCKKy" />
       <concept id="8811147530085329320" name="org.iets3.core.expr.toplevel.structure.RecordLiteral" flags="ng" index="2S399m">
         <child id="8811147530085329323" name="memberValues" index="2S399l" />
@@ -605,6 +611,7 @@
       <concept id="1024425597324739336" name="org.iets3.core.expr.toplevel.structure.RecordMemberRefInConstraint" flags="ng" index="XrbUJ">
         <reference id="1024425597324739346" name="member" index="XrbUP" />
       </concept>
+      <concept id="7850247783016916264" name="org.iets3.core.expr.toplevel.structure.EnumIsNotInTarget" flags="ng" index="15tcJG" />
       <concept id="4790956042240790396" name="org.iets3.core.expr.toplevel.structure.FunRef" flags="ng" index="1aeIDv" />
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
@@ -623,6 +630,9 @@
         <reference id="2861782275883762408" name="extFun" index="1He9kT" />
         <child id="2861782275883807063" name="args" index="1H9Mq6" />
       </concept>
+      <concept id="3733519373265811331" name="org.iets3.core.expr.toplevel.structure.AbstractEnumSingleInTarget" flags="ng" index="3Qn1ul">
+        <reference id="3859154905221301135" name="literal" index="2ZoBHZ" />
+      </concept>
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
       </concept>
@@ -632,6 +642,7 @@
       <concept id="7740953487933794886" name="org.iets3.core.expr.toplevel.structure.SectionMarker" flags="ng" index="1Ws0TD">
         <property id="7740953487933876080" name="label" index="1WsWdv" />
       </concept>
+      <concept id="4557392569141521968" name="org.iets3.core.expr.toplevel.structure.EnumIsNotTarget" flags="ng" index="1Y$79l" />
     </language>
     <language id="64e79176-30a1-4836-821c-bf62ff6c6091" name="org.iets3.core.expr.natlang">
       <concept id="1693890388431451161" name="org.iets3.core.expr.natlang.structure.NatLangCallSyntax" flags="ng" index="1Xp_Lc">
@@ -12168,7 +12179,7 @@
           <node concept="2vmvy5" id="3gKGtj9bXyw" role="2zM23F" />
           <node concept="1QScDb" id="3gKGtj9bXyx" role="2lDidJ">
             <node concept="2JjPkS" id="3gKGtj9bXyy" role="1QScD9">
-              <ref role="2Jt$xV" node="3gKGtj9bXy7" resolve="blue" />
+              <ref role="2ZoBHZ" node="3gKGtj9bXy7" resolve="blue" />
             </node>
             <node concept="7CXmI" id="5IOlOc8Lw1a" role="lGtFl">
               <node concept="2DdRWr" id="5IOlOc8Lw1b" role="7EUXB" />
@@ -12181,13 +12192,13 @@
           </node>
         </node>
         <node concept="2zPypq" id="3gKGtj9bXyB" role="_iOnC">
-          <property role="TrG5h" value="isSomeOceanBlu2e" />
+          <property role="TrG5h" value="isSomeOceanBlue2" />
           <node concept="Uns6S" id="3gKGtj9bXyC" role="2zM23F">
             <node concept="2vmvy5" id="3gKGtj9bXyD" role="Uns6T" />
           </node>
           <node concept="1QScDb" id="3gKGtj9bXyE" role="2lDidJ">
             <node concept="2JjPkS" id="3gKGtj9bXyF" role="1QScD9">
-              <ref role="2Jt$xV" node="3gKGtj9bXy7" resolve="blue" />
+              <ref role="2ZoBHZ" node="3gKGtj9bXy7" resolve="blue" />
             </node>
             <node concept="2nD44o" id="3gKGtj9bXyG" role="2lDidJ">
               <node concept="_emDc" id="3gKGtj9bXyH" role="2lDidJ">
@@ -12196,7 +12207,24 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="3gKGtj9bXyI" role="_iOnC" />
+        <node concept="2zPypq" id="6NLFGgDqoOt" role="_iOnC">
+          <property role="TrG5h" value="isSomeOceanBlue3" />
+          <node concept="2vmvy5" id="6NLFGgDqoOu" role="2zM23F" />
+          <node concept="1QScDb" id="3meuf2bsJNe" role="2lDidJ">
+            <node concept="7CXmI" id="3meuf2bsJNg" role="lGtFl">
+              <node concept="2DdRWr" id="3meuf2bsJNh" role="7EUXB" />
+            </node>
+            <node concept="2nD44o" id="3meuf2bsJNi" role="2lDidJ">
+              <node concept="_emDc" id="3meuf2bsJNj" role="2lDidJ">
+                <ref role="_emDf" node="3gKGtj9bXyd" resolve="ocean" />
+              </node>
+            </node>
+            <node concept="1Y$79l" id="3meuf2bsJVL" role="1QScD9">
+              <ref role="2ZoBHZ" node="3gKGtj9bXy7" resolve="blue" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="6NLFGgDqoKl" role="_iOnC" />
         <node concept="2zPypq" id="3gKGtj9bXyJ" role="_iOnC">
           <property role="TrG5h" value="oceanBlueEq" />
           <node concept="30cPrO" id="3gKGtj9bXyK" role="2lDidJ">
@@ -14206,7 +14234,7 @@
             <node concept="30bsCy" id="u9itSZVGmQ" role="2lDidJ">
               <node concept="1QScDb" id="u9itSZVGmR" role="2lDidJ">
                 <node concept="2JjPkS" id="u9itSZVDXY" role="1QScD9">
-                  <ref role="2Jt$xV" node="1bwJEEguiBh" resolve="RED" />
+                  <ref role="2ZoBHZ" node="1bwJEEguiBh" resolve="RED" />
                 </node>
                 <node concept="1afdae" id="u9itSZVDxC" role="2lDidJ">
                   <ref role="1afue_" node="u9itSZVAZv" resolve="c" />
@@ -14227,6 +14255,7 @@
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="6NLFGgBL5i7" role="_iOnB" />
     <node concept="_fkuM" id="u9itSZSnkB" role="_iOnB">
       <property role="TrG5h" value="TestPlus" />
       <node concept="1jlL7U" id="u9itSZW_$L" role="_fkp5">
@@ -15162,9 +15191,406 @@
       </node>
     </node>
     <node concept="_ixoA" id="4ptnK4jk5u5" role="_iOnB" />
+    <node concept="1aga60" id="6NLFGgBL9l0" role="_iOnB">
+      <property role="TrG5h" value="plus2" />
+      <node concept="30dDZf" id="6NLFGgBL9l1" role="1ahQXP">
+        <node concept="1afdae" id="6NLFGgBL9l2" role="30dEsF">
+          <ref role="1afue_" node="6NLFGgBL9l4" resolve="a" />
+        </node>
+        <node concept="1afdae" id="6NLFGgBL9l3" role="30dEs_">
+          <ref role="1afue_" node="6NLFGgBL9l7" resolve="b" />
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgBL9l4" role="1ahQWs">
+        <property role="TrG5h" value="a" />
+        <node concept="mLuIC" id="6NLFGgBL9l5" role="3ix9CU">
+          <node concept="2gteSX" id="6NLFGgBL9l6" role="2gteSx">
+            <property role="2gteSR" value="0" />
+            <property role="2gteSE" value="5" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgBL9l7" role="1ahQWs">
+        <property role="TrG5h" value="b" />
+        <node concept="mLuIC" id="6NLFGgBL9l8" role="3ix9CU">
+          <node concept="2gteSX" id="6NLFGgBL9l9" role="2gteSx">
+            <property role="2gteSR" value="-10" />
+            <property role="2gteSE" value="10" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgBL9la" role="1ahQWs">
+        <property role="TrG5h" value="c" />
+        <node concept="5mh7t" id="6NLFGgBL9lb" role="3ix9CU">
+          <ref role="5mh6l" node="1bwJEEguiA5" resolve="color" />
+        </node>
+      </node>
+      <node concept="I61D5" id="6NLFGgBL9lc" role="I61D6">
+        <node concept="I61DT" id="6NLFGgBL9ld" role="I61D1">
+          <node concept="30bsCy" id="6NLFGgBL9lf" role="2lDidJ">
+            <node concept="1QScDb" id="3meuf2bd_Ah" role="2lDidJ">
+              <node concept="1Y$79l" id="3meuf2bdBfV" role="1QScD9">
+                <ref role="2ZoBHZ" node="1bwJEEguiBh" resolve="RED" />
+              </node>
+              <node concept="1afdae" id="6NLFGgBL9li" role="2lDidJ">
+                <ref role="1afue_" node="6NLFGgBL9la" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="I61DT" id="6NLFGgBL9lj" role="I61D1">
+          <node concept="30cPrR" id="6NLFGgBL9lk" role="2lDidJ">
+            <node concept="1afdae" id="6NLFGgBL9ll" role="30dEs_">
+              <ref role="1afue_" node="6NLFGgBL9l7" resolve="b" />
+            </node>
+            <node concept="1afdae" id="6NLFGgBL9lm" role="30dEsF">
+              <ref role="1afue_" node="6NLFGgBL9l4" resolve="a" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_fkuM" id="6NLFGgBLvps" role="_iOnB">
+      <property role="TrG5h" value="TestPlus2" />
+      <node concept="1jlL7U" id="6NLFGgBOwA8" role="_fkp5">
+        <node concept="2teEjV" id="6NLFGgBOwA9" role="1jbP1Y">
+          <property role="3X4tbc" value="1781858030747/dbinkele" />
+          <property role="22zroz" value="true" />
+          <ref role="2teEjO" node="6NLFGgBL9l0" resolve="plus2" />
+        </node>
+        <node concept="1jlL7l" id="6NLFGgBOwAa" role="1jlL6c">
+          <node concept="Sm_qJ" id="6NLFGgBO_9X" role="2tibTm" />
+          <node concept="2s0UEP" id="6NLFGgBO_a5" role="2s0UE9">
+            <node concept="2t9cyf" id="6NLFGgBO_ac" role="2t9cyo" />
+            <node concept="2tUAmZ" id="6NLFGgBO_ak" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgBL9l4" resolve="a" />
+              <node concept="30bXRB" id="6NLFGgBO_aj" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgBO_aL" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgBL9l7" resolve="b" />
+              <node concept="30bXRB" id="6NLFGgBO_aK" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgBO_eH" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgBL9la" resolve="c" />
+              <node concept="5mhuz" id="6NLFGgBO_eG" role="2tUAms">
+                <ref role="5mhpJ" node="1bwJEEguiBh" resolve="RED" />
+              </node>
+            </node>
+            <node concept="22E7GR" id="6NLFGgBODNk" role="22EBs4">
+              <ref role="22x4DC" node="6NLFGgBL9l0" resolve="plus2" />
+              <node concept="30bXRB" id="6NLFGgBODNj" role="22E7H2">
+                <property role="30bXRw" value="9" />
+              </node>
+            </node>
+          </node>
+          <node concept="2s0UEP" id="6NLFGgBQAzE" role="2s0UE9">
+            <node concept="2tUAmZ" id="6NLFGgBQBYX" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgBL9l4" resolve="a" />
+              <node concept="30bXRB" id="6NLFGgBQDqY" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgBQELO" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgBL9l7" resolve="b" />
+              <node concept="30bXRB" id="6NLFGgBQELN" role="2tUAms">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgBQG8Y" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgBL9la" resolve="c" />
+              <node concept="5mhuz" id="6NLFGgBQG8X" role="2tUAms">
+                <ref role="5mhpJ" node="1bwJEEguiBk" resolve="GREEN" />
+              </node>
+            </node>
+            <node concept="22E7GR" id="6NLFGgBQH_7" role="22EBs4">
+              <ref role="22x4DC" node="6NLFGgBL9l0" resolve="plus2" />
+              <node concept="30bXRB" id="6NLFGgBQH_6" role="22E7H2">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="2t9cyM" id="6NLFGgBSDnm" role="2t9cyo" />
+          </node>
+        </node>
+      </node>
+      <node concept="3dYjL0" id="6NLFGgBO_a3" role="_fkp5" />
+      <node concept="3dYjL0" id="6NLFGgBO_a0" role="_fkp5" />
+    </node>
     <node concept="_ixoA" id="4ptnK4jk5Ek" role="_iOnB" />
-    <node concept="_ixoA" id="4ptnK4jkeqq" role="_iOnB" />
+    <node concept="1aga60" id="6NLFGgDBFmt" role="_iOnB">
+      <property role="TrG5h" value="plus3" />
+      <node concept="30dDZf" id="6NLFGgDBFmu" role="1ahQXP">
+        <node concept="1afdae" id="6NLFGgDBFmv" role="30dEsF">
+          <ref role="1afue_" node="6NLFGgDBFmx" resolve="a" />
+        </node>
+        <node concept="1afdae" id="6NLFGgDBFmw" role="30dEs_">
+          <ref role="1afue_" node="6NLFGgDBFm$" resolve="b" />
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgDBFmx" role="1ahQWs">
+        <property role="TrG5h" value="a" />
+        <node concept="mLuIC" id="6NLFGgDBFmy" role="3ix9CU">
+          <node concept="2gteSX" id="6NLFGgDBFmz" role="2gteSx">
+            <property role="2gteSR" value="0" />
+            <property role="2gteSE" value="5" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgDBFm$" role="1ahQWs">
+        <property role="TrG5h" value="b" />
+        <node concept="mLuIC" id="6NLFGgDBFm_" role="3ix9CU">
+          <node concept="2gteSX" id="6NLFGgDBFmA" role="2gteSx">
+            <property role="2gteSR" value="-10" />
+            <property role="2gteSE" value="10" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgDBFmB" role="1ahQWs">
+        <property role="TrG5h" value="c" />
+        <node concept="5mh7t" id="6NLFGgDBFmC" role="3ix9CU">
+          <ref role="5mh6l" node="1bwJEEguiA5" resolve="color" />
+        </node>
+      </node>
+      <node concept="I61D5" id="6NLFGgDBFmD" role="I61D6">
+        <node concept="I61DT" id="6NLFGgDBFmE" role="I61D1">
+          <node concept="30bsCy" id="6NLFGgDBFmF" role="2lDidJ">
+            <node concept="1QScDb" id="6NLFGgDBFmG" role="2lDidJ">
+              <node concept="2BPRtJ" id="6NLFGgDBKsf" role="1QScD9">
+                <node concept="2BPR$_" id="6NLFGgDBKsi" role="2YwQAC">
+                  <ref role="2BPR$A" node="1bwJEEguiBk" resolve="GREEN" />
+                </node>
+                <node concept="2BPR$_" id="6NLFGgDBLOc" role="2YwQAC">
+                  <ref role="2BPR$A" node="1bwJEEguiBI" resolve="BLUE" />
+                </node>
+              </node>
+              <node concept="1afdae" id="6NLFGgDBFmI" role="2lDidJ">
+                <ref role="1afue_" node="6NLFGgDBFmB" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="I61DT" id="6NLFGgDBFmJ" role="I61D1">
+          <node concept="30cPrR" id="6NLFGgDBFmK" role="2lDidJ">
+            <node concept="1afdae" id="6NLFGgDBFmL" role="30dEs_">
+              <ref role="1afue_" node="6NLFGgDBFm$" resolve="b" />
+            </node>
+            <node concept="1afdae" id="6NLFGgDBFmM" role="30dEsF">
+              <ref role="1afue_" node="6NLFGgDBFmx" resolve="a" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_fkuM" id="6NLFGgDBQIG" role="_iOnB">
+      <property role="TrG5h" value="TestPlus3" />
+      <node concept="1jlL7U" id="6NLFGgDBX32" role="_fkp5">
+        <node concept="2teEjV" id="6NLFGgDBX34" role="1jbP1Y">
+          <property role="3X4tbc" value="1781867731056/dbinkele" />
+          <property role="22zroz" value="true" />
+          <ref role="2teEjO" node="6NLFGgDBFmt" resolve="plus3" />
+        </node>
+        <node concept="1jlL7l" id="6NLFGgDBX36" role="1jlL6c">
+          <node concept="Sm_qJ" id="6NLFGgDBYvJ" role="2tibTm" />
+          <node concept="2s0UEP" id="6NLFGgDBYvN" role="2s0UE9">
+            <node concept="2t9cyM" id="6NLFGgDBYvO" role="2t9cyo" />
+            <node concept="2tUAmZ" id="6NLFGgDBYvV" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDBFmx" resolve="a" />
+              <node concept="30bXRB" id="6NLFGgDBYvU" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDBYwo" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDBFm$" resolve="b" />
+              <node concept="30bXRB" id="6NLFGgDBYwn" role="2tUAms">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDBY$k" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDBFmB" resolve="c" />
+              <node concept="5mhuz" id="6NLFGgDBY$j" role="2tUAms">
+                <ref role="5mhpJ" node="1bwJEEguiBk" resolve="GREEN" />
+              </node>
+            </node>
+            <node concept="22E7GR" id="6NLFGgDBYCn" role="22EBs4">
+              <ref role="22x4DC" node="6NLFGgDBFmt" resolve="plus3" />
+              <node concept="30bXRB" id="6NLFGgDBYCm" role="22E7H2">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+          </node>
+          <node concept="2s0UEP" id="6NLFGgDGgvi" role="2s0UE9">
+            <node concept="2t9cyf" id="6NLFGgDGhYK" role="2t9cyo" />
+            <node concept="2tUAmZ" id="6NLFGgDGhYS" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDBFmx" resolve="a" />
+              <node concept="30bXRB" id="6NLFGgDGhYR" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDGhZl" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDBFm$" resolve="b" />
+              <node concept="30bXRB" id="6NLFGgDGhZk" role="2tUAms">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDGjvv" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDBFmB" resolve="c" />
+              <node concept="5mhuz" id="6NLFGgDGjvu" role="2tUAms">
+                <ref role="5mhpJ" node="1bwJEEguiBh" resolve="RED" />
+              </node>
+            </node>
+            <node concept="22E7GR" id="6NLFGgDGkZK" role="22EBs4">
+              <ref role="22x4DC" node="6NLFGgDBFmt" resolve="plus3" />
+              <node concept="30bXRB" id="6NLFGgDGkZJ" role="22E7H2">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3dYjL0" id="6NLFGgDBQJ6" role="_fkp5" />
+    </node>
+    <node concept="_ixoA" id="6NLFGgDHmlM" role="_iOnB" />
+    <node concept="_ixoA" id="6NLFGgDHmlO" role="_iOnB" />
+    <node concept="1aga60" id="6NLFGgDHq$K" role="_iOnB">
+      <property role="TrG5h" value="plus4" />
+      <node concept="30dDZf" id="6NLFGgDHq$L" role="1ahQXP">
+        <node concept="1afdae" id="6NLFGgDHq$M" role="30dEsF">
+          <ref role="1afue_" node="6NLFGgDHq$O" resolve="a" />
+        </node>
+        <node concept="1afdae" id="6NLFGgDHq$N" role="30dEs_">
+          <ref role="1afue_" node="6NLFGgDHq$R" resolve="b" />
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgDHq$O" role="1ahQWs">
+        <property role="TrG5h" value="a" />
+        <node concept="mLuIC" id="6NLFGgDHq$P" role="3ix9CU">
+          <node concept="2gteSX" id="6NLFGgDHq$Q" role="2gteSx">
+            <property role="2gteSR" value="0" />
+            <property role="2gteSE" value="5" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgDHq$R" role="1ahQWs">
+        <property role="TrG5h" value="b" />
+        <node concept="mLuIC" id="6NLFGgDHq$S" role="3ix9CU">
+          <node concept="2gteSX" id="6NLFGgDHq$T" role="2gteSx">
+            <property role="2gteSR" value="-10" />
+            <property role="2gteSE" value="10" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="6NLFGgDHq$U" role="1ahQWs">
+        <property role="TrG5h" value="c" />
+        <node concept="5mh7t" id="6NLFGgDHq$V" role="3ix9CU">
+          <ref role="5mh6l" node="1bwJEEguiA5" resolve="color" />
+        </node>
+      </node>
+      <node concept="I61D5" id="6NLFGgDHq$W" role="I61D6">
+        <node concept="I61DT" id="6NLFGgDHq$X" role="I61D1">
+          <node concept="30bsCy" id="6NLFGgDHq$Y" role="2lDidJ">
+            <node concept="1QScDb" id="3meuf2bh_77" role="2lDidJ">
+              <node concept="15tcJG" id="3meuf2bhAKU" role="1QScD9">
+                <node concept="2BPR$_" id="3meuf2bhAKW" role="2YwQAC">
+                  <ref role="2BPR$A" node="1bwJEEguiBh" resolve="RED" />
+                </node>
+                <node concept="2BPR$_" id="3meuf2bhE28" role="2YwQAC">
+                  <ref role="2BPR$A" node="1bwJEEguiBk" resolve="GREEN" />
+                </node>
+              </node>
+              <node concept="1afdae" id="6NLFGgDHq_3" role="2lDidJ">
+                <ref role="1afue_" node="6NLFGgDHq$U" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="I61DT" id="6NLFGgDHq_4" role="I61D1">
+          <node concept="30cPrR" id="6NLFGgDHq_5" role="2lDidJ">
+            <node concept="1afdae" id="6NLFGgDHq_6" role="30dEs_">
+              <ref role="1afue_" node="6NLFGgDHq$R" resolve="b" />
+            </node>
+            <node concept="1afdae" id="6NLFGgDHq_7" role="30dEsF">
+              <ref role="1afue_" node="6NLFGgDHq$O" resolve="a" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="6NLFGgDHovU" role="_iOnB" />
+    <node concept="_fkuM" id="6NLFGgDHBMA" role="_iOnB">
+      <property role="TrG5h" value="TestPlus4" />
+      <node concept="1jlL7U" id="6NLFGgDHXf1" role="_fkp5">
+        <node concept="2teEjV" id="6NLFGgDHXf3" role="1jbP1Y">
+          <property role="3X4tbc" value="1781868405652/dbinkele" />
+          <property role="22zroz" value="true" />
+          <ref role="2teEjO" node="6NLFGgDHq$K" resolve="plus4" />
+        </node>
+        <node concept="1jlL7l" id="6NLFGgDHXf5" role="1jlL6c">
+          <node concept="Sm_qJ" id="6NLFGgDHYLI" role="2tibTm" />
+          <node concept="2s0UEP" id="6NLFGgDHYLL" role="2s0UE9">
+            <node concept="2t9cyM" id="6NLFGgDHYLM" role="2t9cyo" />
+            <node concept="2tUAmZ" id="6NLFGgDHYLT" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDHq$O" resolve="a" />
+              <node concept="30bXRB" id="6NLFGgDHYLS" role="2tUAms">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDHYMm" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDHq$R" resolve="b" />
+              <node concept="30bXRB" id="6NLFGgDHYMl" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDI0lF" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDHq$U" resolve="c" />
+              <node concept="5mhuz" id="6NLFGgDKl75" role="2tUAms">
+                <ref role="5mhpJ" node="1bwJEEguiBI" resolve="BLUE" />
+              </node>
+            </node>
+            <node concept="22E7GR" id="6NLFGgDIe8X" role="22EBs4">
+              <ref role="22x4DC" node="6NLFGgDHq$K" resolve="plus4" />
+              <node concept="30bXRB" id="6NLFGgDIe8W" role="22E7H2">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="2s0UEP" id="6NLFGgDI1T2" role="2s0UE9">
+            <node concept="2t9cyf" id="6NLFGgDI6um" role="2t9cyo" />
+            <node concept="2tUAmZ" id="6NLFGgDI6uu" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDHq$O" resolve="a" />
+              <node concept="30bXRB" id="6NLFGgDI7XK" role="2tUAms">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDI9xy" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDHq$R" resolve="b" />
+              <node concept="30bXRB" id="6NLFGgDI9xx" role="2tUAms">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="2tUAmZ" id="6NLFGgDIhd6" role="2s0UEa">
+              <ref role="2tUAmu" node="6NLFGgDHq$U" resolve="c" />
+              <node concept="5mhuz" id="6NLFGgDIhd5" role="2tUAms">
+                <ref role="5mhpJ" node="1bwJEEguiBk" resolve="GREEN" />
+              </node>
+            </node>
+            <node concept="22E7GR" id="6NLFGgDIiLG" role="22EBs4">
+              <ref role="22x4DC" node="6NLFGgDHq$K" resolve="plus4" />
+              <node concept="30bXRB" id="6NLFGgDIiLF" role="22E7H2">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="6NLFGgDH_C6" role="_iOnB" />
+    <node concept="_ixoA" id="6NLFGgDH_C8" role="_iOnB" />
+    <node concept="_ixoA" id="6NLFGgDH_Ca" role="_iOnB" />
     <node concept="_ixoA" id="4ptnK4jkeBb" role="_iOnB" />
+    <node concept="_ixoA" id="6NLFGgDBOC_" role="_iOnB" />
     <node concept="1aga60" id="4ptnK4jk7nr" role="_iOnB">
       <property role="TrG5h" value="mul" />
       <node concept="1aduha" id="4ptnK4jkd2c" role="1ahQXP">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -93,7 +93,7 @@
     <language slang="l:7bcf9284-ca29-484f-a3b3-2855bdd813ad:org.iets3.core.expr.simpleTypes.tests" version="0" />
     <language slang="l:4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68:org.iets3.core.expr.temporal" version="3" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="6" />
-    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="6" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="8" />
     <language slang="l:63c1aad1-e2db-439c-a30a-02b5e0bc80f3:org.iets3.core.expr.tracing" version="0" />
     <language slang="l:5186c6ce-428c-4f09-a9df-73d9e86c27d3:org.iets3.core.expr.typetags" version="1" />
     <language slang="l:9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d:org.iets3.core.expr.typetags.bindingtime" version="0" />
@@ -167,7 +167,7 @@
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="9" />
     <module reference="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)" version="4" />
-    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="6" />
     <module reference="b0e7c6a8-b47d-4637-b0e8-e5bfd486c4e8(org.iets3.core.expr.tracing.plugin)" version="0" />
     <module reference="5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)" version="1" />
     <module reference="9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d(org.iets3.core.expr.typetags.bindingtime)" version="0" />


### PR DESCRIPTION
Closes #1827

## Motivation

`org.iets3.core.expr.toplevel` already provides two `IDotTarget`s for enumerations — `is()` (`EnumIsTarget`) and `isIn()` (`EnumIsInTarget`) — to check the presence of an enumeration element. Users frequently need the negated checks too, which previously had to be written by hand (e.g. `not(x.is(...))`). This PR adds first-class negated variants.

## Changes

- **New concepts (`org.iets3.core.expr.toplevel`):** Introduced `isNot()` and `isNotIn()`, the negated versions of `is()` and `isIn()`.
  - `isNot()` — checks that an enumeration element is **not equal** to another.
  - `isNotIn()` — checks that an enumeration element is **not contained** in a list.
  - They look and behave exactly like their non-negated counterparts (editor, constraints, type system).
- **Common super concept:** Behavior, constraints and type system shared by the negated and non-negated targets were consolidated into a common super concept to remove duplication and simplify the generator.
- **Generator:** Added `genjava` generation support for `isNot()` / `isNotIn()`.
- **Interpreter:** Added interpreter support for both new operators.
- **Tests:** Extended the generation (`test.ts.expr.os`) and interpretation (`test.in.expr.os.enums`) test models to cover the new operators.
- **CHANGELOG** updated.

## Testing

Generation and interpreter tests for the enumeration operators were extended and pass.
