### PR TITLE
fix: unique name check missing for function arguments and local vars (#1828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## July 2026
+### Added
+- IFunctionLike takes arguments and named body content into account when performing ab uniqueness name check
+
 ## June 2026
 
 ### Added

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -2048,7 +2048,7 @@
                       <node concept="2OqwBi" id="S0JwotCVZv" role="2Oq$k0">
                         <node concept="13iPFW" id="S0JwotCVZw" role="2Oq$k0" />
                         <node concept="3TrEf2" id="S0JwotCVZx" role="2OqNvi">
-                          <ref role="3Tt5mk" to="zzzn:49WTic8eSDm" />
+                          <ref role="3Tt5mk" to="zzzn:49WTic8eSDm" resolve="body" />
                         </node>
                       </node>
                       <node concept="2Rf3mk" id="S0JwotCWV8" role="2OqNvi" />
@@ -2417,7 +2417,7 @@
               <node concept="1Y3b0j" id="4zsmO3KPRBu" role="YeSDq">
                 <property role="2bfB8j" value="true" />
                 <ref role="1Y3XeK" to="hwgx:7NyyyjNtce8" resolve="NodeTreeViewNode" />
-                <ref role="37wK5l" to="hwgx:9MiAwFBo2R" resolve="NodeTreeViewNode" />
+                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
                 <node concept="3Tm1VV" id="4zsmO3KPRBv" role="1B3o_S" />
                 <node concept="13iPFW" id="4zsmO3KPNS6" role="37wK5m" />
                 <node concept="3cpWs3" id="3E_uh2joi2Y" role="37wK5m">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -53,6 +53,7 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -2025,11 +2026,70 @@
       <ref role="13i0hy" to="hwgx:4qSf1u1TRfj" resolve="getUniquelyNamedElements" />
       <node concept="3Tm1VV" id="49WTic8eUlD" role="1B3o_S" />
       <node concept="3clFbS" id="49WTic8eUlH" role="3clF47">
-        <node concept="3clFbF" id="49WTic8eUlQ" role="3cqZAp">
-          <node concept="2OqwBi" id="49WTic8eUnL" role="3clFbG">
-            <node concept="13iPFW" id="49WTic8eUlP" role="2Oq$k0" />
-            <node concept="3Tsc0h" id="49WTic8eUrc" role="2OqNvi">
-              <ref role="3TtcxE" to="zzzn:49WTic8eSCZ" resolve="args" />
+        <node concept="3clFbF" id="AigfNH$2r" role="3cqZAp">
+          <node concept="2OqwBi" id="6XqzopHduYu" role="3clFbG">
+            <node concept="ANE8D" id="6XqzopHduYC" role="2OqNvi" />
+            <node concept="2OqwBi" id="6XqzopHduYw" role="2Oq$k0">
+              <node concept="2OqwBi" id="6XqzopHduYx" role="2Oq$k0">
+                <node concept="13iPFW" id="6XqzopHduYy" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="6XqzopHduYz" role="2OqNvi">
+                  <ref role="3TtcxE" to="zzzn:49WTic8eSCZ" resolve="args" />
+                </node>
+              </node>
+              <node concept="4Tj9Z" id="6XqzopHduY$" role="2OqNvi">
+                <node concept="2OqwBi" id="S0Jwoshk0K" role="576Qk">
+                  <node concept="v3k3i" id="S0JwoshmZM" role="2OqNvi">
+                    <node concept="chp4Y" id="S0Jwoshndl" role="v3oSu">
+                      <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="S0JwotCZW4" role="2Oq$k0">
+                    <node concept="2OqwBi" id="S0JwotCVZu" role="2Oq$k0">
+                      <node concept="2OqwBi" id="S0JwotCVZv" role="2Oq$k0">
+                        <node concept="13iPFW" id="S0JwotCVZw" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="S0JwotCVZx" role="2OqNvi">
+                          <ref role="3Tt5mk" to="zzzn:49WTic8eSDm" />
+                        </node>
+                      </node>
+                      <node concept="2Rf3mk" id="S0JwotCWV8" role="2OqNvi" />
+                    </node>
+                    <node concept="3zZkjj" id="S0JwotD3AJ" role="2OqNvi">
+                      <node concept="1bVj0M" id="S0JwotD3AL" role="23t8la">
+                        <node concept="3clFbS" id="S0JwotD3AM" role="1bW5cS">
+                          <node concept="3clFbF" id="S0JwotD3YQ" role="3cqZAp">
+                            <node concept="22lmx$" id="S0JwotDfED" role="3clFbG">
+                              <node concept="2OqwBi" id="S0JwotDgwk" role="3uHU7w">
+                                <node concept="37vLTw" id="S0JwotDg4x" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                </node>
+                                <node concept="1mIQ4w" id="S0JwotDkqo" role="2OqNvi">
+                                  <node concept="chp4Y" id="S0JwotDkOv" role="cj9EA">
+                                    <ref role="cht4Q" to="zzzn:49WTic8ix6I" resolve="ValExpression" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="S0JwotD4pE" role="3uHU7B">
+                                <node concept="37vLTw" id="S0JwotD3YP" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                </node>
+                                <node concept="1mIQ4w" id="S0JwotD5Hc" role="2OqNvi">
+                                  <node concept="chp4Y" id="S0JwotD5S3" role="cj9EA">
+                                    <ref role="cht4Q" to="zzzn:1VmWkC0z1FT" resolve="LocalVarDeclExpr" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gl6BB" id="S0JwotD3AN" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="S0JwotD3AO" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2805,10 +2865,10 @@
         <node concept="3clFbF" id="18$bUx5aouC" role="3cqZAp">
           <node concept="2OqwBi" id="18$bUx5aqt_" role="3clFbG">
             <node concept="2OqwBi" id="18$bUx5aoD3" role="2Oq$k0">
-              <node concept="13iPFW" id="18$bUx5aouB" role="2Oq$k0" />
               <node concept="3Tsc0h" id="18$bUx5aoPM" role="2OqNvi">
                 <ref role="3TtcxE" to="zzzn:49WTic8ig5E" resolve="expressions" />
               </node>
+              <node concept="13iPFW" id="18$bUx5aouB" role="2Oq$k0" />
             </node>
             <node concept="v3k3i" id="18$bUx5as0L" role="2OqNvi">
               <node concept="chp4Y" id="18$bUx5as4P" role="v3oSu">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -55,6 +55,7 @@
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
     <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
+    <import index="9zoj" ref="r:1b0f275e-bd62-4f6e-8c4b-51b05d651a63(com.mbeddr.core.base.typesystem)" />
     <import index="n0yb" ref="r:1fd78142-d7d8-42c9-9cbb-0609b1bc5311(org.iets3.core.expr.collections.typesystem)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
@@ -20745,6 +20746,112 @@
             </node>
           </node>
         </node>
+        <node concept="1aga60" id="AigfNBDPM" role="_iOnC">
+          <property role="TrG5h" value="g" />
+          <node concept="1aduha" id="AigfNBDPN" role="1ahQXP">
+            <node concept="1adJid" id="AigfNBDPO" role="1aduh9">
+              <property role="TrG5h" value="x" />
+              <node concept="30dDZf" id="7bnT8r5yRdl" role="2lDidJ">
+                <node concept="1afdae" id="7bnT8r5yRdP" role="30dEs_">
+                  <ref role="1afue_" node="AigfNBDPR" resolve="x" />
+                </node>
+                <node concept="30bXRB" id="AigfNBDPP" role="30dEsF">
+                  <property role="30bXRw" value="5" />
+                </node>
+              </node>
+              <node concept="7CXmI" id="AigfNIPOg" role="lGtFl">
+                <node concept="1TM$A" id="AigfNIPOh" role="7EUXB">
+                  <node concept="2PYRI3" id="AigfNIQnB" role="3lydEf">
+                    <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1adzI2" id="AigfNBDPQ" role="1aduh9">
+              <ref role="1adwt6" node="AigfNBDPO" resolve="x" />
+            </node>
+          </node>
+          <node concept="1ahQXy" id="AigfNBDPR" role="1ahQWs">
+            <property role="TrG5h" value="x" />
+            <node concept="30bXR$" id="7bnT8r5yRn0" role="3ix9CU" />
+          </node>
+        </node>
+        <node concept="1aga60" id="6XqzopHdun2" role="_iOnC">
+          <property role="TrG5h" value="h" />
+          <node concept="1ahQXy" id="6XqzopHdun9" role="1ahQWs">
+            <property role="TrG5h" value="q" />
+            <node concept="30bXR$" id="6XqzopHdunu" role="3ix9CU" />
+          </node>
+          <node concept="1aduha" id="6XqzopHdunB" role="1ahQXP">
+            <node concept="umIIN" id="6XqzopHdvrW" role="1aduh9">
+              <property role="TrG5h" value="q" />
+              <node concept="30dDZf" id="6XqzopHdvD1" role="2lDidJ">
+                <node concept="1afdae" id="6XqzopHdvDy" role="30dEs_">
+                  <ref role="1afue_" node="6XqzopHdun9" resolve="q" />
+                </node>
+                <node concept="30bXRB" id="6XqzopHdvsg" role="30dEsF">
+                  <property role="30bXRw" value="5" />
+                </node>
+              </node>
+              <node concept="7CXmI" id="6XqzopHdvua" role="lGtFl">
+                <node concept="1TM$A" id="6XqzopHdvub" role="7EUXB">
+                  <node concept="2PYRI3" id="6XqzopHdvv6" role="3lydEf">
+                    <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="uhfPG" id="6XqzopHdvt6" role="1aduh9">
+              <ref role="uhfO8" node="6XqzopHdvrW" resolve="q" />
+            </node>
+          </node>
+        </node>
+        <node concept="1aga60" id="7h6xCzJDC2J" role="_iOnC">
+          <property role="TrG5h" value="y" />
+          <node concept="1ahQXy" id="7h6xCzJDC2Q" role="1ahQWs">
+            <property role="TrG5h" value="b" />
+            <node concept="mLuIC" id="7h6xCzJDCiv" role="3ix9CU" />
+          </node>
+          <node concept="1aduha" id="7h6xCzJDCiC" role="1ahQXP">
+            <node concept="umIIN" id="7h6xCzJDCs1" role="1aduh9">
+              <property role="TrG5h" value="b" />
+              <node concept="30dDZf" id="7h6xCzJDCth" role="2lDidJ">
+                <node concept="1afdae" id="7h6xCzJDCtK" role="30dEs_">
+                  <ref role="1afue_" node="7h6xCzJDC2Q" resolve="b" />
+                </node>
+                <node concept="30bXRB" id="7h6xCzJDCsl" role="30dEsF">
+                  <property role="30bXRw" value="4" />
+                </node>
+              </node>
+              <node concept="7CXmI" id="S0JwosinDN" role="lGtFl">
+                <node concept="1TM$A" id="S0Jwosio0l" role="7EUXB">
+                  <node concept="2PYRI3" id="S0Jwosio0m" role="3lydEf">
+                    <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1adJid" id="7h6xCzJDCEw" role="1aduh9">
+              <property role="TrG5h" value="b" />
+              <node concept="30bXRB" id="7h6xCzJDCHH" role="2lDidJ">
+                <property role="30bXRw" value="8" />
+              </node>
+              <node concept="7CXmI" id="S0Jwosio2O" role="lGtFl">
+                <node concept="1TM$A" id="S0Jwosiopd" role="7EUXB">
+                  <node concept="2PYRI3" id="S0Jwosiope" role="3lydEf">
+                    <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                  </node>
+                </node>
+                <node concept="1TM$A" id="S0Jwosiopf" role="7EUXB">
+                  <node concept="2PYRI3" id="S0Jwosiopg" role="3lydEf">
+                    <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="AigfNIPM8" role="_iOnC" />
         <node concept="_ixoA" id="1VmWkC0D2os" role="_iOnC" />
         <node concept="_ixoA" id="1VmWkC0D2p9" role="_iOnC" />
         <node concept="7CXmI" id="1VmWkC0z0Cm" role="lGtFl">


### PR DESCRIPTION
## Summary

- Adds a unique-name constraint in `org.iets3.core.expr.lambda` behavior so that a `Function` parameter and a local variable with the same name produce an error (matching the behaviour already present in BaseLanguage)
- Adds a regression test in `m1@tests.mps` covering the duplicate-name case

## Related issue

Closes #1828

## Test plan

- [x] Open the test model `m1@tests.mps` in MPS and confirm the new test case passes
- [x] Create a `Function` with a parameter and a local variable sharing the same name — verify an error is shown
- [x] Confirm no error appears when names are distinct

