### PR TITLE
IFunctionLike: ignore commented out code in unique name check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 - Improve uniqueness name check of `IFunctionLike` `getUniquelyNamedElements()` behavior to avoid overzealous checking.
 - Variability: Feature attribute values are not overwritten anymore if the value stays the same. This avoids changing the model if not necessary, esp. it avoids merge conflicts.
+- `IFunctionLike` `getUniquelyNamedElements()` no longer reports duplicate names for commented out code.
 
 ## July 2026
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -2059,68 +2059,85 @@
                         <node concept="3clFbS" id="S0JwotD3AM" role="1bW5cS">
                           <node concept="3clFbF" id="S0JwotD3YQ" role="3cqZAp">
                             <node concept="1Wc70l" id="6qRswmU$vVI" role="3clFbG">
-                              <node concept="1eOMI4" id="6qRswmU$vVJ" role="3uHU7B">
-                                <node concept="22lmx$" id="6qRswmU$vVK" role="1eOMHV">
-                                  <node concept="2OqwBi" id="6qRswmU$vVL" role="3uHU7B">
-                                    <node concept="37vLTw" id="6qRswmU$vVM" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                              <node concept="1Wc70l" id="3HHveKCyMSL" role="3uHU7B">
+                                <node concept="1eOMI4" id="3HHveKCyMSO" role="3uHU7B">
+                                  <node concept="22lmx$" id="3HHveKCyMSQ" role="1eOMHV">
+                                    <node concept="2OqwBi" id="3HHveKCyMST" role="3uHU7B">
+                                      <node concept="37vLTw" id="3HHveKCyMSW" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                      </node>
+                                      <node concept="1mIQ4w" id="3HHveKCyMSX" role="2OqNvi">
+                                        <node concept="chp4Y" id="3HHveKCyMSZ" role="cj9EA">
+                                          <ref role="cht4Q" to="zzzn:49WTic8ix6I" resolve="ValExpression" />
+                                        </node>
+                                      </node>
                                     </node>
-                                    <node concept="1mIQ4w" id="6qRswmU$vVN" role="2OqNvi">
-                                      <node concept="chp4Y" id="6qRswmU$vVO" role="cj9EA">
-                                        <ref role="cht4Q" to="zzzn:49WTic8ix6I" resolve="ValExpression" />
+                                    <node concept="2OqwBi" id="3HHveKCyMT0" role="3uHU7w">
+                                      <node concept="37vLTw" id="3HHveKCyMT3" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                      </node>
+                                      <node concept="1mIQ4w" id="3HHveKCyMT4" role="2OqNvi">
+                                        <node concept="chp4Y" id="3HHveKCyMT6" role="cj9EA">
+                                          <ref role="cht4Q" to="zzzn:1VmWkC0z1FT" resolve="LocalVarDeclExpr" />
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="2OqwBi" id="6qRswmU$vVP" role="3uHU7w">
-                                    <node concept="37vLTw" id="6qRswmU$vVQ" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                </node>
+                                <node concept="1eOMI4" id="3HHveKCyMT7" role="3uHU7w">
+                                  <node concept="22lmx$" id="3HHveKCyMT9" role="1eOMHV">
+                                    <node concept="17R0WA" id="3HHveKCyMTc" role="3uHU7B">
+                                      <node concept="2OqwBi" id="3HHveKCyMTf" role="3uHU7B">
+                                        <node concept="37vLTw" id="3HHveKCyMTi" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                        </node>
+                                        <node concept="2Xjw5R" id="3HHveKCyMTj" role="2OqNvi">
+                                          <node concept="1xMEDy" id="3HHveKCyMTm" role="1xVPHs">
+                                            <node concept="chp4Y" id="3HHveKCyMTo" role="ri$Ld">
+                                              <ref role="cht4Q" to="vs0r:4qSf1u1TQeO" resolve="IContainerOfUniqueNames" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="13iPFW" id="3HHveKCyMTp" role="3uHU7w" />
                                     </node>
-                                    <node concept="1mIQ4w" id="6qRswmU$vVR" role="2OqNvi">
-                                      <node concept="chp4Y" id="6qRswmU$vVS" role="cj9EA">
-                                        <ref role="cht4Q" to="zzzn:1VmWkC0z1FT" resolve="LocalVarDeclExpr" />
+                                    <node concept="17R0WA" id="3HHveKCyMTq" role="3uHU7w">
+                                      <node concept="2OqwBi" id="3HHveKCyMTt" role="3uHU7B">
+                                        <node concept="37vLTw" id="3HHveKCyMTw" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
+                                        </node>
+                                        <node concept="2Xjw5R" id="3HHveKCyMTx" role="2OqNvi">
+                                          <node concept="1xMEDy" id="3HHveKCyMT$" role="1xVPHs">
+                                            <node concept="chp4Y" id="3HHveKCyMTA" role="ri$Ld">
+                                              <ref role="cht4Q" to="vs0r:4qSf1u1TQeO" resolve="IContainerOfUniqueNames" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2OqwBi" id="3HHveKCyMTB" role="3uHU7w">
+                                        <node concept="13iPFW" id="3HHveKCyMTE" role="2Oq$k0" />
+                                        <node concept="3TrEf2" id="3HHveKCyMTF" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="zzzn:49WTic8eSDm" resolve="body" />
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
-                              <node concept="1eOMI4" id="6qRswmURY5Q" role="3uHU7w">
-                                <node concept="22lmx$" id="6qRswmURY5R" role="1eOMHV">
-                                  <node concept="17R0WA" id="7NVitkbLxEI" role="3uHU7B">
-                                    <node concept="2OqwBi" id="6qRswmURY5T" role="3uHU7B">
-                                      <node concept="37vLTw" id="6qRswmURY5U" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
-                                      </node>
-                                      <node concept="2Xjw5R" id="6qRswmURY5V" role="2OqNvi">
-                                        <node concept="1xMEDy" id="6qRswmURY5W" role="1xVPHs">
-                                          <node concept="chp4Y" id="6qRswmURY5X" role="ri$Ld">
-                                            <ref role="cht4Q" to="vs0r:4qSf1u1TQeO" resolve="IContainerOfUniqueNames" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="13iPFW" id="6qRswmURY5Y" role="3uHU7w" />
+                              <node concept="3clFbC" id="3HHveKCyMTG" role="3uHU7w">
+                                <node concept="2OqwBi" id="3HHveKCyMTJ" role="3uHU7B">
+                                  <node concept="37vLTw" id="3HHveKCyMTM" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
                                   </node>
-                                  <node concept="17R0WA" id="7NVitkbLFYP" role="3uHU7w">
-                                    <node concept="2OqwBi" id="6qRswmURY60" role="3uHU7B">
-                                      <node concept="37vLTw" id="6qRswmURY61" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="S0JwotD3AN" resolve="it" />
-                                      </node>
-                                      <node concept="2Xjw5R" id="6qRswmURY62" role="2OqNvi">
-                                        <node concept="1xMEDy" id="6qRswmURY63" role="1xVPHs">
-                                          <node concept="chp4Y" id="6qRswmURY64" role="ri$Ld">
-                                            <ref role="cht4Q" to="vs0r:4qSf1u1TQeO" resolve="IContainerOfUniqueNames" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="2OqwBi" id="6qRswmURY65" role="3uHU7w">
-                                      <node concept="13iPFW" id="6qRswmURY66" role="2Oq$k0" />
-                                      <node concept="3TrEf2" id="6qRswmURY67" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="zzzn:49WTic8eSDm" resolve="body" />
+                                  <node concept="2Xjw5R" id="3HHveKCyMTN" role="2OqNvi">
+                                    <node concept="1xMEDy" id="3HHveKCyMTQ" role="1xVPHs">
+                                      <node concept="chp4Y" id="3HHveKCyMTS" role="ri$Ld">
+                                        <ref role="cht4Q" to="tpck:3Rc6kd0K$RF" resolve="BaseCommentAttribute" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
+                                <node concept="10Nm6u" id="3HHveKCyMTT" role="3uHU7w" />
                               </node>
                             </node>
                           </node>
@@ -2484,7 +2501,7 @@
                                   <node concept="37vLTw" id="3E_uh2joufI" role="2Oq$k0">
                                     <ref role="3cqZAo" node="4z0AnX817a6" resolve="it" />
                                   </node>
-                                  <node concept="3TrEf2" id="3E_uh2jovym" role="2OqNvi">
+                                  <node concept="3TrEf2" id="3HHveKCKkZN" role="2OqNvi">
                                     <ref role="3Tt5mk" to="zzzn:6zmBjqUkwsc" resolve="type" />
                                   </node>
                                 </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -21081,6 +21081,60 @@
         <node concept="_ixoA" id="1VmWkC0D2p9" role="_iOnC" />
       </node>
     </node>
+    <node concept="1qefOq" id="6rLOYi5Sba3" role="1SKRRt">
+      <node concept="_iOnV" id="6rLOYi5SbzP" role="1qenE9">
+        <property role="TrG5h" value="commentedOutUniqueVarNames" />
+        <node concept="1aga60" id="6rLOYi5SbzQ" role="_iOnC">
+          <property role="TrG5h" value="commentedOutNamesAreIgnored" />
+          <node concept="1ahQXy" id="6rLOYi5SbzR" role="1ahQWs">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXR$" id="6rLOYi5SbzS" role="3ix9CU" />
+          </node>
+          <node concept="1aduha" id="6rLOYi5SbzT" role="1ahQXP">
+            <node concept="1adJid" id="6rLOYi5SbzU" role="1aduh9">
+              <property role="TrG5h" value="x" />
+              <node concept="30bXRB" id="6rLOYi5SbzV" role="2lDidJ">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="30dDZf" id="6rLOYi5SbzW" role="1aduh9">
+              <node concept="1adzI2" id="6rLOYi5SbzX" role="30dEsF">
+                <ref role="1adwt6" node="6rLOYi5SbzU" resolve="x" />
+              </node>
+              <node concept="1afdae" id="6rLOYi5SbzY" role="30dEs_">
+                <ref role="1afue_" node="6rLOYi5SbzR" resolve="a" />
+              </node>
+            </node>
+            <node concept="1X3_iC" id="6rLOYi5SbzZ" role="lGtFl">
+              <property role="3V$3am" value="expressions" />
+              <property role="3V$3ak" value="9464fa06-5ab9-409b-9274-64ab29588457/4790956042240983401/4790956042240983402" />
+              <node concept="1adJid" id="6rLOYi5Sb$0" role="8Wnug">
+                <property role="TrG5h" value="x" />
+                <node concept="30bXRB" id="6rLOYi5Sb$1" role="2lDidJ">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+            </node>
+            <node concept="1X3_iC" id="6rLOYi5Sb$2" role="lGtFl">
+              <property role="3V$3am" value="expressions" />
+              <property role="3V$3ak" value="9464fa06-5ab9-409b-9274-64ab29588457/4790956042240983401/4790956042240983402" />
+              <node concept="umIIN" id="6rLOYi5Sb$3" role="8Wnug">
+                <property role="TrG5h" value="a" />
+                <node concept="30bXRB" id="6rLOYi5Sb$4" role="2lDidJ">
+                  <property role="30bXRw" value="3" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="6rLOYi5Sb$5" role="lGtFl">
+            <node concept="7OXhh" id="6rLOYi5Sb$6" role="7EUXB">
+              <property role="GvXf4" value="true" />
+              <property role="G7GLP" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1lH9Xt" id="KoRsm$utLj">
     <property role="TrG5h" value="ListEquality" />
@@ -37864,64 +37918,6 @@
     <node concept="3clFbS" id="5sOQrHN5SOz" role="LjaKd">
       <node concept="1MFPAf" id="5sOQrHN5SOy" role="3cqZAp">
         <ref role="1MFYO6" to="tg9b:2wqTDZJZvwg" resolve="SplitStringIntoConcatenation" />
-      </node>
-    </node>
-  </node>
-  <node concept="1lH9Xt" id="3HHveKCHjRz">
-    <property role="3DII0k" value="2hh8MJdVwqX/command" />
-    <property role="TrG5h" value="commentedOutUniqueNames" />
-    <node concept="1qefOq" id="3HHveKCHjR$" role="1SKRRt">
-      <node concept="_iOnV" id="3HHveKCHjRA" role="1qenE9">
-        <property role="TrG5h" value="commentedOutUniqueNames" />
-        <node concept="1aga60" id="3HHveKCHjRB" role="_iOnC">
-          <property role="TrG5h" value="commentedOutNamesAreIgnored" />
-          <node concept="1ahQXy" id="3HHveKCHjRD" role="1ahQWs">
-            <property role="TrG5h" value="a" />
-            <node concept="30bXR$" id="3HHveKCHjRE" role="3ix9CU" />
-          </node>
-          <node concept="1aduha" id="3HHveKCHjRF" role="1ahQXP">
-            <node concept="1adJid" id="3HHveKCHjRG" role="1aduh9">
-              <property role="TrG5h" value="x" />
-              <node concept="30bXRB" id="3HHveKCHjRI" role="2lDidJ">
-                <property role="30bXRw" value="1" />
-              </node>
-            </node>
-            <node concept="30dDZf" id="3HHveKCHjRJ" role="1aduh9">
-              <node concept="1adzI2" id="3HHveKCHjRM" role="30dEsF">
-                <ref role="1adwt6" node="3HHveKCHjRG" resolve="x" />
-              </node>
-              <node concept="1afdae" id="3HHveKCHjRN" role="30dEs_">
-                <ref role="1afue_" node="3HHveKCHjRD" resolve="a" />
-              </node>
-            </node>
-            <node concept="1X3_iC" id="3HHveKCHjRO" role="lGtFl">
-              <property role="3V$3am" value="expressions" />
-              <property role="3V$3ak" value="9464fa06-5ab9-409b-9274-64ab29588457/4790956042240983401/4790956042240983402" />
-              <node concept="1adJid" id="3HHveKCHjRQ" role="8Wnug">
-                <property role="TrG5h" value="x" />
-                <node concept="30bXRB" id="3HHveKCHjRS" role="2lDidJ">
-                  <property role="30bXRw" value="2" />
-                </node>
-              </node>
-            </node>
-            <node concept="1X3_iC" id="3HHveKCHjRT" role="lGtFl">
-              <property role="3V$3am" value="expressions" />
-              <property role="3V$3ak" value="9464fa06-5ab9-409b-9274-64ab29588457/4790956042240983401/4790956042240983402" />
-              <node concept="umIIN" id="3HHveKCHjRV" role="8Wnug">
-                <property role="TrG5h" value="a" />
-                <node concept="30bXRB" id="3HHveKCHjRX" role="2lDidJ">
-                  <property role="30bXRw" value="3" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="7CXmI" id="3HHveKCHjRY" role="lGtFl">
-            <node concept="7OXhh" id="3HHveKCHjRZ" role="7EUXB">
-              <property role="GvXf4" value="true" />
-              <property role="G7GLP" value="true" />
-            </node>
-          </node>
-        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -20,6 +20,7 @@
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="3" />
     <use id="b80fab4e-53f2-409c-81d8-3475855e0e42" name="test.ts.expr.os.nix" version="0" />
     <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports>
@@ -37863,6 +37864,64 @@
     <node concept="3clFbS" id="5sOQrHN5SOz" role="LjaKd">
       <node concept="1MFPAf" id="5sOQrHN5SOy" role="3cqZAp">
         <ref role="1MFYO6" to="tg9b:2wqTDZJZvwg" resolve="SplitStringIntoConcatenation" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3HHveKCHjRz">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="commentedOutUniqueNames" />
+    <node concept="1qefOq" id="3HHveKCHjR$" role="1SKRRt">
+      <node concept="_iOnV" id="3HHveKCHjRA" role="1qenE9">
+        <property role="TrG5h" value="commentedOutUniqueNames" />
+        <node concept="1aga60" id="3HHveKCHjRB" role="_iOnC">
+          <property role="TrG5h" value="commentedOutNamesAreIgnored" />
+          <node concept="1ahQXy" id="3HHveKCHjRD" role="1ahQWs">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXR$" id="3HHveKCHjRE" role="3ix9CU" />
+          </node>
+          <node concept="1aduha" id="3HHveKCHjRF" role="1ahQXP">
+            <node concept="1adJid" id="3HHveKCHjRG" role="1aduh9">
+              <property role="TrG5h" value="x" />
+              <node concept="30bXRB" id="3HHveKCHjRI" role="2lDidJ">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="30dDZf" id="3HHveKCHjRJ" role="1aduh9">
+              <node concept="1adzI2" id="3HHveKCHjRM" role="30dEsF">
+                <ref role="1adwt6" node="3HHveKCHjRG" resolve="x" />
+              </node>
+              <node concept="1afdae" id="3HHveKCHjRN" role="30dEs_">
+                <ref role="1afue_" node="3HHveKCHjRD" resolve="a" />
+              </node>
+            </node>
+            <node concept="1X3_iC" id="3HHveKCHjRO" role="lGtFl">
+              <property role="3V$3am" value="expressions" />
+              <property role="3V$3ak" value="9464fa06-5ab9-409b-9274-64ab29588457/4790956042240983401/4790956042240983402" />
+              <node concept="1adJid" id="3HHveKCHjRQ" role="8Wnug">
+                <property role="TrG5h" value="x" />
+                <node concept="30bXRB" id="3HHveKCHjRS" role="2lDidJ">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+            </node>
+            <node concept="1X3_iC" id="3HHveKCHjRT" role="lGtFl">
+              <property role="3V$3am" value="expressions" />
+              <property role="3V$3ak" value="9464fa06-5ab9-409b-9274-64ab29588457/4790956042240983401/4790956042240983402" />
+              <node concept="umIIN" id="3HHveKCHjRV" role="8Wnug">
+                <property role="TrG5h" value="a" />
+                <node concept="30bXRB" id="3HHveKCHjRX" role="2lDidJ">
+                  <property role="30bXRw" value="3" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="3HHveKCHjRY" role="lGtFl">
+            <node concept="7OXhh" id="3HHveKCHjRZ" role="7EUXB">
+              <property role="GvXf4" value="true" />
+              <property role="G7GLP" value="true" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>


### PR DESCRIPTION
## Summary

`IFunctionLike.getUniquelyNamedElements()` reported *duplicate name* errors for declarations that are commented out. Commenting out a `val` or a local variable was enough to make the surrounding function show errors on code that is not part of the program.

## What changed

`getUniquelyNamedElements()` collected `ValExpression`/`LocalVarDeclExpr` from `thisNode.body.descendants`. `descendants` also walks into `BaseCommentAttribute` children, so commented out declarations reached mbeddr's `check_ContainerOfUniqueNames` rule, which reports the error on the named element itself — i.e. on the commented out node.

The predicate now additionally requires `it.ancestor<concept = BaseCommentAttribute> == null`.

`BlockExpression.getUniquelyNamedElements()` needs no change: it reads the `expressions` role directly, and commented out children do not live there.

## Test

New `NodesTestCase` `commentedOutUniqueNames` in `test.ts.expr.os.m1`, covering both directions:

- a commented out `val x` duplicating a live `val x`
- a commented out `var a` duplicating the function argument `a`

```
fun commentedOutNamesAreIgnored(a: int) {
  val x = 1
  x + a
  /*val x = 2*/
  /*var a = 3*/
}
```

checked with `CheckNodeForErrorMessagesOperation` (allow warnings, include self).

Evaluated on that node, the old predicate yields `[a, x, x, a]` (two duplicate-name errors), the new one yields `[a, x]`.

`commentedOutUniqueNames` passes (1/1) and the existing `vars` suite still passes (12/12).

## Notes for reviewers

- No breaking changes, no migrations.
- Follow-up to the recent `getUniquelyNamedElements()` rework (`ab01697e28`, `493a3175df`); this closes the remaining case where commented out code was still checked.
- Base is `maintenance/mps20251`, which is where this branch was cut from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)