### PR TITLE
deps: fix group id of mps artifact

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ jbr = "25.0.3-b508.16"
 
 
 [libraries]
-mps = { group = "com.jetbrains.mps", name = "mps", version.ref = "mpsVersion" }
+mps = { group = "com.jetbrains", name = "mps", version.ref = "mpsVersion" }
 remigrate = { group = "de.itemis.mps.build-backends", name = "remigrate", version = "1.0.1.185.53c5432" }
 
 mpsQaAllInOne = { group = "org.mpsqa", name = "all-in-one", version.ref = "mpsQaVersion" }


### PR DESCRIPTION
I forgor to update the group id of the mps artifacts after branching form master, which is using mps pre releases. The group id of the actual releases is the one added in this PR