### PR TITLE
Make EnumLiteral an ISmartReferent, drop QualifierRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## September 2026
+
+### Changed
+- KernelF: `EnumLiteral` now implements `ISmartReferent` and derives its `resolveInfo` from the same presentation (qualified for a qualified enum, bare otherwise), so completion, the editor cell and `renderReadable()` agree. The hand-written `EnumLiteralRef` substitute menus and the qualified filter in its scope were dropped in favour of the smart-reference machinery MPS generates. The auxiliary concept `QualifierRef` was removed; it had no instances and was never part of a valid model, so no migration is required.
+
+### Fixed
+- KernelF: a broken reference to a literal of a qualified enum no longer rebinds to a same-named literal of a different enum, because the persisted `resolve=` info now carries the qualified name instead of the simple one.
+
 ## August 2026
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -6629,8 +6629,8 @@
                 <ref role="3Tt5mk" to="yv47:67Y8mp$DNs9" resolve="literal" />
               </node>
             </node>
-            <node concept="3TrcHB" id="67Y8mp$EGkB" role="2OqNvi">
-              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            <node concept="2qgKlT" id="7F82HbPiHO9" role="2OqNvi">
+              <ref role="37wK5l" node="7F82HbPdxFa" resolve="presentableName" />
             </node>
           </node>
         </node>
@@ -6699,6 +6699,83 @@
     </node>
     <node concept="13hLZK" id="67Y8mp$Hxsn" role="13h7CW">
       <node concept="3clFbS" id="67Y8mp$Hxso" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7F82HbPdxFa" role="13h7CS">
+      <property role="TrG5h" value="presentableName" />
+      <node concept="3Tm1VV" id="7F82HbPdxFe" role="1B3o_S" />
+      <node concept="17QB3L" id="7F82HbPdxFf" role="3clF45" />
+      <node concept="3clFbS" id="7F82HbPdxFg" role="3clF47">
+        <node concept="3cpWs8" id="7F82HbPdxGL" role="3cqZAp">
+          <node concept="3cpWsn" id="7F82HbPdxGO" role="3cpWs9">
+            <property role="TrG5h" value="ed" />
+            <node concept="3Tqbb2" id="7F82HbPdxGQ" role="1tU5fm">
+              <ref role="ehGHo" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7F82HbPdxGR" role="33vP2m">
+              <node concept="13iPFW" id="7F82HbPdxGU" role="2Oq$k0" />
+              <node concept="2qgKlT" id="7F82HbPdxGV" role="2OqNvi">
+                <ref role="37wK5l" node="67Y8mp$M9$v" resolve="enumDecl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7F82HbPdxGW" role="3cqZAp">
+          <node concept="1Wc70l" id="7F82HbPdxGZ" role="3clFbw">
+            <node concept="2OqwBi" id="7F82HbPdxH2" role="3uHU7B">
+              <node concept="37vLTw" id="7F82HbPdxH5" role="2Oq$k0">
+                <ref role="3cqZAo" node="7F82HbPdxGO" resolve="ed" />
+              </node>
+              <node concept="3x8VRR" id="7F82HbPdxH6" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="7F82HbPdxH7" role="3uHU7w">
+              <node concept="37vLTw" id="7F82HbPdxHa" role="2Oq$k0">
+                <ref role="3cqZAo" node="7F82HbPdxGO" resolve="ed" />
+              </node>
+              <node concept="3TrcHB" id="7F82HbPdxHb" role="2OqNvi">
+                <ref role="3TsBF5" to="yv47:67Y8mp$M9cx" resolve="qualified" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="7F82HbPdxHc" role="3clFbx">
+            <node concept="3cpWs6" id="7F82HbPdxHd" role="3cqZAp">
+              <node concept="2OqwBi" id="7F82HbPdxHe" role="3cqZAk">
+                <node concept="13iPFW" id="7F82HbPdxHh" role="2Oq$k0" />
+                <node concept="2qgKlT" id="7F82HbPdxHi" role="2OqNvi">
+                  <ref role="37wK5l" node="67Y8mp$HuPC" resolve="nameWithEnum" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7F82HbPdxHj" role="3cqZAp">
+          <node concept="2OqwBi" id="7F82HbPdxHk" role="3cqZAk">
+            <node concept="13iPFW" id="7F82HbPdxHn" role="2Oq$k0" />
+            <node concept="3TrcHB" id="7F82HbPdxHo" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7F82HbPhOmr" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:69Qfsw3IoJg" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="7F82HbPhOmv" role="1B3o_S" />
+      <node concept="17QB3L" id="7F82HbPhOmw" role="3clF45" />
+      <node concept="37vLTG" id="7F82HbPhOmx" role="3clF46">
+        <property role="TrG5h" value="reference" />
+        <node concept="3Tqbb2" id="7F82HbPhOmz" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="7F82HbPhOm$" role="3clF47">
+        <node concept="3clFbF" id="7F82HbPhOnm" role="3cqZAp">
+          <node concept="2OqwBi" id="7F82HbPhOno" role="3clFbG">
+            <node concept="13iPFW" id="7F82HbPhOnr" role="2Oq$k0" />
+            <node concept="2qgKlT" id="7F82HbPhOns" role="2OqNvi">
+              <ref role="37wK5l" node="7F82HbPdxFa" resolve="presentableName" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="67Y8mp$HxYp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
@@ -142,9 +142,7 @@
       <concept id="1147467790433" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyGetter" flags="in" index="Eqf_E" />
       <concept id="1147468365020" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_node" flags="nn" index="EsrRn" />
       <concept id="5564765827938091039" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSearchScope_Scope" flags="ig" index="3dgokm" />
-      <concept id="1163200368514" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSetHandler" flags="in" index="3k9gUc" />
       <concept id="1163200647017" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_referenceNode" flags="nn" index="3kakTB" />
-      <concept id="1163202640154" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_newReferentNode" flags="nn" index="3khVwk" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
         <child id="6702802731807532712" name="canBeParent" index="9SGkU" />
@@ -154,7 +152,6 @@
       </concept>
       <concept id="1148687176410" name="jetbrains.mps.lang.constraints.structure.NodeReferentConstraint" flags="ng" index="1N5Pfh">
         <reference id="1148687202698" name="applicableLink" index="1N5Vy1" />
-        <child id="1163203787401" name="referentSetHandler" index="3kmjI7" />
         <child id="1148687345559" name="searchScopeFactory" index="1N6uqs" />
       </concept>
     </language>
@@ -166,22 +163,6 @@
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
-      </concept>
-    </language>
-    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
-      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
-        <reference id="5455284157994012188" name="link" index="2pIpSl" />
-        <child id="1595412875168045827" name="initValue" index="28nt2d" />
-      </concept>
-      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
-        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
-      </concept>
-      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
-        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
-        <child id="5455284157993911099" name="values" index="2pJxcM" />
-      </concept>
-      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
-        <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
@@ -220,9 +201,6 @@
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
-      </concept>
-      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
-        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
@@ -1353,124 +1331,31 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbJ" id="4zsmO3KsNyj" role="3cqZAp">
-            <node concept="3clFbS" id="4zsmO3KsNyl" role="3clFbx">
-              <node concept="3cpWs8" id="4zsmO3KsRvL" role="3cqZAp">
-                <node concept="3cpWsn" id="4zsmO3KsRvM" role="3cpWs9">
-                  <property role="TrG5h" value="allLits" />
-                  <node concept="A3Dl8" id="4zsmO3KsRvN" role="1tU5fm">
-                    <node concept="3Tqbb2" id="4zsmO3KsRvO" role="A3Ik2">
-                      <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="4zsmO3KsRvP" role="33vP2m">
-                    <node concept="37vLTw" id="4zsmO3KsRvQ" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4zsmO3KsMJQ" resolve="enums" />
-                    </node>
-                    <node concept="3goQfb" id="4zsmO3KsRvR" role="2OqNvi">
-                      <node concept="1bVj0M" id="4zsmO3KsRvS" role="23t8la">
-                        <node concept="3clFbS" id="4zsmO3KsRvT" role="1bW5cS">
-                          <node concept="3clFbF" id="4zsmO3KsRvU" role="3cqZAp">
-                            <node concept="2OqwBi" id="4zsmO3KsRvV" role="3clFbG">
-                              <node concept="37vLTw" id="4zsmO3KsRvW" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4z0AnX817hY" resolve="it" />
-                              </node>
-                              <node concept="2qgKlT" id="4zsmO3KsRvX" role="2OqNvi">
-                                <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="gl6BB" id="4z0AnX817hY" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="4z0AnX817hZ" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+          <node concept="3cpWs6" id="7F82HbPiONq" role="3cqZAp">
+            <node concept="2YIFZM" id="7F82HbPiONr" role="3cqZAk">
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+              <node concept="2OqwBi" id="7F82HbPiONs" role="37wK5m">
+                <node concept="37vLTw" id="7F82HbPiONv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4zsmO3KsMJQ" resolve="enums" />
                 </node>
-              </node>
-              <node concept="3cpWs6" id="4zsmO3KsQPN" role="3cqZAp">
-                <node concept="2YIFZM" id="1F1F0IUZBCj" role="3cqZAk">
-                  <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-                  <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-                  <node concept="37vLTw" id="4zsmO3KsSgC" role="37wK5m">
-                    <ref role="3cqZAo" node="4zsmO3KsRvM" resolve="allLits" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3y3z36" id="4zsmO3KsNXq" role="3clFbw">
-              <node concept="10Nm6u" id="4zsmO3KsOoE" role="3uHU7w" />
-              <node concept="3kakTB" id="4zsmO3KsNCn" role="3uHU7B" />
-            </node>
-            <node concept="9aQIb" id="4zsmO3KsT82" role="9aQIa">
-              <node concept="3clFbS" id="4zsmO3KsT83" role="9aQI4">
-                <node concept="3cpWs8" id="4zsmO3KsWEJ" role="3cqZAp">
-                  <node concept="3cpWsn" id="4zsmO3KsWEK" role="3cpWs9">
-                    <property role="TrG5h" value="direct" />
-                    <node concept="A3Dl8" id="4zsmO3KsWCT" role="1tU5fm">
-                      <node concept="3Tqbb2" id="4zsmO3KsWCW" role="A3Ik2">
-                        <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
-                      </node>
+                <node concept="3goQfb" id="7F82HbPiONw" role="2OqNvi">
+                  <node concept="1bVj0M" id="7F82HbPiON_" role="23t8la">
+                    <node concept="gl6BB" id="7F82HbPiONB" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7F82HbPiONC" role="1tU5fm" />
                     </node>
-                    <node concept="2OqwBi" id="4zsmO3KsWEL" role="33vP2m">
-                      <node concept="2OqwBi" id="4zsmO3KsWEM" role="2Oq$k0">
-                        <node concept="37vLTw" id="4zsmO3KsWEN" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4zsmO3KsMJQ" resolve="enums" />
-                        </node>
-                        <node concept="3zZkjj" id="4zsmO3KsWEO" role="2OqNvi">
-                          <node concept="1bVj0M" id="4zsmO3KsWEP" role="23t8la">
-                            <node concept="3clFbS" id="4zsmO3KsWEQ" role="1bW5cS">
-                              <node concept="3clFbF" id="4zsmO3KsWER" role="3cqZAp">
-                                <node concept="3fqX7Q" id="4zsmO3KsWES" role="3clFbG">
-                                  <node concept="2OqwBi" id="4zsmO3KsWET" role="3fr31v">
-                                    <node concept="37vLTw" id="4zsmO3KsWEU" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4z0AnX817i0" resolve="it" />
-                                    </node>
-                                    <node concept="3TrcHB" id="4zsmO3KsWEV" role="2OqNvi">
-                                      <ref role="3TsBF5" to="yv47:67Y8mp$M9cx" resolve="qualified" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="gl6BB" id="4z0AnX817i0" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="4z0AnX817i1" role="1tU5fm" />
-                            </node>
+                    <node concept="3clFbS" id="7F82HbPiOND" role="1bW5cS">
+                      <node concept="3clFbF" id="7F82HbPiONE" role="3cqZAp">
+                        <node concept="2OqwBi" id="7F82HbPiONG" role="3clFbG">
+                          <node concept="37vLTw" id="7F82HbPiONJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7F82HbPiONB" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="7F82HbPiONK" role="2OqNvi">
+                            <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3goQfb" id="4zsmO3KsWEY" role="2OqNvi">
-                        <node concept="1bVj0M" id="4zsmO3KsWEZ" role="23t8la">
-                          <node concept="3clFbS" id="4zsmO3KsWF0" role="1bW5cS">
-                            <node concept="3clFbF" id="4zsmO3KsWF1" role="3cqZAp">
-                              <node concept="2OqwBi" id="4zsmO3KsWF2" role="3clFbG">
-                                <node concept="37vLTw" id="4zsmO3KsWF3" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4z0AnX817i2" resolve="it" />
-                                </node>
-                                <node concept="2qgKlT" id="4zsmO3KsWF4" role="2OqNvi">
-                                  <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="gl6BB" id="4z0AnX817i2" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="4z0AnX817i3" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="4zsmO3KsXpV" role="3cqZAp">
-                  <node concept="2YIFZM" id="4zsmO3KsXpW" role="3cqZAk">
-                    <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-                    <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-                    <node concept="37vLTw" id="4zsmO3Kt6d2" role="37wK5m">
-                      <ref role="3cqZAo" node="4zsmO3KsWEK" resolve="direct" />
                     </node>
                   </node>
                 </node>
@@ -1846,129 +1731,6 @@
       </node>
     </node>
   </node>
-  <node concept="1M2fIO" id="4zsmO3Kw4Yy">
-    <property role="3GE5qa" value="enum" />
-    <ref role="1M2myG" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-    <node concept="1N5Pfh" id="4zsmO3Kw4Yz" role="1Mr941">
-      <ref role="1N5Vy1" to="yv47:4zsmO3KtfVS" resolve="enum" />
-      <node concept="3dgokm" id="4zsmO3Kw4Y_" role="1N6uqs">
-        <node concept="3clFbS" id="4zsmO3Kw4YA" role="2VODD2">
-          <node concept="3cpWs8" id="4zsmO3Kw5Ad" role="3cqZAp">
-            <node concept="3cpWsn" id="4zsmO3Kw5Ae" role="3cpWs9">
-              <property role="TrG5h" value="enums" />
-              <node concept="A3Dl8" id="4zsmO3Kw5Af" role="1tU5fm">
-                <node concept="3Tqbb2" id="4zsmO3Kw5Ag" role="A3Ik2">
-                  <ref role="ehGHo" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="4zsmO3Kw5Ah" role="33vP2m">
-                <node concept="2OqwBi" id="4zsmO3Kw5Ai" role="2Oq$k0">
-                  <node concept="2OqwBi" id="4zsmO3Kw5Aj" role="2Oq$k0">
-                    <node concept="2rP1CM" id="4zsmO3Kw5Ak" role="2Oq$k0" />
-                    <node concept="2Xjw5R" id="4zsmO3Kw5Al" role="2OqNvi">
-                      <node concept="1xMEDy" id="4zsmO3Kw5Am" role="1xVPHs">
-                        <node concept="chp4Y" id="4zsmO3Kw5An" role="ri$Ld">
-                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="4zsmO3Kw5Ao" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
-                    <node concept="35c_gC" id="3Q$zA1CCh2d" role="37wK5m">
-                      <ref role="35c_gD" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="v3k3i" id="4zsmO3Kw5Aq" role="2OqNvi">
-                  <node concept="chp4Y" id="4zsmO3Kw5Ar" role="v3oSu">
-                    <ref role="cht4Q" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="4zsmO3Kw5Eg" role="3cqZAp">
-            <node concept="2YIFZM" id="4zsmO3Kw5PY" role="3clFbG">
-              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
-              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="2OqwBi" id="4zsmO3Kwf2b" role="37wK5m">
-                <node concept="37vLTw" id="4zsmO3Kw5To" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4zsmO3Kw5Ae" resolve="enums" />
-                </node>
-                <node concept="3zZkjj" id="4zsmO3Kwfof" role="2OqNvi">
-                  <node concept="1bVj0M" id="4zsmO3Kwfoh" role="23t8la">
-                    <node concept="3clFbS" id="4zsmO3Kwfoi" role="1bW5cS">
-                      <node concept="3clFbF" id="4zsmO3KwfuR" role="3cqZAp">
-                        <node concept="2OqwBi" id="4zsmO3KwfWp" role="3clFbG">
-                          <node concept="37vLTw" id="4zsmO3KwfuQ" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4z0AnX817i4" resolve="it" />
-                          </node>
-                          <node concept="3TrcHB" id="4zsmO3Kwgv7" role="2OqNvi">
-                            <ref role="3TsBF5" to="yv47:67Y8mp$M9cx" resolve="qualified" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gl6BB" id="4z0AnX817i4" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="4z0AnX817i5" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1N5Pfh" id="4zsmO3Kwqkd" role="1Mr941">
-      <ref role="1N5Vy1" to="yv47:4zsmO3Kwq31" resolve="lit" />
-      <node concept="3dgokm" id="4zsmO3Kwqke" role="1N6uqs">
-        <node concept="3clFbS" id="4zsmO3Kwqkf" role="2VODD2">
-          <node concept="3clFbF" id="4zsmO3Kwqkv" role="3cqZAp">
-            <node concept="2YIFZM" id="4zsmO3Kwqkw" role="3clFbG">
-              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
-              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="2OqwBi" id="4zsmO3KwrlD" role="37wK5m">
-                <node concept="2OqwBi" id="4zsmO3KwqKJ" role="2Oq$k0">
-                  <node concept="3kakTB" id="4zsmO3Kwqxt" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4zsmO3KwqZV" role="2OqNvi">
-                    <ref role="3Tt5mk" to="yv47:4zsmO3KtfVS" resolve="enum" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="4zsmO3KwrZj" role="2OqNvi">
-                  <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3k9gUc" id="4zsmO3Kzq3n" role="3kmjI7">
-        <node concept="3clFbS" id="4zsmO3Kzq3o" role="2VODD2">
-          <node concept="3clFbF" id="4zsmO3Kzq72" role="3cqZAp">
-            <node concept="2OqwBi" id="4zsmO3Kzqhm" role="3clFbG">
-              <node concept="3kakTB" id="4zsmO3Kzq71" role="2Oq$k0" />
-              <node concept="1P9Npp" id="4zsmO3KzqvF" role="2OqNvi">
-                <node concept="2pJPEk" id="4zsmO3KzqxV" role="1P9ThW">
-                  <node concept="2pJPED" id="4zsmO3KzqzZ" role="2pJPEn">
-                    <ref role="2pJxaS" to="yv47:67Y8mp$DNr5" resolve="EnumLiteralRef" />
-                    <node concept="2pIpSj" id="4zsmO3Kzq_H" role="2pJxcM">
-                      <ref role="2pIpSl" to="yv47:67Y8mp$DNs9" resolve="literal" />
-                      <node concept="36biLy" id="4zsmO3KzqD_" role="28nt2d">
-                        <node concept="3khVwk" id="4zsmO3KzqG8" role="36biLW" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="1M2fIO" id="c36CPsxQrh">
     <property role="3GE5qa" value="enum" />
     <ref role="1M2myG" to="yv47:c36CPsxOj8" resolve="EnumIndexOp" />
@@ -2191,6 +1953,25 @@
               </node>
               <node concept="3clFbT" id="3meuf2aVf73" role="37wK5m">
                 <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="7F82HbPkV7b">
+    <property role="3GE5qa" value="enum" />
+    <ref role="1M2myG" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+    <node concept="EnEH3" id="7F82HbPkV7a" role="1MhHOB">
+      <ref role="EomxK" to="tpck:hqLvdgl" resolve="resolveInfo" />
+      <node concept="Eqf_E" id="7F82HbPkV78" role="EtsB7">
+        <node concept="3clFbS" id="7F82HbPkV79" role="2VODD2">
+          <node concept="3clFbF" id="7F82HbPkWfp" role="3cqZAp">
+            <node concept="2OqwBi" id="7F82HbPkWfr" role="3clFbG">
+              <node concept="EsrRn" id="7F82HbPkWfu" role="2Oq$k0" />
+              <node concept="2qgKlT" id="7F82HbPkWfv" role="2OqNvi">
+                <ref role="37wK5l" to="nu60:7F82HbPdxFa" resolve="presentableName" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -89,9 +89,6 @@
       <concept id="4531786690998636238" name="jetbrains.mps.lang.editor.structure.AbstractStyledTextOperation" flags="nn" index="kdiOM">
         <child id="4531786690998636240" name="actualArgument" index="kdiOG" />
       </concept>
-      <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
-        <reference id="6089045305654944382" name="menu" index="2kkw0f" />
-      </concept>
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
@@ -170,6 +167,7 @@
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="4323500428121233431" name="jetbrains.mps.lang.editor.structure.EditorCellId" flags="ng" index="2SqB2G" />
       <concept id="1164914519156" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReplaceNode_CustomNodeConcept" flags="ng" index="UkePV">
         <reference id="1164914727930" name="replacementConcept" index="Ul1FP" />
       </concept>
@@ -181,7 +179,6 @@
         <child id="1220975211821" name="query" index="17MNgL" />
       </concept>
       <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
-      <concept id="615427434521884870" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Subconcepts" flags="ng" index="2VfDsV" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
         <child id="1223387335081" name="query" index="3n$kyP" />
@@ -220,7 +217,6 @@
         <child id="8998492695583129972" name="query" index="16NL0q" />
       </concept>
       <concept id="1220974635399" name="jetbrains.mps.lang.editor.structure.QueryFunction_FontStyle" flags="in" index="17KAyr" />
-      <concept id="2115302367868116903" name="jetbrains.mps.lang.editor.structure.GeneratedSubstituteMenuAttribute" flags="ng" index="382kZG" />
       <concept id="3360401466585705291" name="jetbrains.mps.lang.editor.structure.CellModel_ContextAssistant" flags="ng" index="18a60v" />
       <concept id="1154465273778" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ParentNode" flags="nn" index="3bvxqY" />
       <concept id="1896914160037421068" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_WrapSubstituteMenu" flags="ng" index="3c8P5G">
@@ -264,12 +260,8 @@
       <concept id="772883491827671409" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_CompletionItemInformation" flags="ng" index="3lBNg1" />
       <concept id="772883491827671446" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_Style" flags="ng" index="3lBNjA" />
       <concept id="1223387125302" name="jetbrains.mps.lang.editor.structure.QueryFunction_Boolean" flags="in" index="3nzxsE" />
-      <concept id="730181322658904464" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_IncludeMenu" flags="ng" index="1s_PAr">
-        <child id="730181322658904467" name="menuReference" index="1s_PAo" />
-      </concept>
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="4526149749187797167" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_StyledText" flags="nn" index="1unZQo" />
-      <concept id="5425882385312046132" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CurrentTargetNode" flags="nn" index="1yR$tW" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
@@ -281,6 +273,7 @@
         <child id="1198512004906" name="focusPolicyApplicable" index="cStSX" />
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
         <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
+        <child id="4323500428121274054" name="id" index="2SqHTX" />
         <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
@@ -332,15 +325,10 @@
         <child id="7980428675268276157" name="locations" index="1Qtc8$" />
         <child id="7980428675268276159" name="parts" index="1Qtc8A" />
       </concept>
+      <concept id="625126330682908270" name="jetbrains.mps.lang.editor.structure.CellModel_ReferencePresentation" flags="sg" stub="730538219795961225" index="3SHvHV" />
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
-      <concept id="4307758654696938365" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_RefPresentation" flags="ig" index="1WAQ3h" />
-      <concept id="4307758654696952957" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ReferencedNode" flags="ng" index="1WAUZh" />
       <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
-      <concept id="8428109087107030357" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_ReferenceScope" flags="ng" index="3XHNnq">
-        <reference id="8428109087107339113" name="reference" index="3XGfJA" />
-        <child id="4307758654694904293" name="matchingTextFunction" index="1WZ6D9" />
-      </concept>
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -517,9 +505,6 @@
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="8356039341262087992" name="line" index="1aUNEU" />
-      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -595,10 +580,6 @@
       </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
-      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
-        <reference id="5455284157994012188" name="link" index="2pIpSl" />
-        <child id="1595412875168045827" name="initValue" index="28nt2d" />
-      </concept>
       <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
         <reference id="5455284157993911078" name="property" index="2pJxcJ" />
         <child id="1595412875168045201" name="initValue" index="28ntcv" />
@@ -612,9 +593,6 @@
       </concept>
       <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
         <child id="6985522012210254363" name="expression" index="WxPPp" />
-      </concept>
-      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
-        <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
     <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
@@ -709,7 +687,6 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -721,14 +698,6 @@
         <property id="4767615435817184498" name="showBracketLine" index="3vD9g8" />
         <child id="4767615435811051865" name="collapsedCell" index="3v1y6z" />
         <child id="4767615435808541838" name="expandedCell" index="3v87hO" />
-      </concept>
-    </language>
-    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
-        <property id="155656958578482949" name="value" index="3oM_SC" />
-      </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
-        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -4123,56 +4092,18 @@
     <node concept="1iCGBv" id="67Y8mp$HxGR" role="2wV5jI">
       <ref role="1NtTu8" to="yv47:67Y8mp$DNs9" resolve="literal" />
       <node concept="1sVBvm" id="67Y8mp$HxGT" role="1sWHZn">
-        <node concept="1HlG4h" id="67Y8mp$M9dh" role="2wV5jI">
-          <node concept="1HfYo3" id="67Y8mp$M9dl" role="1HlULh">
-            <node concept="3TQlhw" id="67Y8mp$M9dp" role="1Hhtcw">
-              <node concept="3clFbS" id="67Y8mp$M9dt" role="2VODD2">
-                <node concept="3clFbJ" id="67Y8mp$M9eL" role="3cqZAp">
-                  <node concept="2OqwBi" id="67Y8mp$Macq" role="3clFbw">
-                    <node concept="2OqwBi" id="67Y8mp$M9jy" role="2Oq$k0">
-                      <node concept="pncrf" id="67Y8mp$M9g5" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="67Y8mp$Ma6Y" role="2OqNvi">
-                        <ref role="37wK5l" to="nu60:67Y8mp$M9$v" resolve="enumDecl" />
-                      </node>
-                    </node>
-                    <node concept="3TrcHB" id="67Y8mp$Map_" role="2OqNvi">
-                      <ref role="3TsBF5" to="yv47:67Y8mp$M9cx" resolve="qualified" />
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="67Y8mp$M9eN" role="3clFbx">
-                    <node concept="3cpWs6" id="67Y8mp$Mat5" role="3cqZAp">
-                      <node concept="2OqwBi" id="67Y8mp$MaxU" role="3cqZAk">
-                        <node concept="pncrf" id="67Y8mp$Mau8" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="67Y8mp$Mb1f" role="2OqNvi">
-                          <ref role="37wK5l" to="nu60:67Y8mp$HuPC" resolve="nameWithEnum" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="67Y8mp$Mb58" role="9aQIa">
-                    <node concept="3clFbS" id="67Y8mp$Mb59" role="9aQI4">
-                      <node concept="3cpWs6" id="67Y8mp$Mb6l" role="3cqZAp">
-                        <node concept="2OqwBi" id="67Y8mp$Mbi_" role="3cqZAk">
-                          <node concept="pncrf" id="67Y8mp$Mbaq" role="2Oq$k0" />
-                          <node concept="3TrcHB" id="67Y8mp$MbLC" role="2OqNvi">
-                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="Vb9p2" id="67Y8mp$MWjh" role="3F10Kt">
+        <node concept="3SHvHV" id="7F82HbPkZcK" role="2wV5jI">
+          <node concept="Vb9p2" id="7F82HbPkZcL" role="3F10Kt">
             <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
           </node>
-          <node concept="VechU" id="67Y8mp$MWs7" role="3F10Kt">
+          <node concept="VechU" id="7F82HbPkZcM" role="3F10Kt">
             <property role="Vb096" value="fLJRk5B/darkGray" />
           </node>
-          <node concept="VPxyj" id="7hawBYGB10C" role="3F10Kt">
+          <node concept="VPxyj" id="7F82HbPkZcN" role="3F10Kt">
             <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2SqB2G" id="7F82HbPpN02" role="2SqHTX">
+            <property role="TrG5h" value="literal" />
           </node>
         </node>
       </node>
@@ -6472,217 +6403,6 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="4zsmO3KtfWl">
-    <property role="3GE5qa" value="enum" />
-    <ref role="1XX52x" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-    <node concept="3EZMnI" id="4zsmO3KtfWP" role="2wV5jI">
-      <node concept="1kIj98" id="4zsmO3KzJas" role="3EZMnx">
-        <node concept="1iCGBv" id="4zsmO3KtfWn" role="1kIj9b">
-          <ref role="1NtTu8" to="yv47:4zsmO3KtfVS" resolve="enum" />
-          <node concept="1sVBvm" id="4zsmO3KtfWp" role="1sWHZn">
-            <node concept="3F0A7n" id="4zsmO3KtfWz" role="2wV5jI">
-              <property role="1Intyy" value="true" />
-              <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-              <node concept="Vb9p2" id="4zsmO3KA$kH" role="3F10Kt">
-                <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
-              </node>
-              <node concept="VechU" id="4zsmO3KA$kI" role="3F10Kt">
-                <property role="Vb096" value="fLJRk5B/darkGray" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="315t4" id="60PTWgqZ1jj" role="31dnJ">
-          <node concept="3clFbS" id="60PTWgqZ1jk" role="2VODD2">
-            <node concept="3clFbF" id="60PTWgqZ1jl" role="3cqZAp">
-              <node concept="2OqwBi" id="60PTWgqZ1jm" role="3clFbG">
-                <node concept="2YIFZM" id="60PTWgqZ1jn" role="2Oq$k0">
-                  <ref role="37wK5l" to="oq0c:4qv99IrBnzk" resolve="getConfig" />
-                  <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                </node>
-                <node concept="liA8E" id="60PTWgqZ1jo" role="2OqNvi">
-                  <ref role="37wK5l" to="oq0c:60PTWgqXNLq" resolve="wrapperCellSideTransformationPostProcess" />
-                  <node concept="2YIFZM" id="60PTWgr1CjF" role="37wK5m">
-                    <ref role="37wK5l" to="oq0c:60PTWgovZKt" resolve="getIdentifier" />
-                    <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                    <node concept="35c_gC" id="60PTWgr1CjG" role="37wK5m">
-                      <ref role="35c_gD" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                    </node>
-                    <node concept="359W_D" id="60PTWgr1CjH" role="37wK5m">
-                      <ref role="359W_E" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                      <ref role="359W_F" to="yv47:4zsmO3KtfVS" resolve="enum" />
-                    </node>
-                  </node>
-                  <node concept="313q4" id="60PTWgqZ1js" role="37wK5m" />
-                  <node concept="2MNBq7" id="60PTWgqZ1jt" role="37wK5m" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="315t4" id="60PTWgr0lMy" role="31dnY">
-          <node concept="3clFbS" id="60PTWgr0lMz" role="2VODD2">
-            <node concept="3clFbF" id="60PTWgr0lM$" role="3cqZAp">
-              <node concept="2OqwBi" id="60PTWgr0lM_" role="3clFbG">
-                <node concept="2YIFZM" id="60PTWgr0lMA" role="2Oq$k0">
-                  <ref role="37wK5l" to="oq0c:4qv99IrBnzk" resolve="getConfig" />
-                  <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                </node>
-                <node concept="liA8E" id="60PTWgr0lMB" role="2OqNvi">
-                  <ref role="37wK5l" to="oq0c:60PTWgqXQTX" resolve="wrapperCellSubstitutionPostProcess" />
-                  <node concept="2YIFZM" id="60PTWgr1Coo" role="37wK5m">
-                    <ref role="37wK5l" to="oq0c:60PTWgovZKt" resolve="getIdentifier" />
-                    <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                    <node concept="35c_gC" id="60PTWgr1Cop" role="37wK5m">
-                      <ref role="35c_gD" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                    </node>
-                    <node concept="359W_D" id="60PTWgr1Coq" role="37wK5m">
-                      <ref role="359W_E" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                      <ref role="359W_F" to="yv47:4zsmO3KtfVS" resolve="enum" />
-                    </node>
-                  </node>
-                  <node concept="313q4" id="60PTWgr0lMF" role="37wK5m" />
-                  <node concept="2MNBq7" id="60PTWgr0lMG" role="37wK5m" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="7duGs" id="60PTWgqdGeO" role="7deOD">
-          <node concept="3clFbS" id="60PTWgqdGeP" role="2VODD2">
-            <node concept="3clFbF" id="60PTWgqdGeQ" role="3cqZAp">
-              <node concept="2OqwBi" id="60PTWgqdGeR" role="3clFbG">
-                <node concept="2YIFZM" id="60PTWgqdGeS" role="2Oq$k0">
-                  <ref role="37wK5l" to="oq0c:4qv99IrBnzk" resolve="getConfig" />
-                  <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                </node>
-                <node concept="liA8E" id="60PTWgqdGeT" role="2OqNvi">
-                  <ref role="37wK5l" to="oq0c:60PTWgq7bkl" resolve="isWrapperCellSubstitutionActivated" />
-                  <node concept="2YIFZM" id="60PTWgqdGeU" role="37wK5m">
-                    <ref role="37wK5l" to="oq0c:60PTWgovZKt" resolve="getIdentifier" />
-                    <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                    <node concept="35c_gC" id="60PTWgqeKES" role="37wK5m">
-                      <ref role="35c_gD" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                    </node>
-                    <node concept="359W_D" id="60PTWgqeKHn" role="37wK5m">
-                      <ref role="359W_E" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                      <ref role="359W_F" to="yv47:4zsmO3KtfVS" resolve="enum" />
-                    </node>
-                  </node>
-                  <node concept="7dpZ6" id="60PTWgqdGeX" role="37wK5m" />
-                  <node concept="10Nm6u" id="60PTWgqrdWF" role="37wK5m" />
-                  <node concept="10Nm6u" id="60PTWgqudsF" role="37wK5m" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2e7140" id="60PTWgq8fNR" role="2e1Fq_">
-          <node concept="3clFbS" id="60PTWgq8fNS" role="2VODD2">
-            <node concept="3clFbF" id="60PTWgq8fNT" role="3cqZAp">
-              <node concept="2OqwBi" id="60PTWgq8fNU" role="3clFbG">
-                <node concept="2YIFZM" id="60PTWgq8fNV" role="2Oq$k0">
-                  <ref role="37wK5l" to="oq0c:4qv99IrBnzk" resolve="getConfig" />
-                  <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                </node>
-                <node concept="liA8E" id="60PTWgq8fNW" role="2OqNvi">
-                  <ref role="37wK5l" to="oq0c:60PTWgq7bk$" resolve="isWrapperCellSideTransformationActivated" />
-                  <node concept="2YIFZM" id="60PTWgq8fNX" role="37wK5m">
-                    <ref role="37wK5l" to="oq0c:60PTWgovZKt" resolve="getIdentifier" />
-                    <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                    <node concept="35c_gC" id="60PTWgq8fNY" role="37wK5m">
-                      <ref role="35c_gD" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                    </node>
-                    <node concept="359W_D" id="60PTWgq8fNZ" role="37wK5m">
-                      <ref role="359W_E" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                      <ref role="359W_F" to="yv47:4zsmO3KtfVS" resolve="enum" />
-                    </node>
-                  </node>
-                  <node concept="2e73FJ" id="60PTWgq8fO0" role="37wK5m" />
-                  <node concept="1Lj6YZ" id="60PTWgq8fO1" role="37wK5m" />
-                  <node concept="2MNBq7" id="60PTWgq8fO2" role="37wK5m" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="uPpia" id="60PTWgrzW6F" role="1djCvC">
-          <node concept="3clFbS" id="60PTWgrzW6G" role="2VODD2">
-            <node concept="3cpWs8" id="60PTWgrzW6K" role="3cqZAp">
-              <node concept="3cpWsn" id="60PTWgrzW6L" role="3cpWs9">
-                <property role="TrG5h" value="descriptiontext" />
-                <node concept="17QB3L" id="60PTWgrzW6M" role="1tU5fm" />
-                <node concept="2OqwBi" id="60PTWgrzW6N" role="33vP2m">
-                  <node concept="2YIFZM" id="60PTWgrzW6O" role="2Oq$k0">
-                    <ref role="37wK5l" to="oq0c:4qv99IrBnzk" resolve="getConfig" />
-                    <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                  </node>
-                  <node concept="liA8E" id="60PTWgrzW6P" role="2OqNvi">
-                    <ref role="37wK5l" to="oq0c:60PTWgry9kT" resolve="getWrapperCellSubstitutionDescriptionText" />
-                    <node concept="2YIFZM" id="60PTWgr_u9O" role="37wK5m">
-                      <ref role="37wK5l" to="oq0c:60PTWgovZKt" resolve="getIdentifier" />
-                      <ref role="1Pybhc" to="oq0c:4qv99IrBkzE" resolve="EditorCustomizationConfigHelper" />
-                      <node concept="35c_gC" id="60PTWgr_u9P" role="37wK5m">
-                        <ref role="35c_gD" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                      </node>
-                      <node concept="359W_D" id="60PTWgr_u9Q" role="37wK5m">
-                        <ref role="359W_E" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-                        <ref role="359W_F" to="yv47:4zsmO3KtfVS" resolve="enum" />
-                      </node>
-                    </node>
-                    <node concept="2e73FJ" id="60PTWgrzW6T" role="37wK5m" />
-                    <node concept="3dAXtN" id="60PTWgrzW6U" role="37wK5m" />
-                    <node concept="1Lj6YZ" id="60PTWgrzW6V" role="37wK5m" />
-                    <node concept="1oAbNU" id="60PTWgrzW6W" role="37wK5m" />
-                    <node concept="2MNBq7" id="60PTWgrzW6X" role="37wK5m" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="60PTWgrzW6Y" role="3cqZAp">
-              <node concept="3K4zz7" id="60PTWgrzW6Z" role="3clFbG">
-                <node concept="37vLTw" id="60PTWgrzW70" role="3K4E3e">
-                  <ref role="3cqZAo" node="60PTWgrzW6L" resolve="descriptiontext" />
-                </node>
-                <node concept="2OqwBi" id="60PTWgrzW71" role="3K4Cdx">
-                  <node concept="37vLTw" id="60PTWgrzW72" role="2Oq$k0">
-                    <ref role="3cqZAo" node="60PTWgrzW6L" resolve="descriptiontext" />
-                  </node>
-                  <node concept="17RvpY" id="60PTWgrzW73" role="2OqNvi" />
-                </node>
-                <node concept="1oAbNU" id="60PTWgrAQNR" role="3K4GZi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3F0ifn" id="4zsmO3KtfWJ" role="3EZMnx">
-        <property role="3F0ifm" value=":" />
-        <node concept="11L4FC" id="4zsmO3KtfWN" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="11LMrY" id="4zsmO3KA$5b" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="1iCGBv" id="4zsmO3Kwq3j" role="3EZMnx">
-        <ref role="1NtTu8" to="yv47:4zsmO3Kwq31" resolve="lit" />
-        <node concept="1sVBvm" id="4zsmO3Kwq3l" role="1sWHZn">
-          <node concept="3F0A7n" id="4zsmO3Kwq3x" role="2wV5jI">
-            <property role="1Intyy" value="true" />
-            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-            <node concept="Vb9p2" id="4zsmO3KA$kL" role="3F10Kt">
-              <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
-            </node>
-            <node concept="VechU" id="4zsmO3KA$kM" role="3F10Kt">
-              <property role="Vb096" value="fLJRk5B/darkGray" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="l2Vlx" id="1ASK_HedIv4" role="2iSdaV" />
-    </node>
-  </node>
   <node concept="24kQdi" id="2zwra1$Qiir">
     <property role="3GE5qa" value="enum" />
     <ref role="1XX52x" to="yv47:2zwra1$QhrC" resolve="AllLitList" />
@@ -6798,55 +6518,6 @@
       </node>
     </node>
   </node>
-  <node concept="22mcaB" id="7cBI1LfPKSu">
-    <ref role="aqKnT" to="yv47:67Y8mp$DNr5" resolve="EnumLiteralRef" />
-    <node concept="22hDWg" id="uuJ7IpZttI" role="22hAXT">
-      <property role="TrG5h" value="EnumLiteralRef_SmartReference" />
-    </node>
-    <node concept="3XHNnq" id="7cBI1LfPKSs" role="3ft7WO">
-      <ref role="3XGfJA" to="yv47:67Y8mp$DNs9" resolve="literal" />
-      <node concept="1WAQ3h" id="7cBI1LfPKSt" role="1WZ6D9">
-        <node concept="3clFbS" id="7cBI1LfPKS7" role="2VODD2">
-          <node concept="3clFbJ" id="7cBI1LfPKS8" role="3cqZAp">
-            <node concept="2OqwBi" id="7cBI1LfPKS9" role="3clFbw">
-              <node concept="2OqwBi" id="7cBI1LfPKSa" role="2Oq$k0">
-                <node concept="1WAUZh" id="7cBI1LfPKSp" role="2Oq$k0" />
-                <node concept="2qgKlT" id="7cBI1LfPKSc" role="2OqNvi">
-                  <ref role="37wK5l" to="nu60:67Y8mp$M9$v" resolve="enumDecl" />
-                </node>
-              </node>
-              <node concept="3TrcHB" id="7cBI1LfPKSd" role="2OqNvi">
-                <ref role="3TsBF5" to="yv47:67Y8mp$M9cx" resolve="qualified" />
-              </node>
-            </node>
-            <node concept="3clFbS" id="7cBI1LfPKSe" role="3clFbx">
-              <node concept="3cpWs6" id="7cBI1LfPKSf" role="3cqZAp">
-                <node concept="2OqwBi" id="7cBI1LfPKSg" role="3cqZAk">
-                  <node concept="1WAUZh" id="7cBI1LfPKSq" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="7cBI1LfPKSi" role="2OqNvi">
-                    <ref role="37wK5l" to="nu60:67Y8mp$HuPC" resolve="nameWithEnum" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="9aQIb" id="7cBI1LfPKSj" role="9aQIa">
-              <node concept="3clFbS" id="7cBI1LfPKSk" role="9aQI4">
-                <node concept="3cpWs6" id="7cBI1LfPKSl" role="3cqZAp">
-                  <node concept="2OqwBi" id="7cBI1LfPKSm" role="3cqZAk">
-                    <node concept="1WAUZh" id="7cBI1LfPKSr" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="7cBI1LfPKSo" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="382kZG" id="7cBI1LfPKSv" role="lGtFl" />
-  </node>
   <node concept="22mcaB" id="2dOqIOuu8eB">
     <ref role="aqKnT" to="yv47:ub9nkyKjdj" resolve="EmptyToplevelContent" />
     <node concept="22hDWj" id="uuJ7IpZttJ" role="22hAXT" />
@@ -6854,213 +6525,6 @@
   <node concept="22mcaB" id="7yWljG41Z62">
     <ref role="aqKnT" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
     <node concept="22hDWj" id="uuJ7IpZttK" role="22hAXT" />
-  </node>
-  <node concept="22mcaB" id="7cBI1LfPKSw">
-    <ref role="aqKnT" to="yv47:67Y8mp$DNr5" resolve="EnumLiteralRef" />
-    <node concept="22hDWj" id="uuJ7IpZttL" role="22hAXT" />
-    <node concept="1s_PAr" id="7cBI1LfPKSx" role="3ft7WO">
-      <node concept="2kknPI" id="7cBI1LfPKSy" role="1s_PAo">
-        <ref role="2kkw0f" node="7cBI1LfPKSu" resolve="EnumLiteralRef_SmartReference" />
-      </node>
-    </node>
-    <node concept="2VfDsV" id="7cBI1LfPKSz" role="3ft7WO" />
-    <node concept="2F$Pav" id="7hawBYGxgY0" role="3ft7WO">
-      <node concept="3eGOop" id="7hawBYGxhc$" role="2$S_pN">
-        <node concept="ucgPf" id="7hawBYGxhcA" role="3aKz83">
-          <node concept="3clFbS" id="7hawBYGxhcC" role="2VODD2">
-            <node concept="3clFbF" id="7hawBYG$gs5" role="3cqZAp">
-              <node concept="2pJPEk" id="7hawBYG$gs1" role="3clFbG">
-                <node concept="2pJPED" id="7hawBYG$gCA" role="2pJPEn">
-                  <ref role="2pJxaS" to="yv47:67Y8mp$DNr5" resolve="EnumLiteralRef" />
-                  <node concept="2pIpSj" id="7hawBYG$gO4" role="2pJxcM">
-                    <ref role="2pIpSl" to="yv47:67Y8mp$DNs9" resolve="literal" />
-                    <node concept="36biLy" id="7hawBYG$gZD" role="28nt2d">
-                      <node concept="2ZBlsa" id="7hawBYG$h8p" role="36biLW" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="16NfWO" id="7hawBYGxmtH" role="upBLP">
-          <node concept="uGdhv" id="7hawBYGxmJw" role="16NeZM">
-            <node concept="3clFbS" id="7hawBYGxmJy" role="2VODD2">
-              <node concept="3clFbF" id="7hawBYGxmR2" role="3cqZAp">
-                <node concept="2OqwBi" id="7hawBYG$hA9" role="3clFbG">
-                  <node concept="2ZBlsa" id="7hawBYGxnDh" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="7hawBYG$i1z" role="2OqNvi">
-                    <ref role="37wK5l" to="nu60:67Y8mp$HuPC" resolve="nameWithEnum" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tqbb2" id="7hawBYG$eNG" role="2ZBHrp">
-        <ref role="ehGHo" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
-      </node>
-      <node concept="2$S_p_" id="7hawBYGxhwZ" role="2$S_pT">
-        <node concept="3clFbS" id="7hawBYGxhx0" role="2VODD2">
-          <node concept="3SKdUt" id="7hawBYGAV3Q" role="3cqZAp">
-            <node concept="1PaTwC" id="7hawBYGAV3R" role="1aUNEU">
-              <node concept="3oM_SD" id="7hawBYGAV3T" role="1PaTwD">
-                <property role="3oM_SC" value="these" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVv4" role="1PaTwD">
-                <property role="3oM_SC" value="additional" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVyt" role="1PaTwD">
-                <property role="3oM_SC" value="actions" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVA3" role="1PaTwD">
-                <property role="3oM_SC" value="allow" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVG9" role="1PaTwD">
-                <property role="3oM_SC" value="to" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVJ_" role="1PaTwD">
-                <property role="3oM_SC" value="directly" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVN2" role="1PaTwD">
-                <property role="3oM_SC" value="reference" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAVZP" role="1PaTwD">
-                <property role="3oM_SC" value="other" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAW9q" role="1PaTwD">
-                <property role="3oM_SC" value="literals" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAWd6" role="1PaTwD">
-                <property role="3oM_SC" value="from" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAWgB" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGAWjX" role="1PaTwD">
-                <property role="3oM_SC" value="currently" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDHgd" role="1PaTwD">
-                <property role="3oM_SC" value="used" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDHnf" role="1PaTwD">
-                <property role="3oM_SC" value="qualified" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDIYK" role="1PaTwD">
-                <property role="3oM_SC" value="enum" />
-              </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="uuJ7IpZlt4" role="3cqZAp">
-            <node concept="1PaTwC" id="7hawBYGAY7g" role="1aUNEU">
-              <node concept="3oM_SD" id="7hawBYGAYn7" role="1PaTwD">
-                <property role="3oM_SC" value="(referenced" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDI3S" role="1PaTwD">
-                <property role="3oM_SC" value="in" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDI_P" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDIgR" role="1PaTwD">
-                <property role="3oM_SC" value="currentTargetNode)," />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFwm" role="1PaTwD">
-                <property role="3oM_SC" value="which" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFzX" role="1PaTwD">
-                <property role="3oM_SC" value="are" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDF$I" role="1PaTwD">
-                <property role="3oM_SC" value="otherwise" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFBZ" role="1PaTwD">
-                <property role="3oM_SC" value="not" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFIk" role="1PaTwD">
-                <property role="3oM_SC" value="in" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFN6" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDJPN" role="1PaTwD">
-                <property role="3oM_SC" value="direct" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDJTr" role="1PaTwD">
-                <property role="3oM_SC" value="scope" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFNz" role="1PaTwD">
-                <property role="3oM_SC" value="for" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDGiR" role="1PaTwD">
-                <property role="3oM_SC" value="using" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDGvG" role="1PaTwD">
-                <property role="3oM_SC" value="with" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDGz5" role="1PaTwD">
-                <property role="3oM_SC" value="smart" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDGzC" role="1PaTwD">
-                <property role="3oM_SC" value="reference" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDGpt" role="1PaTwD">
-                <property role="3oM_SC" value="" />
-              </node>
-              <node concept="3oM_SD" id="7hawBYGDFQG" role="1PaTwD">
-                <property role="3oM_SC" value="" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="7hawBYG$53F" role="3cqZAp">
-            <node concept="3clFbS" id="7hawBYG$53H" role="3clFbx">
-              <node concept="3cpWs6" id="7hawBYG$anm" role="3cqZAp">
-                <node concept="2OqwBi" id="7hawBYG$dDc" role="3cqZAk">
-                  <node concept="2OqwBi" id="7hawBYG$d7K" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7hawBYG$d7L" role="2Oq$k0">
-                      <node concept="1yR$tW" id="7hawBYG$d7M" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="7hawBYG$d7N" role="2OqNvi">
-                        <ref role="3Tt5mk" to="yv47:67Y8mp$DNs9" resolve="literal" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7hawBYG$d7O" role="2OqNvi">
-                      <ref role="37wK5l" to="nu60:67Y8mp$M9$v" resolve="enumDecl" />
-                    </node>
-                  </node>
-                  <node concept="3Tsc0h" id="7hawBYG$e$6" role="2OqNvi">
-                    <ref role="3TtcxE" to="yv47:67Y8mp$DMVO" resolve="literals" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="7hawBYG$8sV" role="3clFbw">
-              <node concept="2OqwBi" id="7hawBYG$7u7" role="2Oq$k0">
-                <node concept="2OqwBi" id="7hawBYG$6$l" role="2Oq$k0">
-                  <node concept="1yR$tW" id="7hawBYG$6mX" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="7hawBYG$6Vf" role="2OqNvi">
-                    <ref role="3Tt5mk" to="yv47:67Y8mp$DNs9" resolve="literal" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="7hawBYG$7Yq" role="2OqNvi">
-                  <ref role="37wK5l" to="nu60:67Y8mp$M9$v" resolve="enumDecl" />
-                </node>
-              </node>
-              <node concept="3TrcHB" id="7hawBYG$97j" role="2OqNvi">
-                <ref role="3TsBF5" to="yv47:67Y8mp$M9cx" resolve="qualified" />
-              </node>
-            </node>
-            <node concept="9aQIb" id="7hawBYG$9JF" role="9aQIa">
-              <node concept="3clFbS" id="7hawBYG$9JG" role="9aQI4">
-                <node concept="3cpWs6" id="7hawBYG$a5K" role="3cqZAp">
-                  <node concept="10Nm6u" id="7hawBYG$cL6" role="3cqZAk" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
   </node>
   <node concept="22mcaB" id="mQGcCv$$qI">
     <ref role="aqKnT" to="yv47:mQGcCvDeqQ" resolve="AbstractFunctionAdapter" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -27,9 +27,6 @@
       <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
         <property id="1225118933224" name="comment" index="YLQ7P" />
       </concept>
-      <concept id="7862711839422615209" name="jetbrains.mps.lang.structure.structure.DocumentedNodeAnnotation" flags="ng" index="t5JxF">
-        <property id="7862711839422615217" name="text" index="t5JxN" />
-      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="9005308665739310115" name="languageId" index="2eQzMB" />
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -45,9 +42,6 @@
       </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
         <reference id="1169127628841" name="intfc" index="PrY4T" />
-      </concept>
-      <concept id="8842732777748207592" name="jetbrains.mps.lang.structure.structure.SmartReferenceAttribute" flags="ng" index="RPilO">
-        <reference id="8842732777748207597" name="charactersticReference" index="RPilL" />
       </concept>
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <property id="1096454100552" name="rootable" index="19KtqR" />
@@ -650,6 +644,9 @@
     <node concept="PrWs8" id="3U1bmSgHg4o" role="PzmwI">
       <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
     </node>
+    <node concept="PrWs8" id="7F82HbP94p3" role="PzmwI">
+      <ref role="PrY4T" to="tpck:69Qfsw3InJo" resolve="ISmartReferent" />
+    </node>
   </node>
   <node concept="1TIwiD" id="67Y8mp$DN2V">
     <property role="3GE5qa" value="enum" />
@@ -1227,31 +1224,6 @@
   <node concept="PlHQZ" id="olugnm5RHo">
     <property role="EcuMT" value="438389604712151896" />
     <property role="TrG5h" value="IDeclarationExtensionContext" />
-  </node>
-  <node concept="1TIwiD" id="4zsmO3KtfVR">
-    <property role="EcuMT" value="5250171600077389559" />
-    <property role="3GE5qa" value="enum" />
-    <property role="TrG5h" value="QualifierRef" />
-    <property role="R4oN_" value="a qualified reference to an enumeration literal" />
-    <ref role="1TJDcQ" to="hm2y:6sdnDbSla17" resolve="Expression" />
-    <node concept="1TJgyj" id="4zsmO3KtfVS" role="1TKVEi">
-      <property role="IQ2ns" value="5250171600077389560" />
-      <property role="20kJfa" value="enum" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="67Y8mp$DMUI" resolve="EnumDeclaration" />
-    </node>
-    <node concept="1TJgyj" id="4zsmO3Kwq31" role="1TKVEi">
-      <property role="IQ2ns" value="5250171600078217409" />
-      <property role="20kJfa" value="lit" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="67Y8mp$DMVh" resolve="EnumLiteral" />
-    </node>
-    <node concept="RPilO" id="4zsmO3Kz$pa" role="lGtFl">
-      <ref role="RPilL" node="4zsmO3KtfVS" resolve="enum" />
-    </node>
-    <node concept="t5JxF" id="7hawBYG7tjX" role="lGtFl">
-      <property role="t5JxN" value="Auxiliary concept used only when creating EnumLiteralRefs to qualified enums (replaced by EnumLiteralRef when EnumLiteral is selected)" />
-    </node>
   </node>
   <node concept="1TIwiD" id="2zwra1$QhrC">
     <property role="EcuMT" value="2945473592442820328" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
@@ -1264,7 +1264,7 @@
             <ref role="2Ss9cX" node="2Alk1ztJIvB" resolve="recOrderedByDecl" />
           </node>
           <node concept="5mhuz" id="wlV$3l$XRF" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzkpP" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzkpP" resolve="enumOrderedByDeclaration:lit2" />
           </node>
           <node concept="30bdrP" id="2Alk1ztKtfx" role="2S399l">
             <property role="30bdrQ" value="a2" />
@@ -1278,7 +1278,7 @@
             <ref role="2Ss9cX" node="2Alk1ztJIvB" resolve="recOrderedByDecl" />
           </node>
           <node concept="5mhuz" id="wlV$3l$Yel" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzkpN" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzkpN" resolve="enumOrderedByDeclaration:lit1" />
           </node>
           <node concept="30bdrP" id="2Alk1ztKtpk" role="2S399l">
             <property role="30bdrQ" value="a4" />
@@ -1292,7 +1292,7 @@
             <ref role="2Ss9cX" node="2Alk1ztJIvB" resolve="recOrderedByDecl" />
           </node>
           <node concept="5mhuz" id="wlV$3l$YmR" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzkpR" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzkpR" resolve="enumOrderedByDeclaration:lit3" />
           </node>
           <node concept="30bdrP" id="2Alk1ztKupH" role="2S399l">
             <property role="30bdrQ" value="a3" />
@@ -1311,7 +1311,7 @@
             <ref role="2Ss9cX" node="2Alk1ztJIvB" resolve="recOrderedByDecl" />
           </node>
           <node concept="5mhuz" id="wlV$3l$YtV" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzkpN" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzkpN" resolve="enumOrderedByDeclaration:lit1" />
           </node>
           <node concept="30bdrP" id="365yA_OZJ3S" role="2S399l">
             <property role="30bdrQ" value="a4" />
@@ -1325,7 +1325,7 @@
             <ref role="2Ss9cX" node="2Alk1ztJIvB" resolve="recOrderedByDecl" />
           </node>
           <node concept="5mhuz" id="wlV$3l$Yz$" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzkpP" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzkpP" resolve="enumOrderedByDeclaration:lit2" />
           </node>
           <node concept="30bdrP" id="365yA_OZJ3X" role="2S399l">
             <property role="30bdrQ" value="a2" />
@@ -1339,7 +1339,7 @@
             <ref role="2Ss9cX" node="2Alk1ztJIvB" resolve="recOrderedByDecl" />
           </node>
           <node concept="5mhuz" id="wlV$3l$YDd" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzkpR" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzkpR" resolve="enumOrderedByDeclaration:lit3" />
           </node>
           <node concept="30bdrP" id="365yA_OZJ42" role="2S399l">
             <property role="30bdrQ" value="a3" />
@@ -1359,7 +1359,7 @@
             <ref role="2Ss9cX" node="365yA_OZG9l" resolve="recOrderedByLiteral" />
           </node>
           <node concept="5mhuz" id="wlV$3l$YR_" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="enumOrderedByLiteral:lit2" />
           </node>
           <node concept="30bdrP" id="2Alk1ztKuMC" role="2S399l">
             <property role="30bdrQ" value="a4" />
@@ -1373,7 +1373,7 @@
             <ref role="2Ss9cX" node="365yA_OZG9l" resolve="recOrderedByLiteral" />
           </node>
           <node concept="5mhuz" id="wlV$3l$Z8y" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="enumOrderedByLiteral:lit1" />
           </node>
           <node concept="30bdrP" id="2Alk1ztKuMH" role="2S399l">
             <property role="30bdrQ" value="a3" />
@@ -1387,7 +1387,7 @@
             <ref role="2Ss9cX" node="365yA_OZG9l" resolve="recOrderedByLiteral" />
           </node>
           <node concept="5mhuz" id="wlV$3l$Zh1" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="enumOrderedByLiteral:lit3" />
           </node>
           <node concept="30bdrP" id="2Alk1ztKuMW" role="2S399l">
             <property role="30bdrQ" value="a2" />
@@ -1406,7 +1406,7 @@
             <ref role="2Ss9cX" node="365yA_OZG9l" resolve="recOrderedByLiteral" />
           </node>
           <node concept="5mhuz" id="wlV$3l$Zo8" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="enumOrderedByLiteral:lit1" />
           </node>
           <node concept="30bdrP" id="365yA_OZKi1" role="2S399l">
             <property role="30bdrQ" value="a3" />
@@ -1420,7 +1420,7 @@
             <ref role="2Ss9cX" node="365yA_OZG9l" resolve="recOrderedByLiteral" />
           </node>
           <node concept="5mhuz" id="wlV$3l$ZtL" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="enumOrderedByLiteral:lit2" />
           </node>
           <node concept="30bdrP" id="365yA_OZKi6" role="2S399l">
             <property role="30bdrQ" value="a4" />
@@ -1434,7 +1434,7 @@
             <ref role="2Ss9cX" node="365yA_OZG9l" resolve="recOrderedByLiteral" />
           </node>
           <node concept="5mhuz" id="wlV$3l$Zzt" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="enumOrderedByLiteral:lit3" />
           </node>
           <node concept="30bdrP" id="365yA_OZKib" role="2S399l">
             <property role="30bdrQ" value="a2" />
@@ -1454,7 +1454,7 @@
             <ref role="2Ss9cX" node="365yA_OZHT1" resolve="recOrderedByValue" />
           </node>
           <node concept="5mhuz" id="wlV$3l$ZIG" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="enumOrderedByValue:lit1" />
           </node>
           <node concept="30bdrP" id="365yA_OZMoa" role="2S399l">
             <property role="30bdrQ" value="a1" />
@@ -1468,7 +1468,7 @@
             <ref role="2Ss9cX" node="365yA_OZHT1" resolve="recOrderedByValue" />
           </node>
           <node concept="5mhuz" id="wlV$3l$ZRe" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzntN" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzntN" resolve="enumOrderedByValue:lit2" />
           </node>
           <node concept="30bdrP" id="365yA_OZMzI" role="2S399l">
             <property role="30bdrQ" value="a2" />
@@ -1482,7 +1482,7 @@
             <ref role="2Ss9cX" node="365yA_OZHT1" resolve="recOrderedByValue" />
           </node>
           <node concept="5mhuz" id="wlV$3l_03W" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzntL" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzntL" resolve="enumOrderedByValue:lit3" />
           </node>
           <node concept="30bdrP" id="365yA_OZMRi" role="2S399l">
             <property role="30bdrQ" value="a3" />
@@ -1501,7 +1501,7 @@
             <ref role="2Ss9cX" node="365yA_OZHT1" resolve="recOrderedByValue" />
           </node>
           <node concept="5mhuz" id="wlV$3l_0gT" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzntL" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzntL" resolve="enumOrderedByValue:lit3" />
           </node>
           <node concept="30bdrP" id="365yA_OZN4H" role="2S399l">
             <property role="30bdrQ" value="a3" />
@@ -1515,7 +1515,7 @@
             <ref role="2Ss9cX" node="365yA_OZHT1" resolve="recOrderedByValue" />
           </node>
           <node concept="5mhuz" id="wlV$3l_0ms" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="enumOrderedByValue:lit1" />
           </node>
           <node concept="30bdrP" id="365yA_OZN4M" role="2S399l">
             <property role="30bdrQ" value="a1" />
@@ -1529,7 +1529,7 @@
             <ref role="2Ss9cX" node="365yA_OZHT1" resolve="recOrderedByValue" />
           </node>
           <node concept="5mhuz" id="wlV$3l_0b9" role="2S399l">
-            <ref role="5mhpJ" node="wlV$3lzntN" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzntN" resolve="enumOrderedByValue:lit2" />
           </node>
           <node concept="30bdrP" id="365yA_OZN4R" role="2S399l">
             <property role="30bdrQ" value="a2" />
@@ -1670,13 +1670,13 @@
         </node>
         <node concept="3iBYfx" id="wlV$3lFIYW" role="_fkuS">
           <node concept="5mhuz" id="5WOGwuDLgbZ" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzkpN" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzkpN" resolve="enumOrderedByDeclaration:lit1" />
           </node>
           <node concept="5mhuz" id="5WOGwuDLgcT" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzkpP" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzkpP" resolve="enumOrderedByDeclaration:lit2" />
           </node>
           <node concept="5mhuz" id="5WOGwuDLgdN" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzkpR" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzkpR" resolve="enumOrderedByDeclaration:lit3" />
           </node>
         </node>
       </node>
@@ -1690,13 +1690,13 @@
         </node>
         <node concept="3iBYfx" id="1ChS3oVlVsL" role="_fkuS">
           <node concept="5mhuz" id="1ChS3oVlVsM" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzntL" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzntL" resolve="enumOrderedByValue:lit3" />
           </node>
           <node concept="5mhuz" id="1ChS3oVlVsN" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="enumOrderedByValue:lit1" />
           </node>
           <node concept="5mhuz" id="1ChS3oVlVsO" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzntN" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzntN" resolve="enumOrderedByValue:lit2" />
           </node>
         </node>
       </node>
@@ -1712,13 +1712,13 @@
         </node>
         <node concept="3iBYfx" id="wlV$3lFJr0" role="_fkuS">
           <node concept="5mhuz" id="wlV$3lFJug" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzntN" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzntN" resolve="enumOrderedByValue:lit2" />
           </node>
           <node concept="5mhuz" id="wlV$3lFJr2" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzntJ" resolve="enumOrderedByValue:lit1" />
           </node>
           <node concept="5mhuz" id="wlV$3lFJuM" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzntL" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzntL" resolve="enumOrderedByValue:lit3" />
           </node>
         </node>
       </node>
@@ -1732,13 +1732,13 @@
         </node>
         <node concept="3iBYfx" id="2OJHliZwskp" role="_fkuS">
           <node concept="5mhuz" id="768MZDbn_ho" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="enumOrderedByLiteral:lit1" />
           </node>
           <node concept="5mhuz" id="768MZDbn_hV" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="enumOrderedByLiteral:lit2" />
           </node>
           <node concept="5mhuz" id="768MZDbn_iu" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="enumOrderedByLiteral:lit3" />
           </node>
         </node>
       </node>
@@ -1754,13 +1754,13 @@
         </node>
         <node concept="3iBYfx" id="2OJHliZwsnf" role="_fkuS">
           <node concept="5mhuz" id="768MZDbn_gP" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="lit3" />
+            <ref role="5mhpJ" node="wlV$3lzmk2" resolve="enumOrderedByLiteral:lit3" />
           </node>
           <node concept="5mhuz" id="768MZDbnpB6" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="lit2" />
+            <ref role="5mhpJ" node="wlV$3lzmk4" resolve="enumOrderedByLiteral:lit2" />
           </node>
           <node concept="5mhuz" id="768MZDbn_j1" role="3iBYfI">
-            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="lit1" />
+            <ref role="5mhpJ" node="wlV$3lzmk0" resolve="enumOrderedByLiteral:lit1" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -4534,9 +4534,6 @@
         <node concept="1amXfx" id="3GrH80XL728" role="1am$gN">
           <ref role="1amXd5" to="yv47:3Y6fbK1h_yq" resolve="EnumValueAccessor" />
         </node>
-        <node concept="1amXfx" id="3GrH80XLjyV" role="1am$gN">
-          <ref role="1amXd5" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
-        </node>
         <node concept="1amXfx" id="3GrH80XLw3I" role="1am$gN">
           <ref role="1amXd5" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.kernelf.editor/models/test.kernelf.editor.enums@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.kernelf.editor/models/test.kernelf.editor.enums@tests.mps
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:8e69af59-5985-4fff-ac56-1dca944c6493(test.kernelf.editor.enums@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="8" />
+    <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="4261931054731905240" name="org.iets3.core.expr.base.structure.IContainExpressionParam" flags="ngI" index="2lDidI">
+        <child id="4261931054731905241" name="expr" index="2lDidJ" />
+      </concept>
+      <concept id="7425695345928347719" name="org.iets3.core.expr.base.structure.Expression" flags="ng" index="2vmvVl" />
+    </language>
+    <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
+      <concept id="7061117989422575313" name="org.iets3.core.expr.toplevel.structure.EnumLiteral" flags="ng" index="5mgYR" />
+      <concept id="7061117989422575278" name="org.iets3.core.expr.toplevel.structure.EnumDeclaration" flags="ng" index="5mgZ8">
+        <property id="7061117989424763681" name="qualified" index="5dF97" />
+        <child id="7061117989422575348" name="literals" index="5mgYi" />
+      </concept>
+      <concept id="7061117989422577349" name="org.iets3.core.expr.toplevel.structure.EnumLiteralRef" flags="ng" index="5mhuz">
+        <reference id="7061117989422577417" name="literal" index="5mhpJ" />
+      </concept>
+      <concept id="7089558164906249676" name="org.iets3.core.expr.toplevel.structure.Constant" flags="ng" index="2zPypq" />
+      <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnU">
+        <child id="543569365052711058" name="contents" index="_iOnB" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="7F82HbPoLTR">
+    <property role="TrG5h" value="UnqualifiedLiteralTypedByBareName" />
+    <node concept="3clFbS" id="7F82HbPoLTS" role="LjaKd">
+      <node concept="2TK7Tu" id="7F82HbPoLTT" role="3cqZAp">
+        <property role="2TTd_B" value="red" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbPoLTU" role="25YQCW">
+      <node concept="_iOnU" id="7F82HbPoLTW" role="1qenE9">
+        <property role="TrG5h" value="before" />
+        <node concept="5mgZ8" id="7F82HbPoLTX" role="_iOnB">
+          <property role="TrG5h" value="Color" />
+          <node concept="5mgYR" id="7F82HbPoLTY" role="5mgYi">
+            <property role="TrG5h" value="red" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPoLTZ" role="5mgYi">
+            <property role="TrG5h" value="green" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbPoLU0" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbPoLU1" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPoLU2" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbPoLU3" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="2vmvVl" id="7F82HbPpFuy" role="2lDidJ">
+            <node concept="LIFWc" id="7F82HbP$k84" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Custom_1ltshm_a0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbPoLU5" role="25YQFr">
+      <node concept="_iOnU" id="7F82HbPoLU7" role="1qenE9">
+        <property role="TrG5h" value="before" />
+        <node concept="5mgZ8" id="7F82HbPoLU8" role="_iOnB">
+          <property role="TrG5h" value="Color" />
+          <node concept="5mgYR" id="7F82HbPoLU9" role="5mgYi">
+            <property role="TrG5h" value="red" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPoLUa" role="5mgYi">
+            <property role="TrG5h" value="green" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbPoLUb" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbPoLUc" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPoLUd" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbPoLUe" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="5mhuz" id="7F82HbPpFu$" role="2lDidJ">
+            <ref role="5mhpJ" node="7F82HbPoLU9" resolve="red" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="7F82HbPru2D">
+    <property role="TrG5h" value="BareNameBindsToUnqualifiedEnumNotToQualifiedOne" />
+    <node concept="3clFbS" id="7F82HbPru2E" role="LjaKd">
+      <node concept="2TK7Tu" id="7F82HbPru2F" role="3cqZAp">
+        <property role="2TTd_B" value="large" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbPru2G" role="25YQCW">
+      <node concept="_iOnU" id="7F82HbPru2I" role="1qenE9">
+        <property role="TrG5h" value="collide" />
+        <node concept="5mgZ8" id="7F82HbPru2J" role="_iOnB">
+          <property role="TrG5h" value="Sizes" />
+          <node concept="5mgYR" id="7F82HbPru2K" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru2L" role="5mgYi">
+            <property role="TrG5h" value="small" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbPru2M" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbPru2N" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru2O" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbPru2P" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="2vmvVl" id="7F82HbPrZ02" role="2lDidJ">
+            <node concept="LIFWc" id="7F82HbP$k4D" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Custom_1ltshm_a0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbPru2R" role="25YQFr">
+      <node concept="_iOnU" id="7F82HbPru2T" role="1qenE9">
+        <property role="TrG5h" value="collide" />
+        <node concept="5mgZ8" id="7F82HbPru2U" role="_iOnB">
+          <property role="TrG5h" value="Sizes" />
+          <node concept="5mgYR" id="7F82HbPru2V" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru2W" role="5mgYi">
+            <property role="TrG5h" value="small" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbPru2X" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbPru2Y" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru2Z" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbPru30" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="5mhuz" id="7F82HbPrZ04" role="2lDidJ">
+            <ref role="5mhpJ" node="7F82HbPru2V" resolve="large" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="7F82HbPru54">
+    <property role="TrG5h" value="QualifiedLiteralTypedByQualifiedName" />
+    <node concept="3clFbS" id="7F82HbPru55" role="LjaKd">
+      <node concept="2TK7Tu" id="7F82HbPru56" role="3cqZAp">
+        <property role="2TTd_B" value="Starbucks:large" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbPru57" role="25YQCW">
+      <node concept="_iOnU" id="7F82HbPru59" role="1qenE9">
+        <property role="TrG5h" value="qual" />
+        <node concept="5mgZ8" id="7F82HbPru5a" role="_iOnB">
+          <property role="TrG5h" value="Color" />
+          <node concept="5mgYR" id="7F82HbPru5b" role="5mgYi">
+            <property role="TrG5h" value="red" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru5c" role="5mgYi">
+            <property role="TrG5h" value="green" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbPru5d" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbPru5e" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru5f" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbPru5g" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="2vmvVl" id="7F82HbPrZ05" role="2lDidJ">
+            <node concept="LIFWc" id="7F82HbP$k6n" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Custom_1ltshm_a0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbPru5i" role="25YQFr">
+      <node concept="_iOnU" id="7F82HbPru5k" role="1qenE9">
+        <property role="TrG5h" value="qual" />
+        <node concept="5mgZ8" id="7F82HbPru5l" role="_iOnB">
+          <property role="TrG5h" value="Color" />
+          <node concept="5mgYR" id="7F82HbPru5m" role="5mgYi">
+            <property role="TrG5h" value="red" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru5n" role="5mgYi">
+            <property role="TrG5h" value="green" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbPru5o" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbPru5p" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbPru5q" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbPru5r" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="5mhuz" id="7F82HbPrZ07" role="2lDidJ">
+            <ref role="5mhpJ" node="7F82HbPru5p" resolve="Starbucks:large" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="7F82HbP$rAN">
+    <property role="TrG5h" value="RetypeQualifiedLiteralToSiblingLiteral" />
+    <node concept="3clFbS" id="7F82HbP$rAO" role="LjaKd">
+      <node concept="2TK7Tu" id="7F82HbP$rAP" role="3cqZAp">
+        <property role="2TTd_B" value="Starbucks:venti" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbP$rAQ" role="25YQCW">
+      <node concept="_iOnU" id="7F82HbP$rAS" role="1qenE9">
+        <property role="TrG5h" value="retype" />
+        <node concept="5mgZ8" id="7F82HbP$rAT" role="_iOnB">
+          <property role="TrG5h" value="Color" />
+          <node concept="5mgYR" id="7F82HbP$rAU" role="5mgYi">
+            <property role="TrG5h" value="red" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbP$rAV" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbP$rAW" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbP$rAX" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbP$rAY" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="5mhuz" id="7F82HbP_bJc" role="2lDidJ">
+            <ref role="5mhpJ" node="7F82HbP$rAW" resolve="Starbucks:large" />
+            <node concept="LIFWc" id="7F82HbP_bJd" role="lGtFl">
+              <property role="LIFWd" value="literal" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="15" />
+              <property role="ZRATv" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbP$rB0" role="25YQFr">
+      <node concept="_iOnU" id="7F82HbP$rB2" role="1qenE9">
+        <property role="TrG5h" value="retype" />
+        <node concept="5mgZ8" id="7F82HbP$rB3" role="_iOnB">
+          <property role="TrG5h" value="Color" />
+          <node concept="5mgYR" id="7F82HbP$rB4" role="5mgYi">
+            <property role="TrG5h" value="red" />
+          </node>
+        </node>
+        <node concept="5mgZ8" id="7F82HbP$rB5" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbP$rB6" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbP$rB7" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbP$rB8" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="5mhuz" id="7F82HbP_bJe" role="2lDidJ">
+            <ref role="5mhpJ" node="7F82HbP$rB7" resolve="Starbucks:venti" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="7F82HbP_ubd">
+    <property role="TrG5h" value="QualifiedLiteralNotOfferedByBareName" />
+    <node concept="3clFbS" id="7F82HbP_ube" role="LjaKd">
+      <node concept="2TK7Tu" id="7F82HbP_ubf" role="3cqZAp">
+        <property role="2TTd_B" value="large" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbP_ubg" role="25YQCW">
+      <node concept="_iOnU" id="7F82HbP_ubi" role="1qenE9">
+        <property role="TrG5h" value="hidden" />
+        <node concept="5mgZ8" id="7F82HbP_ubj" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbP_ubk" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbP_ubl" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbP_ubm" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="2vmvVl" id="7F82HbP_DDm" role="2lDidJ">
+            <node concept="LIFWc" id="7F82HbP_DDn" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Custom_1ltshm_a0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7F82HbP_ubo" role="25YQFr">
+      <node concept="_iOnU" id="7F82HbP_ubq" role="1qenE9">
+        <property role="TrG5h" value="hidden" />
+        <node concept="5mgZ8" id="7F82HbP_ubr" role="_iOnB">
+          <property role="TrG5h" value="Starbucks" />
+          <property role="5dF97" value="true" />
+          <node concept="5mgYR" id="7F82HbP_ubs" role="5mgYi">
+            <property role="TrG5h" value="large" />
+          </node>
+          <node concept="5mgYR" id="7F82HbP_ubt" role="5mgYi">
+            <property role="TrG5h" value="venti" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7F82HbP_ubu" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="2vmvVl" id="7F82HbP_DDo" role="2lDidJ">
+            <node concept="LIFWc" id="7F82HbP_DDp" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="5" />
+              <property role="p6zMs" value="5" />
+              <property role="LIFWd" value="Custom_1ltshm_a0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -12158,7 +12158,7 @@
             <ref role="5mh6l" node="3gKGtj9bXy4" resolve="Color" />
           </node>
           <node concept="5mhuz" id="3gKGtj9bXyg" role="2lDidJ">
-            <ref role="5mhpJ" node="3gKGtj9bXy9" resolve="large" />
+            <ref role="5mhpJ" node="3gKGtj9bXy9" resolve="Starbucks:large" />
             <node concept="7CXmI" id="5IOlOc8LvGa" role="lGtFl">
               <node concept="2DdRWr" id="5IOlOc8LvQC" role="7EUXB" />
             </node>


### PR DESCRIPTION
## Why

The editor usability of EnumLiteralRef was poor and inconsistent. Looks like 78a6bc01bc6f46f5314dc24d8c2d29657accd3d3 was an attempt to improve it.

In addition, resolveInfo stored only the simple name causing broken references to rebind to a same-named literal in a different enum.

The `qualified` flag was also being enforced by hand in four places: a filter in the `EnumLiteralRef` scope, a `matchingTextFunction` in a hand-written substitute menu, a second menu part working around that filter, and an auxiliary `QualifierRef` concept giving a two-step way to reach what the filter hid.

## What changed

Make the display and resolution namespaces agree, then let MPS's own machinery do the rest.

- **`EnumLiteral implements ISmartReferent`**, overriding `getPresentation(reference)` with a new `presentableName()` — qualified when the enum is, bare otherwise. This feeds `NodePresentationUtil#presentation` and, through the default cascade, `getVisibleMatchingText`.
- **A constraints property getter computes `IResolveInfo#resolveInfo`** from the same method. That is the resolution namespace: it keys `ListScope#forResolvableElements`, it is what `getMatchingText` falls through to, and `ResolveInfoUpdater` rewrites every reference's persisted `resolve=` string from it on save. Computed, never stored — the arrangement `baseLanguage`'s `Classifier` uses for nested class names. `EnumLiteral` was already an `IResolveInfo` via `IValidNamedConcept`; only the getter was missing, which is exactly why the scope fell through to `name`.
- **The `EnumLiteralRef` editor uses a `ref-presentation` cell**, so the editor cell and the completion row read that one method instead of two functions that happened to agree.

With those in place the special-casing is unnecessary and goes:

- `QualifierRef`, the intermediate concept for the two step creation of references to qualified enums. Zero instances, never part of a valid model, so no migration.
- **Both hand-written `EnumLiteralRef` substitute menus.** MPS regenerates the equivalent from the implicit smart reference attribute — a bare `ReferenceScopeSubstituteMenuPart` that reads its matching text from `ISmartReferent`. The editor aspect now carries no `EnumLiteralRef` menu code at all.
- The qualified filter in the `EnumLiteralRef` scope. What keeps a qualified enum's literals out of the general completion list is `PatternUtil` requiring the first typed character to match, so they surface only once the enum's name is typed.

`renderReadable()` now agrees with the editor for qualified enums.

## Tests

Five `EditorTestCase`s in a new `test.kernelf.editor.enums` model, all passing:

| test | types | asserts |
|---|---|---|
| `UnqualifiedLiteralTypedByBareName` | `red` | → `Color.red` |
| `BareNameBindsToUnqualifiedEnumNotToQualifiedOne` | `large` | → `Sizes.large`, **not** qualified `Starbucks.large` |
| `QualifiedLiteralNotOfferedByBareName` | `large` | nothing substituted |
| `QualifiedLiteralTypedByQualifiedName` | `Starbucks:large` | → `Starbucks.large` |
| `RetypeQualifiedLiteralToSiblingLiteral` | `Starbucks:venti` over an existing ref | → `Starbucks.venti` |

The second is the regression test for the rebind bug; the last covers what the deleted parameterized menu part used to provide.

## Notes for review

- Rebinding for **unqualified** enums is untouched, deliberately — a bare literal name is the identity in that namespace, and `ListScope.resolve` already returns null when two candidates share it, so it only ever fires when the name is globally unique.
