### PR TITLE
Fix NullPointerExceptions and contract violations in RecordValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## September 2026
+
+### Fixed
+- KernelF: `RecordValue` no longer throws a `NullPointerException` from `equals` or `compareTo` when a record member has no value, nor from `compareTo` for inline records, which carry no record declaration. `equals`, `hashCode` and `compareTo` are consistent with each other again, so record values behave correctly in Java-side hash-based and sorted collections.
+
 ## August 2026
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
@@ -127,6 +127,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -822,33 +823,28 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3fqX7Q" id="35CkgbLJAjx" role="3clFbw">
-                    <node concept="2OqwBi" id="35CkgbLJPv$" role="3fr31v">
-                      <node concept="3EllGN" id="35CkgbLJF9M" role="2Oq$k0">
-                        <node concept="2OqwBi" id="35CkgbLJG3j" role="3ElVtu">
-                          <node concept="2GrUjf" id="35CkgbLJFMU" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="35CkgbLJo5t" resolve="e" />
-                          </node>
-                          <node concept="3AY5_j" id="35CkgbLJIwT" role="2OqNvi" />
+                  <node concept="17QLQc" id="5F22zinykyD" role="3clFbw">
+                    <node concept="3EllGN" id="35CkgbLJF9M" role="3uHU7B">
+                      <node concept="2OqwBi" id="35CkgbLJG3j" role="3ElVtu">
+                        <node concept="2GrUjf" id="35CkgbLJFMU" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="35CkgbLJo5t" resolve="e" />
                         </node>
-                        <node concept="2OqwBi" id="35CkgbLJAZp" role="3ElQJh">
-                          <node concept="37vLTw" id="35CkgbLJAOp" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7fOaqhi3WpG" resolve="rv" />
-                          </node>
-                          <node concept="2OwXpG" id="35CkgbLJBIX" role="2OqNvi">
-                            <ref role="2Oxat5" node="7D7uZV2szuN" resolve="memberData" />
-                          </node>
+                        <node concept="3AY5_j" id="35CkgbLJIwT" role="2OqNvi" />
+                      </node>
+                      <node concept="2OqwBi" id="35CkgbLJAZp" role="3ElQJh">
+                        <node concept="37vLTw" id="35CkgbLJAOp" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7fOaqhi3WpG" resolve="rv" />
+                        </node>
+                        <node concept="2OwXpG" id="35CkgbLJBIX" role="2OqNvi">
+                          <ref role="2Oxat5" node="7D7uZV2szuN" resolve="memberData" />
                         </node>
                       </node>
-                      <node concept="liA8E" id="35CkgbLJRT5" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
-                        <node concept="2OqwBi" id="35CkgbLJZzZ" role="37wK5m">
-                          <node concept="2GrUjf" id="35CkgbLJXGU" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="35CkgbLJo5t" resolve="e" />
-                          </node>
-                          <node concept="3AV6Ez" id="35CkgbLK9qX" role="2OqNvi" />
-                        </node>
+                    </node>
+                    <node concept="2OqwBi" id="35CkgbLJZzZ" role="3uHU7w">
+                      <node concept="2GrUjf" id="35CkgbLJXGU" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="35CkgbLJo5t" resolve="e" />
                       </node>
+                      <node concept="3AV6Ez" id="35CkgbLK9qX" role="2OqNvi" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
@@ -744,6 +744,31 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbJ" id="5F22zinzYNM" role="3cqZAp">
+              <node concept="3y3z36" id="5F22zinzYNP" role="3clFbw">
+                <node concept="2OqwBi" id="5F22zinzYNS" role="3uHU7B">
+                  <node concept="Xjq3P" id="5F22zinzYNV" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="5F22zinzYNW" role="2OqNvi">
+                    <ref role="2Oxat5" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5F22zinzYNX" role="3uHU7w">
+                  <node concept="37vLTw" id="5F22zinzYO0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7fOaqhi3WpG" resolve="rv" />
+                  </node>
+                  <node concept="liA8E" id="5F22zinzYO1" role="2OqNvi">
+                    <ref role="37wK5l" node="3vxfdxaYUpD" resolve="recordDeclaration" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="5F22zinzYO2" role="3clFbx">
+                <node concept="3cpWs6" id="5F22zinzYO3" role="3cqZAp">
+                  <node concept="3clFbT" id="5F22zinzYO4" role="3cqZAk">
+                    <property role="3clFbU" value="false" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3clFbJ" id="7fOaqhi3Xgp" role="3cqZAp">
               <node concept="3clFbS" id="7fOaqhi3Xgr" role="3clFbx">
                 <node concept="3cpWs6" id="7fOaqhi3ZPJ" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
@@ -753,7 +753,7 @@
               </node>
             </node>
             <node concept="3clFbJ" id="5F22zinzYNM" role="3cqZAp">
-              <node concept="3y3z36" id="5F22zinzYNP" role="3clFbw">
+              <node concept="17QLQc" id="74GIRWDUEZw" role="3clFbw">
                 <node concept="2OqwBi" id="5F22zinzYNS" role="3uHU7B">
                   <node concept="Xjq3P" id="5F22zinzYNV" role="2Oq$k0" />
                   <node concept="2OwXpG" id="5F22zinzYNW" role="2OqNvi">
@@ -1258,12 +1258,6 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbC" id="5F22zinHxm2" role="3clFbw">
-            <node concept="37vLTw" id="5F22zinHxm5" role="3uHU7B">
-              <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
-            </node>
-            <node concept="10Nm6u" id="5F22zinHxm6" role="3uHU7w" />
-          </node>
           <node concept="9aQIb" id="7k6A8WfycpM" role="9aQIa">
             <node concept="3clFbS" id="7k6A8WfycpN" role="9aQI4">
               <node concept="1DcWWT" id="7k6A8Wfyf43" role="3cqZAp">
@@ -1437,6 +1431,12 @@
                 </node>
               </node>
             </node>
+          </node>
+          <node concept="3clFbC" id="5F22zinHxm2" role="3clFbw">
+            <node concept="37vLTw" id="5F22zinHxm5" role="3uHU7B">
+              <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+            </node>
+            <node concept="10Nm6u" id="5F22zinHxm6" role="3uHU7w" />
           </node>
         </node>
         <node concept="3cpWs6" id="3sWKo0EdDJv" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
@@ -146,11 +146,11 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -172,6 +172,10 @@
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -353,6 +357,10 @@
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1176903168877" name="jetbrains.mps.baseLanguage.collections.structure.UnionOperation" flags="nn" index="4Tj9Z" />
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
@@ -1102,143 +1110,159 @@
       <node concept="3clFbS" id="3sWKo0Ed1L7" role="3clF47">
         <node concept="3clFbJ" id="7k6A8WfxAFP" role="3cqZAp">
           <node concept="3clFbS" id="7k6A8WfxAFR" role="3clFbx">
-            <node concept="1DcWWT" id="3sWKo0Epnv_" role="3cqZAp">
-              <node concept="3clFbS" id="3sWKo0EpnvB" role="2LFqv$">
-                <node concept="3cpWs8" id="3sWKo0Ehgvu" role="3cqZAp">
-                  <node concept="3cpWsn" id="3sWKo0Ehgvv" role="3cpWs9">
-                    <property role="TrG5h" value="thisValue" />
-                    <node concept="3uibUv" id="3sWKo0EhfwP" role="1tU5fm">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                    <node concept="1rXfSq" id="3sWKo0Ehgvw" role="33vP2m">
-                      <ref role="37wK5l" node="7D7uZV2yb7j" resolve="getValueForPath" />
-                      <node concept="2OqwBi" id="3sWKo0Ehgvx" role="37wK5m">
-                        <node concept="37vLTw" id="3sWKo0EpG2n" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3sWKo0EpnvC" resolve="comparisonOrder" />
-                        </node>
-                        <node concept="3TrEf2" id="3sWKo0Ehgvz" role="2OqNvi">
-                          <ref role="3Tt5mk" to="yv47:3sWKo0E1oB1" resolve="member" />
-                        </node>
-                      </node>
+            <node concept="3SKdUt" id="5F22zinHxm7" role="3cqZAp">
+              <node concept="1PaTwC" id="5F22zinHxmb" role="1aUNEU">
+                <node concept="3oM_SD" id="5F22zinHxmd" role="1PaTwD">
+                  <property role="3oM_SC" value="An" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxme" role="1PaTwD">
+                  <property role="3oM_SC" value="inline" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmf" role="1PaTwD">
+                  <property role="3oM_SC" value="record" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmg" role="1PaTwD">
+                  <property role="3oM_SC" value="has" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmh" role="1PaTwD">
+                  <property role="3oM_SC" value="no" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmi" role="1PaTwD">
+                  <property role="3oM_SC" value="declaration" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmj" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmk" role="1PaTwD">
+                  <property role="3oM_SC" value="take" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxml" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmm" role="1PaTwD">
+                  <property role="3oM_SC" value="member" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmn" role="1PaTwD">
+                  <property role="3oM_SC" value="order" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmo" role="1PaTwD">
+                  <property role="3oM_SC" value="from," />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmp" role="1PaTwD">
+                  <property role="3oM_SC" value="so" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmq" role="1PaTwD">
+                  <property role="3oM_SC" value="compare" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmr" role="1PaTwD">
+                  <property role="3oM_SC" value="by" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxms" role="1PaTwD">
+                  <property role="3oM_SC" value="member" />
+                </node>
+                <node concept="3oM_SD" id="5F22zinHxmt" role="1PaTwD">
+                  <property role="3oM_SC" value="name." />
+                </node>
+              </node>
+            </node>
+            <node concept="1DcWWT" id="5F22zinHxmu" role="3cqZAp">
+              <node concept="3cpWsn" id="5F22zinHxmy" role="1Duv9x">
+                <property role="TrG5h" value="name" />
+                <node concept="17QB3L" id="5F22zinHxm$" role="1tU5fm" />
+              </node>
+              <node concept="2OqwBi" id="5F22zinHxm_" role="1DdaDG">
+                <node concept="2OqwBi" id="5F22zinHxmC" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5F22zinHxmF" role="2Oq$k0">
+                    <node concept="Xjq3P" id="5F22zinHxmI" role="2Oq$k0" />
+                    <node concept="liA8E" id="5F22zinHxmJ" role="2OqNvi">
+                      <ref role="37wK5l" node="35CkgbMKMzX" resolve="memberNames" />
                     </node>
                   </node>
-                </node>
-                <node concept="3cpWs8" id="3sWKo0EhokQ" role="3cqZAp">
-                  <node concept="3cpWsn" id="3sWKo0EhokR" role="3cpWs9">
-                    <property role="TrG5h" value="otherValue" />
-                    <node concept="3uibUv" id="3sWKo0EhokS" role="1tU5fm">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                    <node concept="2OqwBi" id="3sWKo0EhueL" role="33vP2m">
-                      <node concept="37vLTw" id="3sWKo0EhueM" role="2Oq$k0">
+                  <node concept="4Tj9Z" id="5F22zinHxmK" role="2OqNvi">
+                    <node concept="2OqwBi" id="5F22zinHxmM" role="576Qk">
+                      <node concept="37vLTw" id="5F22zinHxmP" role="2Oq$k0">
                         <ref role="3cqZAo" node="3sWKo0Ed1L4" resolve="value" />
                       </node>
-                      <node concept="liA8E" id="3sWKo0EhueN" role="2OqNvi">
-                        <ref role="37wK5l" node="7D7uZV2yb7j" resolve="getValueForPath" />
-                        <node concept="2OqwBi" id="3sWKo0EhueO" role="37wK5m">
-                          <node concept="37vLTw" id="3sWKo0EpIF6" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3sWKo0EpnvC" resolve="comparisonOrder" />
-                          </node>
-                          <node concept="3TrEf2" id="3sWKo0EhueQ" role="2OqNvi">
-                            <ref role="3Tt5mk" to="yv47:3sWKo0E1oB1" resolve="member" />
-                          </node>
-                        </node>
+                      <node concept="liA8E" id="5F22zinHxmQ" role="2OqNvi">
+                        <ref role="37wK5l" node="35CkgbMKMzX" resolve="memberNames" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbH" id="3sWKo0EhzNk" role="3cqZAp" />
-                <node concept="3clFbJ" id="3sWKo0Ehf2S" role="3cqZAp">
-                  <node concept="3clFbS" id="3sWKo0Ehf2U" role="3clFbx">
-                    <node concept="3cpWs8" id="3sWKo0EemRl" role="3cqZAp">
-                      <node concept="3cpWsn" id="3sWKo0EemRm" role="3cpWs9">
-                        <property role="TrG5h" value="memberComparison" />
-                        <node concept="10Oyi0" id="3sWKo0EelS7" role="1tU5fm" />
-                        <node concept="2YIFZM" id="5wcxmW8D6tR" role="33vP2m">
-                          <ref role="37wK5l" to="dj6k:36hsHVf8gwW" resolve="compare" />
-                          <ref role="1Pybhc" to="dj6k:36hsHVf8gww" resolve="OH" />
-                          <node concept="37vLTw" id="5wcxmW8D6tS" role="37wK5m">
-                            <ref role="3cqZAo" node="3sWKo0Ehgvv" resolve="thisValue" />
-                          </node>
-                          <node concept="37vLTw" id="5wcxmW8D6tT" role="37wK5m">
-                            <ref role="3cqZAo" node="3sWKo0EhokR" resolve="otherValue" />
-                          </node>
-                        </node>
-                      </node>
+                <node concept="2S7cBI" id="5F22zinHxmR" role="2OqNvi">
+                  <node concept="1bVj0M" id="5F22zinHxmX" role="23t8la">
+                    <node concept="gl6BB" id="5F22zinHxmZ" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="5F22zinHxn0" role="1tU5fm" />
                     </node>
-                    <node concept="3clFbJ" id="3sWKo0EdByc" role="3cqZAp">
-                      <node concept="3y3z36" id="3sWKo0EexLt" role="3clFbw">
-                        <node concept="3cmrfG" id="3sWKo0Eeymq" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="37vLTw" id="3sWKo0EemR_" role="3uHU7B">
-                          <ref role="3cqZAo" node="3sWKo0EemRm" resolve="memberComparison" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="3sWKo0EdBye" role="3clFbx">
-                        <node concept="3cpWs6" id="3sWKo0Ee$89" role="3cqZAp">
-                          <node concept="37vLTw" id="3sWKo0EeA9_" role="3cqZAk">
-                            <ref role="3cqZAo" node="3sWKo0EemRm" resolve="memberComparison" />
-                          </node>
+                    <node concept="3clFbS" id="5F22zinHxn1" role="1bW5cS">
+                      <node concept="3clFbF" id="5F22zinHxn2" role="3cqZAp">
+                        <node concept="37vLTw" id="5F22zinHxn4" role="3clFbG">
+                          <ref role="3cqZAo" node="5F22zinHxmZ" resolve="it" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="1Wc70l" id="3sWKo0EhJlK" role="3clFbw">
-                    <node concept="3y3z36" id="3sWKo0EhMjI" role="3uHU7w">
-                      <node concept="10Nm6u" id="3sWKo0EhNMg" role="3uHU7w" />
-                      <node concept="37vLTw" id="3sWKo0EhKMn" role="3uHU7B">
-                        <ref role="3cqZAo" node="3sWKo0EhokR" resolve="otherValue" />
-                      </node>
-                    </node>
-                    <node concept="3y3z36" id="3sWKo0EhHgZ" role="3uHU7B">
-                      <node concept="37vLTw" id="3sWKo0EhFKA" role="3uHU7B">
-                        <ref role="3cqZAo" node="3sWKo0Ehgvv" resolve="thisValue" />
-                      </node>
-                      <node concept="10Nm6u" id="3sWKo0EhHTm" role="3uHU7w" />
-                    </node>
+                  <node concept="1nlBCl" id="5F22zinHxn5" role="2S7zOq">
+                    <property role="3clFbU" value="true" />
                   </node>
-                </node>
-                <node concept="3clFbH" id="3sWKo0EpnvA" role="3cqZAp" />
-              </node>
-              <node concept="3cpWsn" id="3sWKo0EpnvC" role="1Duv9x">
-                <property role="TrG5h" value="comparisonOrder" />
-                <node concept="3Tqbb2" id="3sWKo0Epvgp" role="1tU5fm">
-                  <ref role="ehGHo" to="yv47:3sWKo0E1oB0" resolve="RecordComparisonOrder" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="3sWKo0EpqFn" role="1DdaDG">
-                <node concept="1PxgMI" id="3sWKo0EpqFo" role="2Oq$k0">
-                  <property role="1BlNFB" value="true" />
-                  <node concept="chp4Y" id="3sWKo0EpqFp" role="3oSUPX">
-                    <ref role="cht4Q" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
-                  </node>
-                  <node concept="37vLTw" id="3sWKo0EpqFq" role="1m5AlR">
-                    <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+              <node concept="3clFbS" id="5F22zinHxn6" role="2LFqv$">
+                <node concept="3cpWs8" id="5F22zinHxn7" role="3cqZAp">
+                  <node concept="3cpWsn" id="5F22zinHxna" role="3cpWs9">
+                    <property role="TrG5h" value="memberComparison" />
+                    <node concept="10Oyi0" id="5F22zinHxnc" role="1tU5fm" />
+                    <node concept="1rXfSq" id="5F22zinHxnd" role="33vP2m">
+                      <ref role="37wK5l" node="5F22zinBqFz" resolve="compareMemberValues" />
+                      <node concept="2OqwBi" id="5F22zinHxne" role="37wK5m">
+                        <node concept="Xjq3P" id="5F22zinHxnh" role="2Oq$k0" />
+                        <node concept="liA8E" id="5F22zinHxni" role="2OqNvi">
+                          <ref role="37wK5l" node="7_$HJtBvdxi" resolve="getValueByName" />
+                          <node concept="37vLTw" id="5F22zinHxnj" role="37wK5m">
+                            <ref role="3cqZAo" node="5F22zinHxmy" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5F22zinHxnk" role="37wK5m">
+                        <node concept="37vLTw" id="5F22zinHxnn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3sWKo0Ed1L4" resolve="value" />
+                        </node>
+                        <node concept="liA8E" id="5F22zinHxno" role="2OqNvi">
+                          <ref role="37wK5l" node="7_$HJtBvdxi" resolve="getValueByName" />
+                          <node concept="37vLTw" id="5F22zinHxnp" role="37wK5m">
+                            <ref role="3cqZAo" node="5F22zinHxmy" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
-                <node concept="3Tsc0h" id="3sWKo0EpqFr" role="2OqNvi">
-                  <ref role="3TtcxE" to="yv47:6vUyz1z4RZG" resolve="comparisonOrder" />
+                <node concept="3clFbJ" id="5F22zinHxnq" role="3cqZAp">
+                  <node concept="3y3z36" id="5F22zinHxnt" role="3clFbw">
+                    <node concept="37vLTw" id="5F22zinHxnw" role="3uHU7B">
+                      <ref role="3cqZAo" node="5F22zinHxna" resolve="memberComparison" />
+                    </node>
+                    <node concept="3cmrfG" id="5F22zinHxnx" role="3uHU7w">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="5F22zinHxny" role="3clFbx">
+                    <node concept="3cpWs6" id="5F22zinHxnz" role="3cqZAp">
+                      <node concept="37vLTw" id="5F22zinHxn$" role="3cqZAk">
+                        <ref role="3cqZAo" node="5F22zinHxna" resolve="memberComparison" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="7k6A8WfxY0W" role="3clFbw">
-            <node concept="2OqwBi" id="7k6A8WfxQxy" role="2Oq$k0">
-              <node concept="1PxgMI" id="7k6A8WfxKFt" role="2Oq$k0">
-                <property role="1BlNFB" value="true" />
-                <node concept="chp4Y" id="7k6A8WfxNsN" role="3oSUPX">
-                  <ref role="cht4Q" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
-                </node>
-                <node concept="37vLTw" id="7k6A8WfxDdY" role="1m5AlR">
-                  <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
-                </node>
-              </node>
-              <node concept="3Tsc0h" id="7k6A8WfxUeN" role="2OqNvi">
-                <ref role="3TtcxE" to="yv47:6vUyz1z4RZG" resolve="comparisonOrder" />
-              </node>
+          <node concept="3clFbC" id="5F22zinHxm2" role="3clFbw">
+            <node concept="37vLTw" id="5F22zinHxm5" role="3uHU7B">
+              <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
             </node>
-            <node concept="3GX2aA" id="7k6A8Wfy2V8" role="2OqNvi" />
+            <node concept="10Nm6u" id="5F22zinHxm6" role="3uHU7w" />
           </node>
           <node concept="9aQIb" id="7k6A8WfycpM" role="9aQIa">
             <node concept="3clFbS" id="7k6A8WfycpN" role="9aQI4">
@@ -1246,91 +1270,49 @@
                 <node concept="3clFbS" id="7k6A8Wfyf44" role="2LFqv$">
                   <node concept="3cpWs8" id="7k6A8Wfyf45" role="3cqZAp">
                     <node concept="3cpWsn" id="7k6A8Wfyf46" role="3cpWs9">
-                      <property role="TrG5h" value="thisValue" />
-                      <node concept="3uibUv" id="7k6A8Wfyf47" role="1tU5fm">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
+                      <property role="TrG5h" value="memberComparison" />
+                      <node concept="10Oyi0" id="5F22zinHxoD" role="1tU5fm" />
                       <node concept="1rXfSq" id="7k6A8Wfyf48" role="33vP2m">
-                        <ref role="37wK5l" node="7D7uZV2yb7j" resolve="getValueForPath" />
-                        <node concept="37vLTw" id="7k6A8WfyOIV" role="37wK5m">
-                          <ref role="3cqZAo" node="7k6A8Wfyf4M" resolve="member" />
+                        <ref role="37wK5l" node="5F22zinBqFz" resolve="compareMemberValues" />
+                        <node concept="1rXfSq" id="5F22zinHxoE" role="37wK5m">
+                          <ref role="37wK5l" node="7D7uZV2yb7j" resolve="getValueForPath" />
+                          <node concept="37vLTw" id="5F22zinHxoF" role="37wK5m">
+                            <ref role="3cqZAo" node="7k6A8Wfyf4M" resolve="member" />
+                          </node>
                         </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="7k6A8Wfyf4c" role="3cqZAp">
-                    <node concept="3cpWsn" id="7k6A8Wfyf4d" role="3cpWs9">
-                      <property role="TrG5h" value="otherValue" />
-                      <node concept="3uibUv" id="7k6A8Wfyf4e" role="1tU5fm">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
-                      <node concept="2OqwBi" id="7k6A8Wfyf4f" role="33vP2m">
-                        <node concept="37vLTw" id="7k6A8Wfyf4g" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3sWKo0Ed1L4" resolve="value" />
-                        </node>
-                        <node concept="liA8E" id="7k6A8Wfyf4h" role="2OqNvi">
-                          <ref role="37wK5l" node="7_$HJtBvdxi" resolve="getValueByName" />
-                          <node concept="2OqwBi" id="7k6A8Wfyf4i" role="37wK5m">
-                            <node concept="37vLTw" id="7k6A8Wfyf4j" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7k6A8Wfyf4M" resolve="member" />
-                            </node>
-                            <node concept="3TrcHB" id="7k6A8WfyZcZ" role="2OqNvi">
-                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        <node concept="2OqwBi" id="5F22zinHxoG" role="37wK5m">
+                          <node concept="37vLTw" id="5F22zinHxoJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3sWKo0Ed1L4" resolve="value" />
+                          </node>
+                          <node concept="liA8E" id="5F22zinHxoK" role="2OqNvi">
+                            <ref role="37wK5l" node="7_$HJtBvdxi" resolve="getValueByName" />
+                            <node concept="2OqwBi" id="5F22zinHxoL" role="37wK5m">
+                              <node concept="37vLTw" id="5F22zinHxoO" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7k6A8Wfyf4M" resolve="member" />
+                              </node>
+                              <node concept="3TrcHB" id="5F22zinHxoP" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbH" id="7k6A8Wfyf4l" role="3cqZAp" />
-                  <node concept="3clFbJ" id="7k6A8Wfyf4m" role="3cqZAp">
-                    <node concept="3clFbS" id="7k6A8Wfyf4n" role="3clFbx">
-                      <node concept="3cpWs8" id="7k6A8Wfyf4o" role="3cqZAp">
-                        <node concept="3cpWsn" id="7k6A8Wfyf4p" role="3cpWs9">
-                          <property role="TrG5h" value="memberComparison" />
-                          <node concept="10Oyi0" id="7k6A8Wfyf4q" role="1tU5fm" />
-                          <node concept="2YIFZM" id="5wcxmW8CDdT" role="33vP2m">
-                            <ref role="37wK5l" to="dj6k:36hsHVf8gwW" resolve="compare" />
-                            <ref role="1Pybhc" to="dj6k:36hsHVf8gww" resolve="OH" />
-                            <node concept="37vLTw" id="5wcxmW8CI0V" role="37wK5m">
-                              <ref role="3cqZAo" node="7k6A8Wfyf46" resolve="thisValue" />
-                            </node>
-                            <node concept="37vLTw" id="5wcxmW8CN3O" role="37wK5m">
-                              <ref role="3cqZAo" node="7k6A8Wfyf4d" resolve="otherValue" />
-                            </node>
-                          </node>
-                        </node>
+                  <node concept="3clFbJ" id="5F22zinHxoQ" role="3cqZAp">
+                    <node concept="3y3z36" id="5F22zinHxoT" role="3clFbw">
+                      <node concept="37vLTw" id="5F22zinHxoW" role="3uHU7B">
+                        <ref role="3cqZAo" node="7k6A8Wfyf46" resolve="memberComparison" />
                       </node>
-                      <node concept="3clFbJ" id="7k6A8Wfyf4z" role="3cqZAp">
-                        <node concept="3y3z36" id="7k6A8Wfyf4$" role="3clFbw">
-                          <node concept="3cmrfG" id="7k6A8Wfyf4_" role="3uHU7w">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="37vLTw" id="7k6A8Wfyf4A" role="3uHU7B">
-                            <ref role="3cqZAo" node="7k6A8Wfyf4p" resolve="memberComparison" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="7k6A8Wfyf4B" role="3clFbx">
-                          <node concept="3cpWs6" id="7k6A8Wfyf4C" role="3cqZAp">
-                            <node concept="37vLTw" id="7k6A8Wfyf4D" role="3cqZAk">
-                              <ref role="3cqZAo" node="7k6A8Wfyf4p" resolve="memberComparison" />
-                            </node>
-                          </node>
-                        </node>
+                      <node concept="3cmrfG" id="5F22zinHxoX" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
                       </node>
                     </node>
-                    <node concept="1Wc70l" id="7k6A8Wfyf4E" role="3clFbw">
-                      <node concept="3y3z36" id="7k6A8Wfyf4F" role="3uHU7w">
-                        <node concept="10Nm6u" id="7k6A8Wfyf4G" role="3uHU7w" />
-                        <node concept="37vLTw" id="7k6A8Wfyf4H" role="3uHU7B">
-                          <ref role="3cqZAo" node="7k6A8Wfyf4d" resolve="otherValue" />
+                    <node concept="3clFbS" id="5F22zinHxoY" role="3clFbx">
+                      <node concept="3cpWs6" id="5F22zinHxoZ" role="3cqZAp">
+                        <node concept="37vLTw" id="5F22zinHxp0" role="3cqZAk">
+                          <ref role="3cqZAo" node="7k6A8Wfyf46" resolve="memberComparison" />
                         </node>
-                      </node>
-                      <node concept="3y3z36" id="7k6A8Wfyf4I" role="3uHU7B">
-                        <node concept="37vLTw" id="7k6A8Wfyf4J" role="3uHU7B">
-                          <ref role="3cqZAo" node="7k6A8Wfyf46" resolve="thisValue" />
-                        </node>
-                        <node concept="10Nm6u" id="7k6A8Wfyf4K" role="3uHU7w" />
                       </node>
                     </node>
                   </node>
@@ -1358,6 +1340,104 @@
               </node>
             </node>
           </node>
+          <node concept="3eNFk2" id="5F22zinHxn_" role="3eNLev">
+            <node concept="2OqwBi" id="5F22zinHxnC" role="3eO9$A">
+              <node concept="2OqwBi" id="5F22zinHxnF" role="2Oq$k0">
+                <node concept="1PxgMI" id="5F22zinHxnI" role="2Oq$k0">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="37vLTw" id="5F22zinHxnL" role="1m5AlR">
+                    <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+                  </node>
+                  <node concept="chp4Y" id="5F22zinHxnM" role="3oSUPX">
+                    <ref role="cht4Q" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="5F22zinHxnN" role="2OqNvi">
+                  <ref role="3TtcxE" to="yv47:6vUyz1z4RZG" resolve="comparisonOrder" />
+                </node>
+              </node>
+              <node concept="3GX2aA" id="5F22zinHxnO" role="2OqNvi" />
+            </node>
+            <node concept="3clFbS" id="5F22zinHxnP" role="3eOfB_">
+              <node concept="1DcWWT" id="5F22zinHxnQ" role="3cqZAp">
+                <node concept="3cpWsn" id="5F22zinHxnU" role="1Duv9x">
+                  <property role="TrG5h" value="comparisonOrder" />
+                  <node concept="3Tqbb2" id="5F22zinHxnW" role="1tU5fm">
+                    <ref role="ehGHo" to="yv47:3sWKo0E1oB0" resolve="RecordComparisonOrder" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5F22zinHxnX" role="1DdaDG">
+                  <node concept="1PxgMI" id="5F22zinHxo0" role="2Oq$k0">
+                    <property role="1BlNFB" value="true" />
+                    <node concept="37vLTw" id="5F22zinHxo3" role="1m5AlR">
+                      <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+                    </node>
+                    <node concept="chp4Y" id="5F22zinHxo4" role="3oSUPX">
+                      <ref role="cht4Q" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5F22zinHxo5" role="2OqNvi">
+                    <ref role="3TtcxE" to="yv47:6vUyz1z4RZG" resolve="comparisonOrder" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5F22zinHxo6" role="2LFqv$">
+                  <node concept="3cpWs8" id="5F22zinHxo7" role="3cqZAp">
+                    <node concept="3cpWsn" id="5F22zinHxoa" role="3cpWs9">
+                      <property role="TrG5h" value="memberComparison" />
+                      <node concept="10Oyi0" id="5F22zinHxoc" role="1tU5fm" />
+                      <node concept="1rXfSq" id="5F22zinHxod" role="33vP2m">
+                        <ref role="37wK5l" node="5F22zinBqFz" resolve="compareMemberValues" />
+                        <node concept="1rXfSq" id="5F22zinHxoe" role="37wK5m">
+                          <ref role="37wK5l" node="7D7uZV2yb7j" resolve="getValueForPath" />
+                          <node concept="2OqwBi" id="5F22zinHxof" role="37wK5m">
+                            <node concept="37vLTw" id="5F22zinHxoi" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5F22zinHxnU" resolve="comparisonOrder" />
+                            </node>
+                            <node concept="3TrEf2" id="5F22zinHxoj" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:3sWKo0E1oB1" resolve="member" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5F22zinHxok" role="37wK5m">
+                          <node concept="37vLTw" id="5F22zinHxon" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3sWKo0Ed1L4" resolve="value" />
+                          </node>
+                          <node concept="liA8E" id="5F22zinHxoo" role="2OqNvi">
+                            <ref role="37wK5l" node="7D7uZV2yb7j" resolve="getValueForPath" />
+                            <node concept="2OqwBi" id="5F22zinHxop" role="37wK5m">
+                              <node concept="37vLTw" id="5F22zinHxos" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5F22zinHxnU" resolve="comparisonOrder" />
+                              </node>
+                              <node concept="3TrEf2" id="5F22zinHxot" role="2OqNvi">
+                                <ref role="3Tt5mk" to="yv47:3sWKo0E1oB1" resolve="member" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="5F22zinHxou" role="3cqZAp">
+                    <node concept="3y3z36" id="5F22zinHxox" role="3clFbw">
+                      <node concept="37vLTw" id="5F22zinHxo$" role="3uHU7B">
+                        <ref role="3cqZAo" node="5F22zinHxoa" resolve="memberComparison" />
+                      </node>
+                      <node concept="3cmrfG" id="5F22zinHxo_" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="5F22zinHxoA" role="3clFbx">
+                      <node concept="3cpWs6" id="5F22zinHxoB" role="3cqZAp">
+                        <node concept="37vLTw" id="5F22zinHxoC" role="3cqZAk">
+                          <ref role="3cqZAo" node="5F22zinHxoa" resolve="memberComparison" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="3cpWs6" id="3sWKo0EdDJv" role="3cqZAp">
           <node concept="3cmrfG" id="3sWKo0EdEj6" role="3cqZAk">
@@ -1367,6 +1447,148 @@
       </node>
       <node concept="2AHcQZ" id="3sWKo0Ed1L8" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2YIFZL" id="5F22zinBqFz" role="jymVt">
+      <property role="TrG5h" value="compareMemberValues" />
+      <node concept="3Tm6S6" id="5F22zinBqFB" role="1B3o_S" />
+      <node concept="10Oyi0" id="5F22zinBqFC" role="3clF45" />
+      <node concept="37vLTG" id="5F22zinBqFD" role="3clF46">
+        <property role="TrG5h" value="thisValue" />
+        <node concept="3uibUv" id="5F22zinBqFF" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5F22zinBqFG" role="3clF46">
+        <property role="TrG5h" value="otherValue" />
+        <node concept="3uibUv" id="5F22zinBqFI" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5F22zinBqFJ" role="3clF47">
+        <node concept="3SKdUt" id="5F22zinBqFK" role="3cqZAp">
+          <node concept="1PaTwC" id="5F22zinBqFO" role="1aUNEU">
+            <node concept="3oM_SD" id="5F22zinBqFQ" role="1PaTwD">
+              <property role="3oM_SC" value="A" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFR" role="1PaTwD">
+              <property role="3oM_SC" value="member" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFS" role="1PaTwD">
+              <property role="3oM_SC" value="without" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFT" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFU" role="1PaTwD">
+              <property role="3oM_SC" value="value" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFV" role="1PaTwD">
+              <property role="3oM_SC" value="sorts" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFW" role="1PaTwD">
+              <property role="3oM_SC" value="before" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFX" role="1PaTwD">
+              <property role="3oM_SC" value="one" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFY" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqFZ" role="1PaTwD">
+              <property role="3oM_SC" value="has" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG0" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG1" role="1PaTwD">
+              <property role="3oM_SC" value="value," />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG2" role="1PaTwD">
+              <property role="3oM_SC" value="so" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG3" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG4" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG5" role="1PaTwD">
+              <property role="3oM_SC" value="order" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG6" role="1PaTwD">
+              <property role="3oM_SC" value="stays" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinBqG7" role="1PaTwD">
+              <property role="3oM_SC" value="transitive." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5F22zinBqG8" role="3cqZAp">
+          <node concept="1Wc70l" id="5F22zinBqGb" role="3clFbw">
+            <node concept="3clFbC" id="5F22zinBqGe" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinBqGh" role="3uHU7B">
+                <ref role="3cqZAo" node="5F22zinBqFD" resolve="thisValue" />
+              </node>
+              <node concept="10Nm6u" id="5F22zinBqGi" role="3uHU7w" />
+            </node>
+            <node concept="3clFbC" id="5F22zinBqGj" role="3uHU7w">
+              <node concept="37vLTw" id="5F22zinBqGm" role="3uHU7B">
+                <ref role="3cqZAo" node="5F22zinBqFG" resolve="otherValue" />
+              </node>
+              <node concept="10Nm6u" id="5F22zinBqGn" role="3uHU7w" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5F22zinBqGo" role="3clFbx">
+            <node concept="3cpWs6" id="5F22zinBqGp" role="3cqZAp">
+              <node concept="3cmrfG" id="5F22zinBqGq" role="3cqZAk">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5F22zinBqGr" role="3cqZAp">
+          <node concept="3clFbC" id="5F22zinBqGu" role="3clFbw">
+            <node concept="37vLTw" id="5F22zinBqGx" role="3uHU7B">
+              <ref role="3cqZAo" node="5F22zinBqFD" resolve="thisValue" />
+            </node>
+            <node concept="10Nm6u" id="5F22zinBqGy" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5F22zinBqGz" role="3clFbx">
+            <node concept="3cpWs6" id="5F22zinBqG$" role="3cqZAp">
+              <node concept="3cmrfG" id="5F22zinBqG_" role="3cqZAk">
+                <property role="3cmrfH" value="-1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5F22zinBqGA" role="3cqZAp">
+          <node concept="3clFbC" id="5F22zinBqGD" role="3clFbw">
+            <node concept="37vLTw" id="5F22zinBqGG" role="3uHU7B">
+              <ref role="3cqZAo" node="5F22zinBqFG" resolve="otherValue" />
+            </node>
+            <node concept="10Nm6u" id="5F22zinBqGH" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5F22zinBqGI" role="3clFbx">
+            <node concept="3cpWs6" id="5F22zinBqGJ" role="3cqZAp">
+              <node concept="3cmrfG" id="5F22zinBqGK" role="3cqZAk">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinBqGL" role="3cqZAp">
+          <node concept="2YIFZM" id="5F22zinBqGN" role="3clFbG">
+            <ref role="1Pybhc" to="dj6k:36hsHVf8gww" resolve="OH" />
+            <ref role="37wK5l" to="dj6k:36hsHVf8gwW" resolve="compare" />
+            <node concept="37vLTw" id="5F22zinBqGO" role="37wK5m">
+              <ref role="3cqZAo" node="5F22zinBqFD" resolve="thisValue" />
+            </node>
+            <node concept="37vLTw" id="5F22zinBqGP" role="37wK5m">
+              <ref role="3cqZAo" node="5F22zinBqFG" resolve="otherValue" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.records@tests.mps
@@ -9,6 +9,7 @@
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
   </languages>
   <imports>
     <import index="pq1l" ref="r:93cd1fe8-b296-405c-a6e6-040c940ccfa1(org.iets3.core.expr.toplevel.plugin)" />
@@ -49,8 +50,12 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -63,6 +68,7 @@
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -77,6 +83,8 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -84,6 +92,13 @@
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
     </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
@@ -142,6 +157,12 @@
         <child id="8427750732757990724" name="expected" index="3tpDZB" />
       </concept>
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -149,6 +170,14 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
   </registry>
@@ -479,6 +508,733 @@
             </node>
             <node concept="liA8E" id="4Ab6HDmuLbY" role="2OqNvi">
               <ref role="37wK5l" to="pq1l:7D7uZV2w7Jt" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="5F22zinA07W" role="1SL9yI">
+      <property role="TrG5h" value="equalsIsNullSafeForNullMemberValues" />
+      <node concept="3cqZAl" id="5F22zinA07Z" role="3clF45" />
+      <node concept="3clFbS" id="5F22zinA080" role="3clF47">
+        <node concept="3cpWs8" id="5F22zinA081" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA084" role="3cpWs9">
+            <property role="TrG5h" value="withNull" />
+            <node concept="3uibUv" id="5F22zinA086" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA087" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA089" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="3xONca" id="5F22zinA08a" role="37wK5m">
+                  <ref role="3xOPvv" node="4Ab6HDmungh" resolve="r" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA08b" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA08d" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA08g" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA084" resolve="withNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA08h" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA08i" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA08j" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA08k" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA08m" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA08p" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA084" resolve="withNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA08q" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA08r" role="37wK5m">
+                <property role="Xl_RC" value="y" />
+              </node>
+              <node concept="10Nm6u" id="5F22zinA08s" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA08t" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA08w" role="3cpWs9">
+            <property role="TrG5h" value="withValue" />
+            <node concept="3uibUv" id="5F22zinA08y" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA08z" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA08_" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="3xONca" id="5F22zinA08A" role="37wK5m">
+                  <ref role="3xOPvv" node="4Ab6HDmungh" resolve="r" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA08B" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA08D" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA08G" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA08w" resolve="withValue" />
+            </node>
+            <node concept="liA8E" id="5F22zinA08H" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA08I" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA08J" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA08K" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA08M" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA08P" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA08w" resolve="withValue" />
+            </node>
+            <node concept="liA8E" id="5F22zinA08Q" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA08R" role="37wK5m">
+                <property role="Xl_RC" value="y" />
+              </node>
+              <node concept="3cmrfG" id="5F22zinA08S" role="37wK5m">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA08T" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA08W" role="3cpWs9">
+            <property role="TrG5h" value="alsoWithNull" />
+            <node concept="3uibUv" id="5F22zinA08Y" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA08Z" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA091" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="3xONca" id="5F22zinA092" role="37wK5m">
+                  <ref role="3xOPvv" node="4Ab6HDmungh" resolve="r" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA093" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA095" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA098" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA08W" resolve="alsoWithNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA099" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA09a" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA09b" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA09c" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA09e" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA09h" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA08W" resolve="alsoWithNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA09i" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA09j" role="37wK5m">
+                <property role="Xl_RC" value="y" />
+              </node>
+              <node concept="10Nm6u" id="5F22zinA09k" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="5F22zinA09l" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA09n" role="3vFALc">
+            <node concept="37vLTw" id="5F22zinA09q" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA084" resolve="withNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA09r" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7fOaqhi3UmU" resolve="equals" />
+              <node concept="37vLTw" id="5F22zinA09s" role="37wK5m">
+                <ref role="3cqZAo" node="5F22zinA08w" resolve="withValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="5F22zinA09t" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA09v" role="3vFALc">
+            <node concept="37vLTw" id="5F22zinA09y" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA08w" resolve="withValue" />
+            </node>
+            <node concept="liA8E" id="5F22zinA09z" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7fOaqhi3UmU" resolve="equals" />
+              <node concept="37vLTw" id="5F22zinA09$" role="37wK5m">
+                <ref role="3cqZAo" node="5F22zinA084" resolve="withNull" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA09_" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA09B" role="3vwVQn">
+            <node concept="37vLTw" id="5F22zinA09E" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA084" resolve="withNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA09F" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7fOaqhi3UmU" resolve="equals" />
+              <node concept="37vLTw" id="5F22zinA09G" role="37wK5m">
+                <ref role="3cqZAo" node="5F22zinA08W" resolve="alsoWithNull" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="5F22zinA09H" role="1SL9yI">
+      <property role="TrG5h" value="compareToWorksWithoutRecordDeclaration" />
+      <node concept="3cqZAl" id="5F22zinA09K" role="3clF45" />
+      <node concept="3clFbS" id="5F22zinA09L" role="3clF47">
+        <node concept="3cpWs8" id="5F22zinA09M" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA09P" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3uibUv" id="5F22zinA09R" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA09S" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA09U" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="10Nm6u" id="5F22zinA09V" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA09W" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA09Y" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0a1" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA09P" resolve="a" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0a2" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0a3" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0a4" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA0a5" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA0a8" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3uibUv" id="5F22zinA0aa" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA0ab" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA0ad" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="10Nm6u" id="5F22zinA0ae" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0af" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0ah" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0ak" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0a8" resolve="b" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0al" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0am" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0an" role="37wK5m">
+                <property role="Xl_RC" value="B" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0ao" role="3cqZAp">
+          <node concept="3eOVzh" id="5F22zinA0aq" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0at" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0aw" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA09P" resolve="a" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0ax" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0ay" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0a8" resolve="b" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0az" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0a$" role="3cqZAp">
+          <node concept="3eOSWO" id="5F22zinA0aA" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0aD" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0aG" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0a8" resolve="b" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0aH" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0aI" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA09P" resolve="a" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0aJ" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0aK" role="3cqZAp">
+          <node concept="3clFbC" id="5F22zinA0aM" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0aP" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0aS" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA09P" resolve="a" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0aT" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0aU" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA09P" resolve="a" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0aV" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA0aW" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA0aZ" role="3cpWs9">
+            <property role="TrG5h" value="justX" />
+            <node concept="3uibUv" id="5F22zinA0b1" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA0b2" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA0b4" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="10Nm6u" id="5F22zinA0b5" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0b6" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0b8" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0bb" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0aZ" resolve="justX" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0bc" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0bd" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0be" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA0bf" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA0bi" role="3cpWs9">
+            <property role="TrG5h" value="xAndZ" />
+            <node concept="3uibUv" id="5F22zinA0bk" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA0bl" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA0bn" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="10Nm6u" id="5F22zinA0bo" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0bp" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0br" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0bu" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0bi" resolve="xAndZ" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0bv" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0bw" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0bx" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0by" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0b$" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0bB" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0bi" resolve="xAndZ" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0bC" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0bD" role="37wK5m">
+                <property role="Xl_RC" value="z" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0bE" role="37wK5m">
+                <property role="Xl_RC" value="Q" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0bF" role="3cqZAp">
+          <node concept="3eOVzh" id="5F22zinA0bH" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0bK" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0bN" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0aZ" resolve="justX" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0bO" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0bP" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0bi" resolve="xAndZ" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0bQ" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0bR" role="3cqZAp">
+          <node concept="3eOSWO" id="5F22zinA0bT" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0bW" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0bZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0bi" resolve="xAndZ" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0c0" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0c1" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0aZ" resolve="justX" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0c2" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="5F22zinA0c3" role="1SL9yI">
+      <property role="TrG5h" value="compareToOrdersNullMemberValuesConsistently" />
+      <node concept="3cqZAl" id="5F22zinA0c6" role="3clF45" />
+      <node concept="3clFbS" id="5F22zinA0c7" role="3clF47">
+        <node concept="3cpWs8" id="5F22zinA0c8" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA0cb" role="3cpWs9">
+            <property role="TrG5h" value="withNull" />
+            <node concept="3uibUv" id="5F22zinA0cd" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA0ce" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA0cg" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="3xONca" id="5F22zinA0ch" role="37wK5m">
+                  <ref role="3xOPvv" node="4Ab6HDmungh" resolve="r" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0ci" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0ck" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0cn" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0cb" resolve="withNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0co" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0cp" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0cq" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0cr" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0ct" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0cw" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0cb" resolve="withNull" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0cx" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0cy" role="37wK5m">
+                <property role="Xl_RC" value="y" />
+              </node>
+              <node concept="10Nm6u" id="5F22zinA0cz" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA0c$" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA0cB" role="3cpWs9">
+            <property role="TrG5h" value="one" />
+            <node concept="3uibUv" id="5F22zinA0cD" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA0cE" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA0cG" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="3xONca" id="5F22zinA0cH" role="37wK5m">
+                  <ref role="3xOPvv" node="4Ab6HDmungh" resolve="r" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0cI" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0cK" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0cN" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0cB" resolve="one" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0cO" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0cP" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0cQ" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0cR" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0cT" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0cW" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0cB" resolve="one" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0cX" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0cY" role="37wK5m">
+                <property role="Xl_RC" value="y" />
+              </node>
+              <node concept="3cmrfG" id="5F22zinA0cZ" role="37wK5m">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5F22zinA0d0" role="3cqZAp">
+          <node concept="3cpWsn" id="5F22zinA0d3" role="3cpWs9">
+            <property role="TrG5h" value="two" />
+            <node concept="3uibUv" id="5F22zinA0d5" role="1tU5fm">
+              <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+            </node>
+            <node concept="2ShNRf" id="5F22zinA0d6" role="33vP2m">
+              <node concept="1pGfFk" id="5F22zinA0d8" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="pq1l:7$ajNzjzTau" resolve="RecordValue" />
+                <node concept="3xONca" id="5F22zinA0d9" role="37wK5m">
+                  <ref role="3xOPvv" node="4Ab6HDmungh" resolve="r" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0da" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0dc" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0df" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0d3" resolve="two" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0dg" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0dh" role="37wK5m">
+                <property role="Xl_RC" value="x" />
+              </node>
+              <node concept="Xl_RD" id="5F22zinA0di" role="37wK5m">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5F22zinA0dj" role="3cqZAp">
+          <node concept="2OqwBi" id="5F22zinA0dl" role="3clFbG">
+            <node concept="37vLTw" id="5F22zinA0do" role="2Oq$k0">
+              <ref role="3cqZAo" node="5F22zinA0d3" resolve="two" />
+            </node>
+            <node concept="liA8E" id="5F22zinA0dp" role="2OqNvi">
+              <ref role="37wK5l" to="pq1l:7D7uZV2yclI" resolve="add" />
+              <node concept="Xl_RD" id="5F22zinA0dq" role="37wK5m">
+                <property role="Xl_RC" value="y" />
+              </node>
+              <node concept="3cmrfG" id="5F22zinA0dr" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="5F22zinA0ds" role="3cqZAp">
+          <node concept="1PaTwC" id="5F22zinA0dw" role="1aUNEU">
+            <node concept="3oM_SD" id="5F22zinA0dy" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dz" role="1PaTwD">
+              <property role="3oM_SC" value="null" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0d$" role="1PaTwD">
+              <property role="3oM_SC" value="member" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0d_" role="1PaTwD">
+              <property role="3oM_SC" value="value" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dA" role="1PaTwD">
+              <property role="3oM_SC" value="sorts" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dB" role="1PaTwD">
+              <property role="3oM_SC" value="before" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dC" role="1PaTwD">
+              <property role="3oM_SC" value="any" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dD" role="1PaTwD">
+              <property role="3oM_SC" value="present" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dE" role="1PaTwD">
+              <property role="3oM_SC" value="value," />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dF" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dG" role="1PaTwD">
+              <property role="3oM_SC" value="does" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dH" role="1PaTwD">
+              <property role="3oM_SC" value="so" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dI" role="1PaTwD">
+              <property role="3oM_SC" value="consistently," />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="5F22zinA0dJ" role="3cqZAp">
+          <node concept="1PaTwC" id="5F22zinA0dN" role="1aUNEU">
+            <node concept="3oM_SD" id="5F22zinA0dP" role="1PaTwD">
+              <property role="3oM_SC" value="so" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dQ" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dR" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dS" role="1PaTwD">
+              <property role="3oM_SC" value="ordering" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dT" role="1PaTwD">
+              <property role="3oM_SC" value="stays" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dU" role="1PaTwD">
+              <property role="3oM_SC" value="transitive:" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dV" role="1PaTwD">
+              <property role="3oM_SC" value="withNull" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dW" role="1PaTwD">
+              <property role="3oM_SC" value="&lt;" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dX" role="1PaTwD">
+              <property role="3oM_SC" value="one" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dY" role="1PaTwD">
+              <property role="3oM_SC" value="&lt;" />
+            </node>
+            <node concept="3oM_SD" id="5F22zinA0dZ" role="1PaTwD">
+              <property role="3oM_SC" value="two" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0e0" role="3cqZAp">
+          <node concept="3eOVzh" id="5F22zinA0e2" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0e5" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0e8" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0cb" resolve="withNull" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0e9" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0ea" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0cB" resolve="one" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0eb" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0ec" role="3cqZAp">
+          <node concept="3eOSWO" id="5F22zinA0ee" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0eh" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0ek" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0cB" resolve="one" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0el" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0em" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0cb" resolve="withNull" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0en" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0eo" role="3cqZAp">
+          <node concept="3eOVzh" id="5F22zinA0eq" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0et" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0ew" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0cb" resolve="withNull" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0ex" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0ey" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0d3" resolve="two" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0ez" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5F22zinA0e$" role="3cqZAp">
+          <node concept="3eOVzh" id="5F22zinA0eA" role="3vwVQn">
+            <node concept="2OqwBi" id="5F22zinA0eD" role="3uHU7B">
+              <node concept="37vLTw" id="5F22zinA0eG" role="2Oq$k0">
+                <ref role="3cqZAo" node="5F22zinA0cB" resolve="one" />
+              </node>
+              <node concept="liA8E" id="5F22zinA0eH" role="2OqNvi">
+                <ref role="37wK5l" to="pq1l:3sWKo0Ed1L0" resolve="compareTo" />
+                <node concept="37vLTw" id="5F22zinA0eI" role="37wK5m">
+                  <ref role="3cqZAo" node="5F22zinA0d3" resolve="two" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5F22zinA0eJ" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
`RecordValue` (org.iets3.core.expr.toplevel.plugin) threw `NullPointerException` from both `equals` and `compareTo` whenever a record member had no value, and its `equals`/`hashCode`/`compareTo` trio was mutually inconsistent. This fixes all three, with test cases in `test.ts.expr.os.records`.

## What changed

**1. `equals` threw an NPE on null member values** (`7ec5d2e4`)

`!rv.memberData[e.key].equals(e.value)` dereferenced the other record's member value, which is `null` for a member that is present in the map but has no value. Replaced with the null-safe `:ne:` operator, so it generates as `Objects.equals(...)`.

**2. `equals` and `hashCode` disagreed** (`030cab47`)

`hashCode` was `Objects.hash(memberData, recordDeclaration)` while `equals` compared only `memberData`. Two record values with equal members but different record declarations were therefore `equals` with differing hash codes — broken for `HashMap`/`HashSet`. `equals` now compares the record declaration as well.

The declaration is compared by node identity, which is what `IRecordDeclaration.equals` (`thisNode :eq: declaration`) already does for KernelF's own `==`. Since records are nominal, both operands of a well-typed comparison carry the same declaration, so this changes nothing for well-typed programs; it fixes the contract for values that reach a hash-based collection across record types.

**3. `compareTo` threw an NPE, and was not a valid `Comparable`** (`934b968f`)

- *No record declaration.* The interpreter builds `new RecordValue(null)` for inline/projected records. `SLinkOperations.getChildren(null, …)` returns empty, so control fell into the `effectiveMembers()` branch, which returns `null` for a `null` node, and the for-loop NPE'd. Such a record now compares by member name, over the sorted union of both sides' member names.
- *Null member values.* These were skipped entirely, which made the ordering intransitive: `{y:1}` vs `{y:null}` and `{y:null}` vs `{y:2}` both compared equal while `{y:1}` vs `{y:2}` did not — a `TreeSet` of the three held two elements. A new private `compareMemberValues` sorts a member without a value before one that has a value; two present values still go through `OH.compare` unchanged.

The `comparisonOrder` branch is unchanged in intent — it still compares only the declared sort key, which is the feature, so `compareTo == 0` remains deliberately weaker than `equals`.

## Tests

Three test methods added to `RecordValueTest` in `test.ts.expr.os.records`. Against the unfixed code the two `compareTo` tests reproduce the defects — one with the `NullPointerException` at `RecordValue.compareTo`, one with an `AssertionError` because `withNull.compareTo(one)` was `0`:

- `equalsIsNullSafeForNullMemberValues` — regression test for (1)
- `compareToWorksWithoutRecordDeclaration` — inline records: ordering, reflexivity, and differing key sets
- `compareToOrdersNullMemberValuesConsistently` — `withNull < one < two`, i.e. transitivity

All 4 tests in `RecordValueTest` pass, and the existing `records` test case (10 tests) is unaffected.

## For the reviewer

- The KernelF `==` operator uses **neither** method: `EqualsHelper.equals` has its own `RecordValue` branch. `equals`/`hashCode` matter for Java-side collections, `compareTo` for ordering (`OH.compare`, sorting, `TreeSet`/`TreeMap`). So the risk surface here is Java-side, not language semantics.
- Interpreter suites in `test.in.expr.os` that touch record ordering were run: `enums`, `enum_sort`, `EnumsWithValuesOfSortableTypes`, `references`, `records`, `path`, `grouping` pass. `projection` fails, but it fails identically with `compareTo` reverted (same four items, `Type system returned null type for child` and an `invalid null value detected` in `SumOp`) — pre-existing and unrelated.
- Separate finding, not addressed here: `EqualsHelper.equals` returns `false` for two structurally identical inline records, because it invokes the `IRecordDeclaration.equals` behavior method on a `null` node and gets the boolean default back. So `==` between two projected records is always `false`. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)