### PR TITLE
Add initial iets3-os-developer agent skill

### DIFF
--- a/.claude/skills/iets3-os-developer/SKILL.md
+++ b/.claude/skills/iets3-os-developer/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: iets3-os-developer
+description: Repo-specific development knowledge for IETS3/iets3.opensource — existing infrastructure and component knowledge across the variability languages, the KernelF expression languages, and physical units. TRIGGER when: implementing a ticket or bugfix, preparing or reviewing a PR, or doing any language development work in the iets3.opensource repository.
+---
+
+<!-- synced-with-mps-developer: 2026-07-13 -->
+
+## What this skill is
+
+The **repo layer** of the itemis MPS knowledge architecture for iets3.opensource ("os"). Load it together with the other two layers:
+
+- **`mps-developer`** (plugin `mps-language-engineering`) — generic MPS patterns; cross-references use its stable slugs (e.g. `types.checking-rules`).
+- **`mps-platform-projects`** (plugin `mps-itemis-ecosystem`) — the IETS3 family layer: repo map, the core ↔ opensource split, and the shared ticket-to-merge workflow (branches, commits, CHANGELOG, PR structure, review etiquette, testing conventions).
+- **This skill** — what is genuinely specific to *this* repo: existing infrastructure and component knowledge, so you reach for existing mechanisms instead of inventing new ones.
+
+Like the other layers, this is a growing knowledge base fed by analyzing merged PRs (maintainers use the `mps-learn-from-pr` skill of the `mps-tooling-evolution` plugin); it is deliberately incomplete. The sync marker above records when it was last reconciled against `mps-developer`'s breaking-changes log.
+
+## Orientation
+
+- Languages live under `code/languages/org.iets3.opensource/languages/` — one directory per language, models under `models/`; the MPS project is `org.iets3.opensource`.
+- os is the **upstream half** of the IETS3 family: core consumes it as a pinned binary build. Changes here often get a companion PR in iets3.core — see "The core ↔ opensource split" in `mps-platform-projects`.
+- Branching, tickets, and the PR workflow follow the IETS3 family conventions — see `mps-platform-projects`.
+
+## References (load progressively — only the topic(s) your task touches)
+
+Organized by domain; this repo skill will grow, so knowledge is split by topic from the start:
+
+- **`references/variability.md`** — the variability languages (`org.iets3.variability.*`): feature-model checking rules and constraints, the skeleton-tree viewer.
+- **`references/kernelf.md`** — the KernelF expression languages (`org.iets3.core.expr.*`, physical units excluded): number types and the typesystem.
+- **`references/physunits.md`** — the physical-units language (`typetags.physunits`); note that `typetags.units` is the deprecated legacy implementation and must not be used.
+- **`references/misc.md`** — cross-cutting knowledge not tied to one domain (e.g. sandbox/testing infrastructure); home for new topics until they warrant their own file.

--- a/.claude/skills/iets3-os-developer/references/kernelf.md
+++ b/.claude/skills/iets3-os-developer/references/kernelf.md
@@ -1,0 +1,23 @@
+# KernelF (expression languages)
+
+Repo-specific knowledge for the KernelF-based expression languages (`org.iets3.core.expr.*`) in iets3.opensource — everything built around Expressions. **Physical units** (`typetags.physunits`) are technically part of this stack but are big enough to have their own file — see `physunits.md`.
+
+## Enum declarations
+
+- `EnumDeclaration` and friends live in `org.iets3.core.expr.toplevel.*` (structure/behavior/editor/intentions). Its editor layout is driven by the behavior method **`EnumDeclaration.useVerticalLayout()`** (`= useVerticalLayout property || isValued()`), referenced from the enum editor, the literal editor, and the insert-literal keymap — change layout logic there, not per-cell. A `toggleVerticalLayout` intention flips the property (PR #1737). Follows `editor.user-toggleable-formatting` / `intentions.toggle-property` in `mps-developer`.
+
+## Enum dot-target operators
+
+- Enum dot-syntax operators (`x.is(...)`, `x.isIn(...)`, and the negated `isNot`/`isNotIn`, PR #1846) are `IDotTarget` concepts in `org.iets3.core.expr.toplevel` (`EnumIsTarget`, `EnumIsInTarget`, `EnumIsNotTarget`, `EnumIsNotInTarget`) sharing abstract super concepts `AbstractEnumInTarget` / `AbstractEnumSingleInTarget` — put shared structure/behavior/constraints/editor there (`structure.factor-shared-superconcept` in `mps-developer`).
+- A new KernelF operator needs the **full aspect set**: structure + editor + constraints + typesystem, **plus a `genjava` generator** (`org.iets3.core.expr.genjava.*`) and **interpreter** support. Cover both execution paths in tests: generation tests in `test.ts.expr.os`, interpreter tests in `test.in.expr.os.*` (e.g. `test.in.expr.os.enums`).
+- Known bug (deferred): the enum-literal **scoping rule** in `expr.toplevel.constraints` can't handle optional (`opt`) enum types, so enum literals aren't referenceable there — affects the old `EnumIsInTarget` too.
+
+## Collections
+
+- The **list-literal editor** lives in `org.iets3.core.expr.collections.editor` (`ListLiteral_Editor`). It breaks onto multiple lines once a list holds more than 3 elements (`editor.count-threshold-linebreak` in `mps-developer`, PR #1422).
+
+## Number types and typesystem
+
+- The expression typesystem lives in per-language typesystem models: `org.iets3.core.expr.base.typesystem` (e.g. the `typeof_IOptionallyTyped` inference rule connecting declared and computed types) and `org.iets3.core.expr.simpleTypes.typesystem`.
+- **Number-type semantics**: `number{precision}` with optional range spec (`[-∞|∞]`); `int` corresponds to `number{0}`, `real` to `number{∞}`. Compatibility with `int`/`real` is **bidirectional** since PR #1764, implemented via `InequationReplacementRule`s `replaceIntegerType` / `replaceRealType` (`types.subtyping-replacement-rules` in `mps-developer`) — extend those rules when number-type compatibility changes, and keep the full matrix covered.
+- Typesystem tests live in `test.ts.expr.os.m1@tests` as declarative compatibility matrices with section markers (`testing.type-compatibility-matrix` in `mps-developer`).

--- a/.claude/skills/iets3-os-developer/references/misc.md
+++ b/.claude/skills/iets3-os-developer/references/misc.md
@@ -1,0 +1,7 @@
+# Miscellaneous / cross-cutting
+
+Repo-specific knowledge that does not belong to a single language domain (variability / KernelF / physical units). New topics that don't fit the other files land here until they are big enough to warrant their own.
+
+## Sandboxes for manual testing
+
+- Sandbox solutions in this repo are named **`org.iets3.variability.os.sandbox.*`** (e.g. `...sandbox.notpresentvalue`) — so far only the variability languages ship them. The sandbox-per-feature convention itself is family-wide — see the testing conventions in `mps-platform-projects`.

--- a/.claude/skills/iets3-os-developer/references/physunits.md
+++ b/.claude/skills/iets3-os-developer/references/physunits.md
@@ -1,0 +1,20 @@
+# Physical units
+
+Repo-specific knowledge for the physical-units language (`org.iets3.core.expr.typetags.physunits`) in iets3.opensource. It is part of the KernelF expression stack (`org.iets3.core.expr.typetags.*`) but kept separate here because it is a large topic of its own.
+
+> **Legacy — do not use:** `org.iets3.core.expr.typetags.units` is the **outdated legacy implementation** of physical units. It should no longer be used or developed. The current, maintained language is **`typetags.physunits`** — direct all new work and fixes there.
+
+## SI unit definitions
+
+- **SI unit definitions are data, not language code**: they live as `Library` roots (concept `org.iets3.core.expr.toplevel.Library`) in the solution `org.iets3.core.expr.typetags.phyunits.si` (model `...phyunits.si.units`, e.g. library `SIDerivedUnits` with `Unit` declarations `J`, `C`, `W`, …). Properties on the `Unit` nodes control e.g. which metric-prefix scalings are allowed (negative scalings for J/C/W enabled in PR #1584) — such changes are model edits to the library, no typesystem/generator work needed.
+
+## Typesystem — number precision for prefixed units
+
+- The type of a tagged (unit-carrying) expression is inferred by the **`typeof_TaggedExpression`** `InferenceRule` in **`org.iets3.core.expr.typetags.physunits.typesystem`**. For a **prefixed** unit it derives the `number{precision}` by scaling the value's single-point range by the prefix factor (via `GlobalUnitPrefixManager` / `AbstractUnitPrefix` and `NumberRangeSpec_Behavior.times()`), then `setPrecisionFromValue(...)` — do **not** hardcode infinite precision (bug #1594: infinite precision forced the matched type to widen and broke subtyping; `types.computed-type-parameters` in `mps-developer`).
+- Number range/precision arithmetic lives in **`org.iets3.core.expr.simpleTypes.behavior`** — `NumberRangeSpec_Behavior` (`isSinglePoint()`, `times(BigDecimal)`, `getSinglePointRange()`) and `NumberType_Behavior`. Extend these rather than inlining range math into rules.
+- Typesystem tests are in **`test.ts.expr.os.phyunits@tests`** — `ExpressionsPart1` (`NodesTestCase`) with a `Quantities` `Library` as test data (`testing.type-compatibility-matrix`).
+- **Known open issue (deferred):** adding mixed digital-information units of the same quantity (e.g. `kbyte + bit`) computes a wrong result — the byte↔bit implicit conversion misbehaves; flagged in #1594 review, deferred to separate tickets.
+
+## Documentation
+
+- **The physunits documentation is itself an MPS model**: `org.iets3.core.expr.typetags.physunits.documentation` — fix doc typos there like any other model edit.

--- a/.claude/skills/iets3-os-developer/references/variability.md
+++ b/.claude/skills/iets3-os-developer/references/variability.md
@@ -1,0 +1,36 @@
+# Variability
+
+Repo-specific knowledge for the variability languages (`org.iets3.variability.*`) in iets3.opensource. Reach for these existing mechanisms before inventing new ones; cross-references into `mps-developer` use its stable slugs.
+
+## Feature-model checking rules
+
+- Checking rules for the feature-model language live in **`org.iets3.variability.featuremodel.base.typesystem`** (`NonTypesystemRule`s per concept, e.g. `check_FeatureAttribute`, `check_FeatureAttributeDotTarget`) — follow `types.checking-rules` in `mps-developer`.
+- Domain predicates for rules are **behavior methods on the structure concepts** (e.g. `FeatureAttribute.notPresentValueForSolver(): Optional<Expression>`) — extend those rather than traversing models inside rule bodies.
+- Checking-rule tests live in **`test.org.iets3.variability.featuremodel.base.checking_rules@tests`** — a dedicated test model per rule group, using inline warning-check annotations bound to the specific rule (`testing.warning-check-annotations` in `mps-developer`).
+
+## Configuration editor
+
+- The configuration editors and their **cell action maps** (enter → `INSERT` new config line after; shift-enter → `INSERT_BEFORE`, active only in the header line; plus deletion/creation/paste restrictions) live in **`org.iets3.variability.configuration.base.editor`** — *not* in `featuremodel.base`, whose configuration-related concepts are **deprecated** and whose editors are kept only to display un-migrated legacy models (PR #1431 moved the behavior here). Follow `editor.action-maps` / `editor.deprecated-concept-editors` in `mps-developer`.
+
+- **Large-config editor performance:** the `FeatureModelConfiguration_Editor` (in `configuration.base.editor`) removes the `IETS3Tracing`, `conditionalEditor` and `conditionalEditor_doNotUseThisHint` hints via an `ExplicitHintsSpecification` (`removeHints`) — variant-configuration editors need neither conditional editors nor tracing, and removing them cut editor buildup ~40% for configs with thousands of `FeatureConfiguration` nodes (#1621; `editor.hint-removal-performance` in `mps-developer`). This required build/module deps on `org.iets3.core.expr.tracing` and `de.slisson.mps.conditionalEditor.hints`. Keep new config-editor hints off this subtree unless truly needed.
+- The `FeatureAttributeAssignment_Editor` (in `configuration.base.editor`) provides an **inspector editor** so the full assignment editor shows in the inspector when a cell is embedded read-only in the **configuration matrix** (`editor.inspector-cell-layout` in `mps-developer`, PR #1564). Its cells are factored into the `FeatureAttrAssignmentEditor` editor component, mounted in both `cellModel` and `inspectedCellModel`. This is required because the matrix uses `de.slisson.mps.tables` gridquery cells, which ignore context hints and always show the standard inspector — editor tests for this concept are in `...configuration.base.editor@tests` (e.g. `SetManualAssignmentCause`) and bind to cells by label, so re-point them after editor restructuring.
+
+## Feature-model (tree/diagram) editor
+
+- The feature-model editor lives in **`org.iets3.variability.featuremodel.base.editor`** (`TopPartFeature` component, `Feature_Keymap`). A newly created child/sibling defaults to a plain **`Feature`**; typing **`:`** on a feature converts it to a **`FeatureModelInclude`** (also with cardinality) via the keymap. Conversions must **preserve** cardinality/constraints — the `changeFeature` parametric intention in `featuremodel.base.intentions` had a bug where it dropped them (PR #1760; `editor.type-conversion-preserve-data` in `mps-developer`).
+- This editor behavior is covered by **`EditorTestCase`s** in `test.org.iets3.variability.featuremodel.base.editor@tests` (`NewChildIsFeature`, `TypeSemicolonFeature`, `TypeBracketFeatureCardinality`, …) — extend them when touching the keymap (`testing.editor-tests`).
+
+## Feature-model constraints
+
+- **`FeatureModel.name` is derived** from the root feature's name via a get-property constraint in `featuremodel.base.constraints`, with sentinel `'NO_NAME'` when the root is null/unnamed (`constraints.derived-property-sentinel` in `mps-developer`, PR #1714) — don't validate against the raw derived name.
+
+## Configuration combination logic (extension points)
+
+- How configurations combine (`extends`, `abstract`, sub-config references) is pluggable via the **`configCombinationLogicExtPoint`** extension point + interface **`IConfigCombinationLogic`** (`allowAbstractSubConfigs()`, …) in `org.iets3.variability.configuration.base.plugin`, default `DefaultConfigCombinationLogic` (PR #1832; `plugin.extension-point` in `mps-developer`). The `check_FeatureModelConfiguration` typesystem rule consults it rather than hard-coding — so per-application rules differ.
+- Priority-based extension selection is shared infrastructure in **`org.iets3.variability.base.plugin`**: `IExtensionWithPriority` + `AbstractExtensionWithPriority`/`AbstractExtensionProvider` (`plugin.priority-extension`). The enriched-config-name extension point (`enrichedConfigNameLogicExtPoint`) is built on it — reuse this base for new priority extension points.
+- **Config hashing**: transient per-config hashes live in `configuration.base.behavior` — `AbstractConfigHashing` with `SolverRelevantDataHashing` and `AllDetailsHashing`; cached on the config node, recomputed only when the source changes. `AllReachableConfigTraversal` (a `Traversal` over sub-config references) visits a config and everything reachable from it (consumed by core #1755).
+
+## Skeleton tree viewer
+
+- The "Show Skeleton Tree" feature spans two models: **`SkeletonTreeGraphCreator`** (class in `org.iets3.variability.artifacts.base.behavior`) generates the graphviz dot file; the **`SkeletonTreeViewer` tool + `openSkelTreeViewer` action** live in `org.iets3.variability.base.ide.plugin` and render it via the external `dot` executable (`ide.external-tool-invocation` in `mps-developer`).
+- **The skeleton-tree structure is a contract**: iets3.core has many tests asserting it. Changes to the *structure* (vs. rendering/file handling) ripple into core — scope such changes explicitly in the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ## July 2026
 ### Added
 - IFunctionLike takes arguments and named body content into account when performing ab uniqueness name check
+- Developer tooling: the repository now ships an `iets3-os-developer` agent skill (under `.claude/skills/`) capturing repo-specific MPS language-engineering knowledge (variability, KernelF, physical units) for AI-assisted development with Claude Code.
 
 ### Fixed
 - Variability: `EvalVarPointCache.flushCaches()` was a no-op when the variability-aware artifact (IVAA) was implemented as a node attribute (annotation).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Working on iets3.opensource with Claude Code
+
+This repository ships an agent skill at `.claude/skills/iets3-os-developer/`.
+It is loaded **automatically** when you open the repo with Claude Code — no setup
+needed. It captures iets3.opensource-specific development knowledge (existing
+infrastructure, component locations, conventions) so the agent starts informed.
+
+## The itemis MPS plugins (itemis-internal)
+
+The repo skill is the **repo-specific layer** of a larger, three-layer knowledge
+structure. The other two layers live in Claude Code plugins:
+
+- `mps-language-engineering` — generic MPS language-engineering patterns
+- `mps-itemis-ecosystem` — knowledge shared across the IETS3 repos (the
+  core ↔ opensource relationship, the common ticket-to-merge workflow)
+
+> **Note:** these plugins and their marketplace are **itemis-internal and not
+> available as open source**. They are simply the knowledge base itemis uses to
+> work on this repo; they are not required, and the skill above is self-contained
+> without them. **Contributors are encouraged to maintain their own agent
+> knowledge base** as project skills under `.claude/skills/` — the skill shipped
+> here is just the itemis one. (itemis developers install the plugins from the
+> internal marketplace: `/plugin install mps-language-engineering@mps-plugins`.)
+
+## Model-level work: Portalon
+
+For reading or editing the MPS AST, running builds, or model checks, run a
+JetBrains MPS instance with the **Portalon** plugin installed, so the `portalon`
+MCP is available to Claude. Without it, Claude can still help with text-level
+work (git, build files, documentation) but not with the models themselves.


### PR DESCRIPTION
This solves #1860.

Adds `.claude/skills/iets3-os-developer/` — the **repo layer** of the three-layer MPS agent-knowledge architecture maintained in `itemis/mps-plugins`. It gives AI coding agents working in iets3.opensource the repo-specific conventions and infrastructure knowledge up front.

## Contents

- **`.claude/skills/iets3-os-developer/SKILL.md`** — orientation: how the three layers (generic `mps-developer`, family `mps-platform-projects`, this repo skill) relate, a sync marker into the generic layer's breaking-changes log, and a note that os is the upstream half of the family consumed by core as a pinned build. Points to the domain-split reference files below.
- **`references/`** — existing infrastructure and component knowledge, split by domain so it can grow and be loaded progressively:
  - **`variability.md`** — the variability languages (feature-model checking rules & constraints, configuration editors, skeleton-tree viewer, config-combination extension points).
  - **`kernelf.md`** — the KernelF expression languages (enum declarations & dot-target operators, collections, number types and typesystem).
  - **`physunits.md`** — the physical-units language (SI unit definitions as data, number-precision typesystem, documentation model; legacy `typetags.units` is off-limits).
  - **`misc.md`** — cross-cutting knowledge (e.g. sandbox/testing infrastructure).
- **`CLAUDE.md`** (repo root) — bootstraps Claude Code: notes the auto-loaded skill and points to Portalon for model-level work. Since this repo is **open source** but the itemis MPS plugins/marketplace are **not**, it frames those plugins as itemis-internal and optional, and invites external contributors to maintain their own agent knowledge base as project skills under `.claude/skills/`.
- **`CHANGELOG.md`** — entry noting the new developer tooling.

Cross-references into the generic layer use its stable pattern slugs. Seeded by analyzing recently merged iets3.opensource PRs; grows over time via the `mps-learn-from-pr` tooling.

Only agent-support files (`CLAUDE.md`, `.claude/skills/`) and the CHANGELOG are touched — no language or build changes.
