### PR TITLE
Variability: Do not overwrite feature attribute assignments if not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,20 @@ Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelo
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
 ## August 2026
+
 ### Fixed
 - Improve uniqueness name check of `IFunctionLike` `getUniquelyNamedElements()` behavior to avoid overzealous checking.
+- Variability: Feature attribute values are not overwritten anymore if the value stays the same. This avoids changing the model if not necessary, esp. it avoids merge conflicts.
 
 ## July 2026
+
 ### Added
 - IFunctionLike takes arguments and named body content into account when performing ab uniqueness name check
 - Developer tooling: the repository now ships an `iets3-os-developer` agent skill (under `.claude/skills/`) capturing repo-specific MPS language-engineering knowledge (variability, KernelF, physical units) for AI-assisted development with Claude Code.
 
 ### Fixed
 - Variability: `EvalVarPointCache.flushCaches()` was a no-op when the variability-aware artifact (IVAA) was implemented as a node attribute (annotation).
+
 
 ## June 2026
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.plugin.mps
@@ -17,6 +17,7 @@
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="3" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -522,15 +523,21 @@
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
       <concept id="1227026094155" name="jetbrains.mps.baseLanguage.collections.structure.RemoveLastElementOperation" flags="nn" index="2Kt5_m" />
       <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
         <child id="1205679832066" name="ascending" index="2S7zOq" />
       </concept>
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
@@ -540,6 +547,10 @@
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
       <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
@@ -7760,22 +7771,11 @@
     </node>
     <node concept="2tJIrI" id="5U0lJXvtUbS" role="jymVt" />
     <node concept="312cEg" id="5U0lJXv4AJD" role="jymVt">
-      <property role="TrG5h" value="expressionForFeatureAttributeAssignment" />
+      <property role="TrG5h" value="expressionForAttributeAssignment" />
+      <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="1Vm2qfJrNiL" role="1B3o_S" />
-      <node concept="2YIFZM" id="5U0lJXv4GWD" role="33vP2m">
-        <ref role="37wK5l" to="3o3z:~Lists.newLinkedList()" resolve="newLinkedList" />
-        <ref role="1Pybhc" to="3o3z:~Lists" resolve="Lists" />
-      </node>
-      <node concept="3vKaQO" id="5U0lJXvwEH4" role="1tU5fm">
-        <node concept="3uibUv" id="5U0lJXvwEH5" role="3O5elw">
-          <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-          <node concept="3Tqbb2" id="5s_r3CocHQK" role="11_B2D">
-            <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-          </node>
-          <node concept="3Tqbb2" id="5U0lJXvwEH8" role="11_B2D">
-            <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-          </node>
-        </node>
+      <node concept="3uibUv" id="6Y_FTmDGhS6" role="1tU5fm">
+        <ref role="3uigEE" node="6Y_FTmCDwuP" resolve="AssignmentValueList" />
       </node>
     </node>
     <node concept="312cEg" id="5U0lJXvq_HW" role="jymVt">
@@ -7798,7 +7798,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5U0lJXvquEp" role="jymVt" />
-    <node concept="2tJIrI" id="5U0lJXv4iGG" role="jymVt" />
     <node concept="3clFbW" id="b1tjOXxjp$" role="jymVt">
       <node concept="3cqZAl" id="b1tjOXxjp_" role="3clF45" />
       <node concept="3clFbS" id="b1tjOXxjpB" role="3clF47">
@@ -7815,16 +7814,8 @@
       </node>
       <node concept="37vLTG" id="5U0lJXvu1eL" role="3clF46">
         <property role="TrG5h" value="valuesForAttributes" />
-        <node concept="3vKaQO" id="5U0lJXwpcJX" role="1tU5fm">
-          <node concept="3uibUv" id="5U0lJXwpcJY" role="3O5elw">
-            <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-            <node concept="3Tqbb2" id="5s_r3Co570g" role="11_B2D">
-              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-            </node>
-            <node concept="3Tqbb2" id="5U0lJXwpcK1" role="11_B2D">
-              <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-            </node>
-          </node>
+        <node concept="3uibUv" id="6Y_FTmDGupJ" role="1tU5fm">
+          <ref role="3uigEE" node="6Y_FTmCDwuP" resolve="AssignmentValueList" />
         </node>
       </node>
       <node concept="37vLTG" id="5U0lJXvu1Fj" role="3clF46">
@@ -7871,7 +7862,7 @@
             <node concept="2OqwBi" id="5U0lJXvwApd" role="37vLTJ">
               <node concept="Xjq3P" id="5U0lJXvw_FC" role="2Oq$k0" />
               <node concept="2OwXpG" id="5U0lJXvwBnd" role="2OqNvi">
-                <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForFeatureAttributeAssignment" />
+                <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForAttributeAssignment" />
               </node>
             </node>
             <node concept="37vLTw" id="5U0lJXvwDW5" role="37vLTx">
@@ -7899,16 +7890,8 @@
       <node concept="3Tm6S6" id="6$693rs_ROW" role="1B3o_S" />
       <node concept="37vLTG" id="5U0lJXvw2jm" role="3clF46">
         <property role="TrG5h" value="valuesForAttributes" />
-        <node concept="3vKaQO" id="5U0lJXwpeLE" role="1tU5fm">
-          <node concept="3uibUv" id="5U0lJXwpeLF" role="3O5elw">
-            <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-            <node concept="3Tqbb2" id="5s_r3CokAyS" role="11_B2D">
-              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-            </node>
-            <node concept="3Tqbb2" id="5U0lJXwpeLI" role="11_B2D">
-              <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-            </node>
-          </node>
+        <node concept="3uibUv" id="6Y_FTmDGnFn" role="1tU5fm">
+          <ref role="3uigEE" node="6Y_FTmCDwuP" resolve="AssignmentValueList" />
         </node>
       </node>
       <node concept="37vLTG" id="5U0lJXvvU4C" role="3clF46">
@@ -7941,17 +7924,10 @@
           <node concept="37vLTw" id="6$693rsA3FO" role="37wK5m">
             <ref role="3cqZAo" node="4JT$GAQ8XJ6" resolve="failResult" />
           </node>
-          <node concept="2YIFZM" id="5U0lJXxeFFE" role="37wK5m">
-            <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
-            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
-            <node concept="3uibUv" id="5U0lJXxeKBv" role="3PaCim">
-              <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-              <node concept="3Tqbb2" id="5s_r3CokCvW" role="11_B2D">
-                <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-              </node>
-              <node concept="3Tqbb2" id="5U0lJXxeKBy" role="11_B2D">
-                <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-              </node>
+          <node concept="2ShNRf" id="6Y_FTmDGMxG" role="37wK5m">
+            <node concept="1pGfFk" id="6Y_FTmDGOcg" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="6Y_FTmCDW8E" resolve="AssignmentValueList" />
             </node>
           </node>
           <node concept="2YIFZM" id="5U0lJXxeGtW" role="37wK5m">
@@ -7973,32 +7949,20 @@
     </node>
     <node concept="2tJIrI" id="1Vm2qfJr1wJ" role="jymVt" />
     <node concept="3clFb_" id="1Vm2qfJq7_7" role="jymVt">
-      <property role="TrG5h" value="expressionForFeatureAttributeAssignment" />
+      <property role="TrG5h" value="expressionForAttributeAssignment" />
       <node concept="3Tm1VV" id="2OJr5rR5nsL" role="1B3o_S" />
       <node concept="3clFbS" id="1Vm2qfJq7_b" role="3clF47">
         <node concept="3clFbF" id="1Vm2qfJqq1F" role="3cqZAp">
-          <node concept="2YIFZM" id="1Vm2qfJqyEK" role="3clFbG">
-            <ref role="37wK5l" to="3o3z:~ImmutableList.copyOf(java.util.Collection)" resolve="copyOf" />
-            <ref role="1Pybhc" to="3o3z:~ImmutableList" resolve="ImmutableList" />
-            <node concept="2OqwBi" id="1Vm2qfJqMlI" role="37wK5m">
-              <node concept="Xjq3P" id="1Vm2qfJqDYI" role="2Oq$k0" />
-              <node concept="2OwXpG" id="1Vm2qfJqUP7" role="2OqNvi">
-                <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForFeatureAttributeAssignment" />
-              </node>
+          <node concept="2OqwBi" id="1Vm2qfJqMlI" role="3clFbG">
+            <node concept="Xjq3P" id="1Vm2qfJqDYI" role="2Oq$k0" />
+            <node concept="2OwXpG" id="1Vm2qfJqUP7" role="2OqNvi">
+              <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForAttributeAssignment" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="3vKaQO" id="1Vm2qfJqiOW" role="3clF45">
-        <node concept="3uibUv" id="1Vm2qfJqiOX" role="3O5elw">
-          <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-          <node concept="3Tqbb2" id="1Vm2qfJqiOY" role="11_B2D">
-            <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-          </node>
-          <node concept="3Tqbb2" id="1Vm2qfJqiOZ" role="11_B2D">
-            <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-          </node>
-        </node>
+      <node concept="3uibUv" id="6Y_FTmDH0$8" role="3clF45">
+        <ref role="3uigEE" node="6Y_FTmCDwuP" resolve="AssignmentValueList" />
       </node>
     </node>
     <node concept="2tJIrI" id="1Vm2qfJwHks" role="jymVt" />
@@ -8093,68 +8057,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="eCS_wK0Kc7" role="jymVt" />
-    <node concept="3clFb_" id="eCS_wK0P20" role="jymVt">
-      <property role="TrG5h" value="mapOfAttributeAssignmentToFixedValue" />
-      <node concept="3Tm1VV" id="2OJr5rR5Q_g" role="1B3o_S" />
-      <node concept="3clFbS" id="eCS_wK0P24" role="3clF47">
-        <node concept="3clFbF" id="eCS_wK0Taq" role="3cqZAp">
-          <node concept="2YIFZM" id="eCS_wK18FV" role="3clFbG">
-            <ref role="37wK5l" to="3o3z:~ImmutableMap.copyOf(java.lang.Iterable)" resolve="copyOf" />
-            <ref role="1Pybhc" to="3o3z:~ImmutableMap" resolve="ImmutableMap" />
-            <node concept="2OqwBi" id="77vQCjMh2o0" role="37wK5m">
-              <node concept="2OqwBi" id="eCS_wK18FW" role="2Oq$k0">
-                <node concept="Xjq3P" id="eCS_wK18FX" role="2Oq$k0" />
-                <node concept="2OwXpG" id="eCS_wK18FY" role="2OqNvi">
-                  <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForFeatureAttributeAssignment" />
-                </node>
-              </node>
-              <node concept="3$u5V9" id="77vQCjMh4s1" role="2OqNvi">
-                <node concept="1bVj0M" id="77vQCjMh4s2" role="23t8la">
-                  <node concept="3clFbS" id="77vQCjMh4s3" role="1bW5cS">
-                    <node concept="3clFbF" id="77vQCjMh4s4" role="3cqZAp">
-                      <node concept="2YIFZM" id="77vQCjMh4s5" role="3clFbG">
-                        <ref role="37wK5l" to="1qo3:~Pair.of(java.lang.Object,java.lang.Object)" resolve="of" />
-                        <ref role="1Pybhc" to="1qo3:~Pair" resolve="Pair" />
-                        <node concept="2OqwBi" id="77vQCjMh4s6" role="37wK5m">
-                          <node concept="37vLTw" id="77vQCjMh4s7" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4YqPvJUBHyI" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="77vQCjMh4s8" role="2OqNvi">
-                            <ref role="37wK5l" to="1qo3:~Pair.getRight()" resolve="getRight" />
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="77vQCjMh4s9" role="37wK5m">
-                          <node concept="37vLTw" id="77vQCjMh4sa" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4YqPvJUBHyI" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="77vQCjMh4sb" role="2OqNvi">
-                            <ref role="37wK5l" to="1qo3:~Pair.getLeft()" resolve="getLeft" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="gl6BB" id="4YqPvJUBHyI" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="4YqPvJUBHyJ" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="eCS_wK14AF" role="3clF45">
-        <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
-        <node concept="3Tqbb2" id="eCS_wK16KK" role="11_B2D">
-          <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-        </node>
-        <node concept="3Tqbb2" id="eCS_wK16KJ" role="11_B2D">
-          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="eCS_wK0dVo" role="jymVt" />
     <node concept="3clFbW" id="6jw22F8k8aP" role="jymVt">
       <node concept="3cqZAl" id="6jw22F8k8aS" role="3clF45" />
@@ -8242,7 +8144,7 @@
                   <node concept="2OqwBi" id="5U0lJXvwQAh" role="37wK5m">
                     <node concept="Xjq3P" id="5U0lJXvwPrP" role="2Oq$k0" />
                     <node concept="2OwXpG" id="5U0lJXvwSbk" role="2OqNvi">
-                      <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForFeatureAttributeAssignment" />
+                      <ref role="2Oxat5" node="5U0lJXv4AJD" resolve="expressionForAttributeAssignment" />
                     </node>
                   </node>
                 </node>
@@ -8305,99 +8207,60 @@
       <node concept="3cqZAl" id="5U0lJXzQlfS" role="3clF45" />
       <node concept="37vLTG" id="5U0lJXzQlfH" role="3clF46">
         <property role="TrG5h" value="faas" />
-        <node concept="A3Dl8" id="6qEFF$U4yx9" role="1tU5fm">
-          <node concept="3uibUv" id="6qEFF$U4yxb" role="A3Ik2">
-            <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-            <node concept="3Tqbb2" id="7_2J968haiP" role="11_B2D">
-              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-            </node>
-            <node concept="3Tqbb2" id="6qEFF$U4yxe" role="11_B2D">
-              <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-            </node>
-          </node>
+        <node concept="3uibUv" id="6Y_FTmDKsjs" role="1tU5fm">
+          <ref role="3uigEE" node="6Y_FTmCDwuP" resolve="AssignmentValueList" />
         </node>
       </node>
       <node concept="3clFbS" id="5U0lJXzQlfd" role="3clF47">
-        <node concept="3clFbF" id="5U0lJXzQlfe" role="3cqZAp">
-          <node concept="2OqwBi" id="5U0lJXzQlff" role="3clFbG">
-            <node concept="37vLTw" id="5U0lJXzQlfN" role="2Oq$k0">
+        <node concept="3clFbF" id="6Y_FTmDMh2W" role="3cqZAp">
+          <node concept="2OqwBi" id="6Y_FTmDMhoB" role="3clFbG">
+            <node concept="37vLTw" id="6Y_FTmDMh2U" role="2Oq$k0">
               <ref role="3cqZAo" node="5U0lJXzQlfH" resolve="faas" />
             </node>
-            <node concept="2es0OD" id="5U0lJXzQlfh" role="2OqNvi">
-              <node concept="1bVj0M" id="5U0lJXzQlfi" role="23t8la">
-                <node concept="3clFbS" id="5U0lJXzQlfj" role="1bW5cS">
-                  <node concept="3cpWs8" id="5U0lJXzQlfk" role="3cqZAp">
-                    <node concept="3cpWsn" id="5U0lJXzQlfl" role="3cpWs9">
-                      <property role="TrG5h" value="expr" />
-                      <node concept="3Tqbb2" id="5U0lJXzQlfm" role="1tU5fm">
-                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            <node concept="liA8E" id="6Y_FTmDMhKq" role="2OqNvi">
+              <ref role="37wK5l" node="6Y_FTmDKL29" resolve="forEach" />
+              <node concept="1bVj0M" id="6Y_FTmDMhZy" role="37wK5m">
+                <node concept="gl6BB" id="6Y_FTmDMhZF" role="1bW2Oz">
+                  <property role="TrG5h" value="expr" />
+                  <node concept="2jxLKc" id="6Y_FTmDMhZG" role="1tU5fm" />
+                </node>
+                <node concept="gl6BB" id="6Y_FTmDMhZN" role="1bW2Oz">
+                  <property role="TrG5h" value="faa" />
+                  <node concept="2jxLKc" id="6Y_FTmDMhZO" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="6Y_FTmDMhZP" role="1bW5cS">
+                  <node concept="3clFbF" id="G2E4WstpT0" role="3cqZAp">
+                    <node concept="1rXfSq" id="G2E4WstpT1" role="3clFbG">
+                      <ref role="37wK5l" node="G2E4WstiOn" resolve="setValueIfChanged" />
+                      <node concept="37vLTw" id="G2E4WstpT2" role="37wK5m">
+                        <ref role="3cqZAo" node="6Y_FTmDMhZN" resolve="faa" />
                       </node>
-                      <node concept="2OqwBi" id="5U0lJXzQlfn" role="33vP2m">
-                        <node concept="37vLTw" id="5U0lJXzQlfo" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2r1kIC$yAmS" resolve="it" />
-                        </node>
-                        <node concept="liA8E" id="5U0lJXzQlfp" role="2OqNvi">
-                          <ref role="37wK5l" to="1qo3:~Pair.getKey()" resolve="getKey" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="5U0lJXzQlfq" role="3cqZAp">
-                    <node concept="3cpWsn" id="5U0lJXzQlfr" role="3cpWs9">
-                      <property role="TrG5h" value="faa" />
-                      <node concept="3Tqbb2" id="5U0lJXzQlfs" role="1tU5fm">
-                        <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-                      </node>
-                      <node concept="2OqwBi" id="5U0lJXzQlft" role="33vP2m">
-                        <node concept="37vLTw" id="5U0lJXzQlfu" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2r1kIC$yAmS" resolve="it" />
-                        </node>
-                        <node concept="liA8E" id="5U0lJXzQlfv" role="2OqNvi">
-                          <ref role="37wK5l" to="1qo3:~Pair.getValue()" resolve="getValue" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5U0lJXzQlfw" role="3cqZAp">
-                    <node concept="37vLTI" id="6qEFF$TvHJ0" role="3clFbG">
-                      <node concept="2OqwBi" id="5U0lJXzQlfy" role="37vLTJ">
-                        <node concept="37vLTw" id="5U0lJXzQlfz" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5U0lJXzQlfr" resolve="faa" />
-                        </node>
-                        <node concept="3TrEf2" id="5U0lJXzQlf$" role="2OqNvi">
-                          <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
-                        </node>
-                      </node>
-                      <node concept="1rXfSq" id="2L0OAuPVFpN" role="37vLTx">
+                      <node concept="1rXfSq" id="G2E4WstpT3" role="37wK5m">
                         <ref role="37wK5l" node="2L0OAuPVwjG" resolve="attachUnitToExpression" />
-                        <node concept="37vLTw" id="2L0OAuPVG2R" role="37wK5m">
-                          <ref role="3cqZAo" node="5U0lJXzQlfl" resolve="expr" />
+                        <node concept="37vLTw" id="G2E4WstpT4" role="37wK5m">
+                          <ref role="3cqZAo" node="6Y_FTmDMhZF" resolve="expr" />
                         </node>
-                        <node concept="2OqwBi" id="2L0OAuPVGYs" role="37wK5m">
-                          <node concept="37vLTw" id="2L0OAuPVGCB" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5U0lJXzQlfr" resolve="faa" />
+                        <node concept="2OqwBi" id="G2E4WstpT5" role="37wK5m">
+                          <node concept="37vLTw" id="G2E4WstpT6" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6Y_FTmDMhZN" resolve="faa" />
                           </node>
-                          <node concept="3TrEf2" id="2L0OAuPVHx5" role="2OqNvi">
+                          <node concept="3TrEf2" id="G2E4WstpT7" role="2OqNvi">
                             <ref role="3Tt5mk" to="4ndm:30ECcbtMzQ8" resolve="attribute" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="5U0lJXzQlfB" role="3cqZAp">
-                    <node concept="2OqwBi" id="5U0lJXzQlfC" role="3clFbG">
-                      <node concept="37vLTw" id="5U0lJXzQlfD" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5U0lJXzQlfr" resolve="faa" />
+                  <node concept="3clFbF" id="6Y_FTmD12U0" role="3cqZAp">
+                    <node concept="2OqwBi" id="6Y_FTmD13ad" role="3clFbG">
+                      <node concept="37vLTw" id="6Y_FTmD12TY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6Y_FTmDMhZN" resolve="faa" />
                       </node>
-                      <node concept="2qgKlT" id="5U0lJXzQlfE" role="2OqNvi">
+                      <node concept="2qgKlT" id="6Y_FTmD13AG" role="2OqNvi">
                         <ref role="37wK5l" to="lte6:6jw22F9ba_Z" resolve="setCompulsory" />
                       </node>
                     </node>
                   </node>
-                </node>
-                <node concept="gl6BB" id="2r1kIC$yAmS" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="2r1kIC$yAmT" role="1tU5fm" />
                 </node>
               </node>
             </node>
@@ -8558,6 +8421,103 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="G2E4Wsxxf8" role="jymVt" />
+    <node concept="2YIFZL" id="G2E4WstiOn" role="jymVt">
+      <property role="TrG5h" value="setValueIfChanged" />
+      <node concept="3Tm6S6" id="6Y_FTmDl20k" role="1B3o_S" />
+      <node concept="3cqZAl" id="G2E4WstiOp" role="3clF45" />
+      <node concept="P$JXv" id="G2E4WstiOq" role="lGtFl">
+        <node concept="TZ5HA" id="G2E4WstiOr" role="TZ5H$">
+          <node concept="1dT_AC" id="G2E4WstiOs" role="1dT_Ay">
+            <property role="1dT_AB" value="Write the value only when it actually differs from the one already present, so that an" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="G2E4WstiOt" role="TZ5H$">
+          <node concept="1dT_AC" id="G2E4WstiOu" role="1dT_Ay">
+            <property role="1dT_AB" value="unchanged value keeps its node (and its node id) across solver runs and branches (issue #1921)." />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="G2E4WstiOv" role="3clF46">
+        <property role="TrG5h" value="faa" />
+        <node concept="3Tqbb2" id="G2E4WstiOw" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="G2E4WstiOx" role="3clF46">
+        <property role="TrG5h" value="newValue" />
+        <node concept="3Tqbb2" id="G2E4WstiOy" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="G2E4WstiOz" role="3clF47">
+        <node concept="3clFbJ" id="6Y_FTmCN14V" role="3cqZAp">
+          <node concept="3fqX7Q" id="6Y_FTmCN14W" role="3clFbw">
+            <node concept="1rXfSq" id="5$m_JoTCMA8" role="3fr31v">
+              <ref role="37wK5l" node="5$m_JoTC$Z8" resolve="isStructuralMatch" />
+              <node concept="2OqwBi" id="5$m_JoTCN15" role="37wK5m">
+                <node concept="37vLTw" id="5$m_JoTCMNi" role="2Oq$k0">
+                  <ref role="3cqZAo" node="G2E4WstiOv" resolve="faa" />
+                </node>
+                <node concept="3TrEf2" id="5$m_JoTCNzT" role="2OqNvi">
+                  <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5$m_JoTCOkv" role="37wK5m">
+                <ref role="3cqZAo" node="G2E4WstiOx" resolve="newValue" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="6Y_FTmCN153" role="3clFbx">
+            <node concept="3clFbF" id="6Y_FTmCN154" role="3cqZAp">
+              <node concept="37vLTI" id="6Y_FTmCN155" role="3clFbG">
+                <node concept="2OqwBi" id="6Y_FTmCN156" role="37vLTJ">
+                  <node concept="37vLTw" id="6Y_FTmCN157" role="2Oq$k0">
+                    <ref role="3cqZAo" node="G2E4WstiOv" resolve="faa" />
+                  </node>
+                  <node concept="3TrEf2" id="6Y_FTmCN158" role="2OqNvi">
+                    <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6Y_FTmCN159" role="37vLTx">
+                  <ref role="3cqZAo" node="G2E4WstiOx" resolve="newValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5$m_JoTCxcT" role="jymVt" />
+    <node concept="2YIFZL" id="5$m_JoTC$Z8" role="jymVt">
+      <property role="TrG5h" value="isStructuralMatch" />
+      <node concept="3clFbS" id="5$m_JoTC$Zb" role="3clF47">
+        <node concept="3clFbF" id="5$m_JoTCAgW" role="3cqZAp">
+          <node concept="2YFouu" id="5$m_JoTCAIi" role="3clFbG">
+            <node concept="37vLTw" id="5$m_JoTCARk" role="3uHU7w">
+              <ref role="3cqZAo" node="5$m_JoTC_vM" resolve="expr2" />
+            </node>
+            <node concept="37vLTw" id="5$m_JoTCAgV" role="3uHU7B">
+              <ref role="3cqZAo" node="5$m_JoTC_s7" resolve="expr1" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5$m_JoTCxJx" role="1B3o_S" />
+      <node concept="10P_77" id="5$m_JoTC$XO" role="3clF45" />
+      <node concept="37vLTG" id="5$m_JoTC_s7" role="3clF46">
+        <property role="TrG5h" value="expr1" />
+        <node concept="3Tqbb2" id="5$m_JoTC_s6" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5$m_JoTC_vM" role="3clF46">
+        <property role="TrG5h" value="expr2" />
+        <node concept="3Tqbb2" id="5$m_JoTC_NP" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="2BePqP5FSJm">
     <property role="TrG5h" value="ConfigurationSolverFacade" />
@@ -8571,6 +8531,7 @@
         <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6Y_FTmDF2dJ" role="jymVt" />
     <node concept="3clFbW" id="2BePqP5Km09" role="jymVt">
       <node concept="3cqZAl" id="2BePqP5Km0a" role="3clF45" />
       <node concept="3Tm1VV" id="2BePqP5Km0b" role="1B3o_S" />
@@ -9664,6 +9625,32 @@
                   <ref role="37wK5l" to="n8u2:uQ5YDztXEw" resolve="commandAction" />
                   <node concept="1bVj0M" id="2$kgRrWCzjI" role="37wK5m">
                     <node concept="3clFbS" id="2$kgRrWCzjL" role="1bW5cS">
+                      <node concept="3cpWs8" id="6Y_FTmCJhEC" role="3cqZAp">
+                        <node concept="3cpWsn" id="6Y_FTmCJhED" role="3cpWs9">
+                          <property role="TrG5h" value="valuesBeforeUnset" />
+                          <node concept="3uibUv" id="6Y_FTmCJhEE" role="1tU5fm">
+                            <ref role="3uigEE" node="6Y_FTmCDhWp" resolve="AssignmentValueMap" />
+                          </node>
+                          <node concept="2ShNRf" id="6Y_FTmCJDTt" role="33vP2m">
+                            <node concept="1pGfFk" id="6Y_FTmCJS0A" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" node="6Y_FTmCDrp3" resolve="AssignmentValueMap" />
+                              <node concept="2OqwBi" id="6Y_FTmCJZOQ" role="37wK5m">
+                                <node concept="37vLTw" id="6Y_FTmCJZOR" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2BePqP5KhiC" resolve="fmc" />
+                                </node>
+                                <node concept="2Rf3mk" id="6Y_FTmCJZOS" role="2OqNvi">
+                                  <node concept="1xMEDy" id="6Y_FTmCJZOT" role="1xVPHs">
+                                    <node concept="chp4Y" id="6Y_FTmCJZOU" role="ri$Ld">
+                                      <ref role="cht4Q" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                       <node concept="3clFbF" id="2BePqP5VSWH" role="3cqZAp">
                         <node concept="2OqwBi" id="2BePqP5VXEh" role="3clFbG">
                           <node concept="Xjq3P" id="2BePqP6f0Ar" role="2Oq$k0" />
@@ -9678,24 +9665,16 @@
                       <node concept="3clFbH" id="2OJr5rQ1UqB" role="3cqZAp" />
                       <node concept="3cpWs8" id="2OJr5rQ1INS" role="3cqZAp">
                         <node concept="3cpWsn" id="2OJr5rQ1IN7" role="3cpWs9">
-                          <property role="TrG5h" value="expressionForFeatureAttributeAssignmentAlreadySet" />
-                          <node concept="3vKaQO" id="2OJr5rQ1INO" role="1tU5fm">
-                            <node concept="3uibUv" id="2OJr5rQ1INP" role="3O5elw">
-                              <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
-                              <node concept="3Tqbb2" id="2OJr5rQ1INQ" role="11_B2D">
-                                <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-                              </node>
-                              <node concept="3Tqbb2" id="2OJr5rQ1INR" role="11_B2D">
-                                <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-                              </node>
-                            </node>
+                          <property role="TrG5h" value="expressionForAttributeAssignmentAlreadySet" />
+                          <node concept="3uibUv" id="6Y_FTmDNYRQ" role="1tU5fm">
+                            <ref role="3uigEE" node="6Y_FTmCDwuP" resolve="AssignmentValueList" />
                           </node>
                           <node concept="2OqwBi" id="2BePqP6atsc" role="33vP2m">
                             <node concept="37vLTw" id="2BePqP6ank7" role="2Oq$k0">
                               <ref role="3cqZAo" node="2OJr5rQM9RI" resolve="configFixedValues" />
                             </node>
                             <node concept="liA8E" id="1Vm2qfJrs76" role="2OqNvi">
-                              <ref role="37wK5l" node="1Vm2qfJq7_7" resolve="expressionForFeatureAttributeAssignment" />
+                              <ref role="37wK5l" node="1Vm2qfJq7_7" resolve="expressionForAttributeAssignment" />
                             </node>
                           </node>
                         </node>
@@ -9712,27 +9691,10 @@
                           <node concept="2OqwBi" id="2OJr5rRj$V8" role="33vP2m">
                             <node concept="2OqwBi" id="2OJr5rRj$V9" role="2Oq$k0">
                               <node concept="37vLTw" id="2OJr5rRj$Va" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2OJr5rQ1IN7" resolve="expressionForFeatureAttributeAssignmentAlreadySet" />
+                                <ref role="3cqZAo" node="2OJr5rQ1IN7" resolve="expressionForAttributeAssignmentAlreadySet" />
                               </node>
-                              <node concept="3$u5V9" id="2OJr5rRj$Vb" role="2OqNvi">
-                                <node concept="1bVj0M" id="2OJr5rRj$Vc" role="23t8la">
-                                  <node concept="3clFbS" id="2OJr5rRj$Vd" role="1bW5cS">
-                                    <node concept="3clFbF" id="2OJr5rRj$Ve" role="3cqZAp">
-                                      <node concept="2OqwBi" id="2OJr5rRj$Vf" role="3clFbG">
-                                        <node concept="37vLTw" id="2OJr5rRj$Vg" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="2OJr5rRj$Vi" resolve="it" />
-                                        </node>
-                                        <node concept="liA8E" id="2OJr5rRj$Vh" role="2OqNvi">
-                                          <ref role="37wK5l" to="1qo3:~Pair.getValue()" resolve="getValue" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="gl6BB" id="2OJr5rRj$Vi" role="1bW2Oz">
-                                    <property role="TrG5h" value="it" />
-                                    <node concept="2jxLKc" id="2OJr5rRj$Vj" role="1tU5fm" />
-                                  </node>
-                                </node>
+                              <node concept="liA8E" id="6Y_FTmDPfKJ" role="2OqNvi">
+                                <ref role="37wK5l" node="6Y_FTmDOBNm" resolve="assignments" />
                               </node>
                             </node>
                             <node concept="ANE8D" id="2OJr5rRj$Vk" role="2OqNvi" />
@@ -9747,6 +9709,9 @@
                           </node>
                           <node concept="37vLTw" id="2OJr5rR_8Lc" role="37wK5m">
                             <ref role="3cqZAo" node="2OJr5rRj$V7" resolve="faas" />
+                          </node>
+                          <node concept="37vLTw" id="6Y_FTmCx4Qm" role="37wK5m">
+                            <ref role="3cqZAo" node="6Y_FTmCJhED" resolve="valuesBeforeUnset" />
                           </node>
                         </node>
                       </node>
@@ -9993,7 +9958,7 @@
         </node>
       </node>
       <node concept="37vLTG" id="2OJr5rR_fA0" role="3clF46">
-        <property role="TrG5h" value="expressionForFeatureAttributeAssignmentAlreadySet" />
+        <property role="TrG5h" value="expressionForAttributeAssignmentAlreadySet" />
         <node concept="_YKpA" id="2OJr5rR_fA1" role="1tU5fm">
           <node concept="3Tqbb2" id="2OJr5rR_fA2" role="_ZDj9">
             <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
@@ -10020,8 +9985,14 @@
         <node concept="TUZQ0" id="1GjSFjioPxt" role="3nqlJM">
           <property role="TUZQ4" value=" " />
           <node concept="zr_55" id="1GjSFjioPxv" role="zr_5Q">
-            <ref role="zr_51" node="2OJr5rR_fA0" resolve="expressionForFeatureAttributeAssignmentAlreadySet" />
+            <ref role="zr_51" node="2OJr5rR_fA0" resolve="expressionForAttributeAssignmentAlreadySet" />
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6Y_FTmCwHm2" role="3clF46">
+        <property role="TrG5h" value="valuesBeforeUnset" />
+        <node concept="3uibUv" id="6Y_FTmCLe6N" role="1tU5fm">
+          <ref role="3uigEE" node="6Y_FTmCDhWp" resolve="AssignmentValueMap" />
         </node>
       </node>
     </node>
@@ -10528,22 +10499,21 @@
         </node>
         <node concept="3cpWs8" id="5$7ebOseCUJ" role="3cqZAp">
           <node concept="3cpWsn" id="5$7ebOseCUK" role="3cpWs9">
-            <property role="TrG5h" value="attributeAssignment2Expression" />
-            <node concept="3uibUv" id="5$7ebOseCUL" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
-              <node concept="3Tqbb2" id="5$7ebOseCUM" role="11_B2D">
-                <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
-              </node>
-              <node concept="3Tqbb2" id="5$7ebOseCUN" role="11_B2D">
-                <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-              </node>
+            <property role="TrG5h" value="attributeAssignment2Expr" />
+            <node concept="3uibUv" id="6Y_FTmDQ_DV" role="1tU5fm">
+              <ref role="3uigEE" node="6Y_FTmCDhWp" resolve="AssignmentValueMap" />
             </node>
-            <node concept="2OqwBi" id="5$7ebOseCUO" role="33vP2m">
-              <node concept="37vLTw" id="5$7ebOseCVv" role="2Oq$k0">
-                <ref role="3cqZAo" node="5$7ebOseCVt" resolve="configFixedValues" />
+            <node concept="2OqwBi" id="6Y_FTmDR13m" role="33vP2m">
+              <node concept="2OqwBi" id="5$7ebOseCUO" role="2Oq$k0">
+                <node concept="37vLTw" id="5$7ebOseCVv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5$7ebOseCVt" resolve="configFixedValues" />
+                </node>
+                <node concept="liA8E" id="5$7ebOseCUQ" role="2OqNvi">
+                  <ref role="37wK5l" node="1Vm2qfJq7_7" resolve="expressionForAttributeAssignment" />
+                </node>
               </node>
-              <node concept="liA8E" id="5$7ebOseCUQ" role="2OqNvi">
-                <ref role="37wK5l" node="eCS_wK0P20" resolve="mapOfAttributeAssignmentToFixedValue" />
+              <node concept="liA8E" id="6Y_FTmDR9i_" role="2OqNvi">
+                <ref role="37wK5l" node="6Y_FTmDHQMI" resolve="asMap" />
               </node>
             </node>
           </node>
@@ -10569,10 +10539,10 @@
                       </node>
                       <node concept="2OqwBi" id="5$7ebOseCV4" role="33vP2m">
                         <node concept="37vLTw" id="5$7ebOseCV5" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$7ebOseCUK" resolve="attributeAssignment2Expression" />
+                          <ref role="3cqZAo" node="5$7ebOseCUK" resolve="attributeAssignment2Expr" />
                         </node>
                         <node concept="liA8E" id="5$7ebOseCV6" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
+                          <ref role="37wK5l" node="6Y_FTmCIu34" resolve="get" />
                           <node concept="37vLTw" id="5$7ebOseCV7" role="37wK5m">
                             <ref role="3cqZAo" node="5$7ebOseCVp" resolve="attrAssign" />
                           </node>
@@ -10831,10 +10801,30 @@
       <node concept="3Tm6S6" id="2BePqP68C2w" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="2BePqP5JuOT" role="jymVt" />
-    <node concept="2tJIrI" id="2BePqP5KKIi" role="jymVt" />
     <node concept="3clFb_" id="2BePqP5JZy_" role="jymVt">
       <property role="TrG5h" value="unsetAutomaticAttributeAssignment" />
       <node concept="3clFbS" id="24Bo9f1UMtp" role="3clF47">
+        <node concept="3cpWs8" id="G2E4WstsJm" role="3cqZAp">
+          <node concept="3cpWsn" id="G2E4WstsJn" role="3cpWs9">
+            <property role="TrG5h" value="newValues" />
+            <node concept="3uibUv" id="6Y_FTmDRyI9" role="1tU5fm">
+              <ref role="3uigEE" node="6Y_FTmCDhWp" resolve="AssignmentValueMap" />
+            </node>
+            <node concept="2OqwBi" id="6Y_FTmDROy$" role="33vP2m">
+              <node concept="2OqwBi" id="G2E4WstsJr" role="2Oq$k0">
+                <node concept="37vLTw" id="G2E4WstsJs" role="2Oq$k0">
+                  <ref role="3cqZAo" node="G2E4WstrMR" resolve="configFixedValues" />
+                </node>
+                <node concept="liA8E" id="G2E4WstsJt" role="2OqNvi">
+                  <ref role="37wK5l" node="1Vm2qfJq7_7" resolve="expressionForAttributeAssignment" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6Y_FTmDS0nz" role="2OqNvi">
+                <ref role="37wK5l" node="6Y_FTmDHQMI" resolve="asMap" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="24Bo9f1UMtq" role="3cqZAp">
           <node concept="2OqwBi" id="24Bo9f1UMtr" role="3clFbG">
             <node concept="2OqwBi" id="24Bo9f1UMts" role="2Oq$k0">
@@ -10854,11 +10844,11 @@
                 <node concept="1bVj0M" id="24Bo9f1UMtz" role="23t8la">
                   <node concept="3clFbS" id="24Bo9f1UMt$" role="1bW5cS">
                     <node concept="3clFbF" id="24Bo9f1UMt_" role="3cqZAp">
-                      <node concept="2OqwBi" id="24Bo9f1UMtA" role="3clFbG">
-                        <node concept="37vLTw" id="24Bo9f1UMtB" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6Y_FTmCwnjE" role="3clFbG">
+                        <node concept="37vLTw" id="6Y_FTmCwnjF" role="2Oq$k0">
                           <ref role="3cqZAo" node="24Bo9f1UMtD" resolve="it" />
                         </node>
-                        <node concept="2qgKlT" id="24Bo9f1UMtC" role="2OqNvi">
+                        <node concept="2qgKlT" id="6Y_FTmCwnjG" role="2OqNvi">
                           <ref role="37wK5l" to="lte6:zJQZm70xzm" resolve="automatic" />
                         </node>
                       </node>
@@ -10874,28 +10864,46 @@
             <node concept="2es0OD" id="24Bo9f1UMtF" role="2OqNvi">
               <node concept="1bVj0M" id="24Bo9f1UMtG" role="23t8la">
                 <node concept="3clFbS" id="24Bo9f1UMtH" role="1bW5cS">
-                  <node concept="3clFbF" id="24Bo9f1UMtI" role="3cqZAp">
-                    <node concept="2OqwBi" id="24Bo9f1UMtJ" role="3clFbG">
-                      <node concept="2OqwBi" id="24Bo9f1UMtK" role="2Oq$k0">
-                        <node concept="37vLTw" id="24Bo9f1UMtL" role="2Oq$k0">
-                          <ref role="3cqZAo" node="24Bo9f1UMtT" resolve="it" />
+                  <node concept="3clFbJ" id="G2E4WsttFW" role="3cqZAp">
+                    <node concept="2OqwBi" id="G2E4Wsybb7" role="3clFbw">
+                      <node concept="2OqwBi" id="G2E4WsttFY" role="2Oq$k0">
+                        <node concept="37vLTw" id="G2E4WsttFZ" role="2Oq$k0">
+                          <ref role="3cqZAo" node="G2E4WstsJn" resolve="newValues" />
                         </node>
-                        <node concept="3TrEf2" id="24Bo9f1UMtM" role="2OqNvi">
-                          <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                        <node concept="liA8E" id="G2E4WsttG0" role="2OqNvi">
+                          <ref role="37wK5l" node="6Y_FTmCIu34" resolve="get" />
+                          <node concept="37vLTw" id="G2E4WsttG1" role="37wK5m">
+                            <ref role="3cqZAo" node="24Bo9f1UMtT" resolve="it" />
+                          </node>
                         </node>
                       </node>
-                      <node concept="2oxUTD" id="24Bo9f1UMtN" role="2OqNvi">
-                        <node concept="10Nm6u" id="24Bo9f1UMtO" role="2oxUTC" />
-                      </node>
+                      <node concept="3w_OXm" id="G2E4WsykDh" role="2OqNvi" />
                     </node>
-                  </node>
-                  <node concept="3clFbF" id="24Bo9f1UMtP" role="3cqZAp">
-                    <node concept="2OqwBi" id="24Bo9f1UMtQ" role="3clFbG">
-                      <node concept="37vLTw" id="24Bo9f1UMtR" role="2Oq$k0">
-                        <ref role="3cqZAo" node="24Bo9f1UMtT" resolve="it" />
+                    <node concept="3clFbS" id="G2E4WsttG3" role="3clFbx">
+                      <node concept="3clFbF" id="24Bo9f1UMtI" role="3cqZAp">
+                        <node concept="2OqwBi" id="24Bo9f1UMtJ" role="3clFbG">
+                          <node concept="2OqwBi" id="24Bo9f1UMtK" role="2Oq$k0">
+                            <node concept="37vLTw" id="24Bo9f1UMtL" role="2Oq$k0">
+                              <ref role="3cqZAo" node="24Bo9f1UMtT" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="24Bo9f1UMtM" role="2OqNvi">
+                              <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                            </node>
+                          </node>
+                          <node concept="2oxUTD" id="24Bo9f1UMtN" role="2OqNvi">
+                            <node concept="10Nm6u" id="24Bo9f1UMtO" role="2oxUTC" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="2qgKlT" id="24Bo9f1UMtS" role="2OqNvi">
-                        <ref role="37wK5l" to="lte6:6jw22F99kPS" resolve="unsetAutomatic" />
+                      <node concept="3clFbF" id="24Bo9f1UMtP" role="3cqZAp">
+                        <node concept="2OqwBi" id="24Bo9f1UMtQ" role="3clFbG">
+                          <node concept="37vLTw" id="24Bo9f1UMtR" role="2Oq$k0">
+                            <ref role="3cqZAo" node="24Bo9f1UMtT" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="24Bo9f1UMtS" role="2OqNvi">
+                            <ref role="37wK5l" to="lte6:6jw22F99kPS" resolve="unsetAutomatic" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -10912,6 +10920,12 @@
       </node>
       <node concept="3cqZAl" id="24Bo9f1UMu0" role="3clF45" />
       <node concept="3Tm6S6" id="24Bo9f1UMtZ" role="1B3o_S" />
+      <node concept="37vLTG" id="G2E4WstrMR" role="3clF46">
+        <property role="TrG5h" value="configFixedValues" />
+        <node concept="3uibUv" id="G2E4WstrMS" role="1tU5fm">
+          <ref role="3uigEE" node="b1tjOXxaeY" resolve="ConfigFixedValues" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="2BePqP5JuOU" role="jymVt" />
     <node concept="3clFb_" id="2BePqP5Ljni" role="jymVt">
@@ -11133,6 +11147,9 @@
             <node concept="Xjq3P" id="2BePqP5MLSv" role="2Oq$k0" />
             <node concept="liA8E" id="2BePqP5MRtO" role="2OqNvi">
               <ref role="37wK5l" node="2BePqP5JZy_" resolve="unsetAutomaticAttributeAssignment" />
+              <node concept="37vLTw" id="G2E4WstwOB" role="37wK5m">
+                <ref role="3cqZAo" node="2pcB_fRT7I2" resolve="configFixedValues" />
+              </node>
             </node>
           </node>
         </node>
@@ -11638,7 +11655,7 @@
                 <ref role="3cqZAo" node="6$693rsRuZS" resolve="fv" />
               </node>
               <node concept="liA8E" id="1Vm2qfJrG25" role="2OqNvi">
-                <ref role="37wK5l" node="1Vm2qfJq7_7" resolve="expressionForFeatureAttributeAssignment" />
+                <ref role="37wK5l" node="1Vm2qfJq7_7" resolve="expressionForAttributeAssignment" />
               </node>
             </node>
           </node>
@@ -12272,6 +12289,400 @@
     <node concept="3Tm1VV" id="7Sbg4UjP3Uf" role="1B3o_S" />
     <node concept="3uibUv" id="7Sbg4UjPS$D" role="1zkMxy">
       <ref role="3uigEE" to="2rbz:7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
+    </node>
+  </node>
+  <node concept="312cEu" id="6Y_FTmCDhWp">
+    <property role="TrG5h" value="AssignmentValueMap" />
+    <property role="3GE5qa" value="solver" />
+    <node concept="2tJIrI" id="6Y_FTmCDhW$" role="jymVt" />
+    <node concept="312cEg" id="6Y_FTmCDllw" role="jymVt">
+      <property role="TrG5h" value="faa2value" />
+      <node concept="3Tm6S6" id="6Y_FTmCDihJ" role="1B3o_S" />
+      <node concept="3rvAFt" id="6Y_FTmCDlik" role="1tU5fm">
+        <node concept="3Tqbb2" id="6Y_FTmCDmA7" role="3rvQeY">
+          <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+        </node>
+        <node concept="3Tqbb2" id="6Y_FTmCDr6P" role="3rvSg0">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="6Y_FTmCIbHh" role="33vP2m">
+        <node concept="32Fmki" id="6Y_FTmCIk36" role="2ShVmc" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmCDllP" role="jymVt" />
+    <node concept="3clFbW" id="6Y_FTmCDrp3" role="jymVt">
+      <node concept="3cqZAl" id="6Y_FTmCDrp5" role="3clF45" />
+      <node concept="3Tmbuc" id="5$m_JoTBhC8" role="1B3o_S" />
+      <node concept="3clFbS" id="6Y_FTmCDrp7" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmCIlrx" role="3cqZAp">
+          <node concept="2OqwBi" id="6Y_FTmCIm0K" role="3clFbG">
+            <node concept="37vLTw" id="6Y_FTmCIlrv" role="2Oq$k0">
+              <ref role="3cqZAo" node="6Y_FTmCI5BT" resolve="assignments" />
+            </node>
+            <node concept="2es0OD" id="6Y_FTmCImwQ" role="2OqNvi">
+              <node concept="1bVj0M" id="6Y_FTmCImwS" role="23t8la">
+                <node concept="3clFbS" id="6Y_FTmCImwT" role="1bW5cS">
+                  <node concept="3clFbJ" id="6Y_FTmCKI8G" role="3cqZAp">
+                    <node concept="3clFbS" id="6Y_FTmCKI8I" role="3clFbx">
+                      <node concept="3clFbF" id="6Y_FTmCIr2c" role="3cqZAp">
+                        <node concept="37vLTI" id="6Y_FTmCIsuU" role="3clFbG">
+                          <node concept="2OqwBi" id="6Y_FTmCKLWK" role="37vLTx">
+                            <node concept="37vLTw" id="6Y_FTmCIs_u" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6Y_FTmCImwU" resolve="faa" />
+                            </node>
+                            <node concept="3TrEf2" id="6Y_FTmCKMuk" role="2OqNvi">
+                              <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                            </node>
+                          </node>
+                          <node concept="3EllGN" id="6Y_FTmCIrYv" role="37vLTJ">
+                            <node concept="37vLTw" id="6Y_FTmCIscF" role="3ElVtu">
+                              <ref role="3cqZAo" node="6Y_FTmCImwU" resolve="faa" />
+                            </node>
+                            <node concept="37vLTw" id="6Y_FTmCIr29" role="3ElQJh">
+                              <ref role="3cqZAo" node="6Y_FTmCDllw" resolve="faa2value" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="6Y_FTmCKJnf" role="3clFbw">
+                      <node concept="2OqwBi" id="6Y_FTmCKIqu" role="2Oq$k0">
+                        <node concept="37vLTw" id="6Y_FTmCKIbl" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6Y_FTmCImwU" resolve="faa" />
+                        </node>
+                        <node concept="3TrEf2" id="6Y_FTmCKJ3P" role="2OqNvi">
+                          <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                        </node>
+                      </node>
+                      <node concept="3x8VRR" id="6Y_FTmCKKBv" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6Y_FTmCImwU" role="1bW2Oz">
+                  <property role="TrG5h" value="faa" />
+                  <node concept="2jxLKc" id="6Y_FTmCImwV" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6Y_FTmCI5BT" role="3clF46">
+        <property role="TrG5h" value="assignments" />
+        <node concept="A3Dl8" id="6Y_FTmCI5BR" role="1tU5fm">
+          <node concept="3Tqbb2" id="6Y_FTmCI6mK" role="A3Ik2">
+            <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmDHmUe" role="jymVt" />
+    <node concept="3clFbW" id="6Y_FTmDHzKj" role="jymVt">
+      <node concept="37vLTG" id="6Y_FTmDHA9O" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="3vKaQO" id="6Y_FTmDImpO" role="1tU5fm">
+          <node concept="3uibUv" id="6Y_FTmDImpQ" role="3O5elw">
+            <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
+            <node concept="3Tqbb2" id="6Y_FTmDImpR" role="11_B2D">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="3Tqbb2" id="6Y_FTmDImpS" role="11_B2D">
+              <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6Y_FTmDHzKl" role="3clF45" />
+      <node concept="3Tmbuc" id="5$m_JoTBhOW" role="1B3o_S" />
+      <node concept="3clFbS" id="6Y_FTmDHzKn" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmDHADX" role="3cqZAp">
+          <node concept="2OqwBi" id="6Y_FTmDHAOp" role="3clFbG">
+            <node concept="37vLTw" id="6Y_FTmDHADW" role="2Oq$k0">
+              <ref role="3cqZAo" node="6Y_FTmDHA9O" resolve="data" />
+            </node>
+            <node concept="2es0OD" id="6Y_FTmDI9d2" role="2OqNvi">
+              <node concept="1bVj0M" id="6Y_FTmDI9d4" role="23t8la">
+                <node concept="3clFbS" id="6Y_FTmDI9d5" role="1bW5cS">
+                  <node concept="3clFbF" id="6Y_FTmDI9uJ" role="3cqZAp">
+                    <node concept="37vLTI" id="6Y_FTmDIeMA" role="3clFbG">
+                      <node concept="2OqwBi" id="6Y_FTmDIfaB" role="37vLTx">
+                        <node concept="37vLTw" id="6Y_FTmDIeSi" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6Y_FTmDI9d6" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="6Y_FTmDIhjP" role="2OqNvi">
+                          <ref role="37wK5l" to="1qo3:~Pair.getLeft()" resolve="getLeft" />
+                        </node>
+                      </node>
+                      <node concept="3EllGN" id="6Y_FTmDIarZ" role="37vLTJ">
+                        <node concept="2OqwBi" id="6Y_FTmDIbta" role="3ElVtu">
+                          <node concept="37vLTw" id="6Y_FTmDIayS" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6Y_FTmDI9d6" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="6Y_FTmDIdv_" role="2OqNvi">
+                            <ref role="37wK5l" to="1qo3:~Pair.getRight()" resolve="getRight" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6Y_FTmDI9uI" role="3ElQJh">
+                          <ref role="3cqZAo" node="6Y_FTmCDllw" resolve="faa2value" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6Y_FTmDI9d6" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6Y_FTmDI9d7" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmCIsUy" role="jymVt" />
+    <node concept="3clFb_" id="6Y_FTmCIu34" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="3clFbS" id="6Y_FTmCIu37" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmCIvuh" role="3cqZAp">
+          <node concept="3EllGN" id="6Y_FTmCIwDx" role="3clFbG">
+            <node concept="37vLTw" id="6Y_FTmCIwRN" role="3ElVtu">
+              <ref role="3cqZAo" node="6Y_FTmCIuyz" resolve="faa" />
+            </node>
+            <node concept="37vLTw" id="6Y_FTmCIvug" role="3ElQJh">
+              <ref role="3cqZAo" node="6Y_FTmCDllw" resolve="faa2value" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6Y_FTmCItqZ" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6Y_FTmCItLM" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+      <node concept="37vLTG" id="6Y_FTmCIuyz" role="3clF46">
+        <property role="TrG5h" value="faa" />
+        <node concept="3Tqbb2" id="6Y_FTmCIuyy" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="6Y_FTmCDhWq" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="6Y_FTmCDwuP">
+    <property role="3GE5qa" value="solver" />
+    <property role="TrG5h" value="AssignmentValueList" />
+    <node concept="3Tm1VV" id="6Y_FTmCDwuQ" role="1B3o_S" />
+    <node concept="2tJIrI" id="6Y_FTmCDwvi" role="jymVt" />
+    <node concept="312cEg" id="6Y_FTmCDzVV" role="jymVt">
+      <property role="TrG5h" value="items" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6Y_FTmCDwOt" role="1B3o_S" />
+      <node concept="_YKpA" id="6Y_FTmCDx0D" role="1tU5fm">
+        <node concept="3uibUv" id="6Y_FTmCDzxO" role="_ZDj9">
+          <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
+          <node concept="3Tqbb2" id="6Y_FTmCDzxP" role="11_B2D">
+            <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+          </node>
+          <node concept="3Tqbb2" id="6Y_FTmCDzxQ" role="11_B2D">
+            <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmCDVTt" role="jymVt" />
+    <node concept="3clFbW" id="6Y_FTmCDW8E" role="jymVt">
+      <node concept="3cqZAl" id="6Y_FTmCDW8G" role="3clF45" />
+      <node concept="3Tmbuc" id="5$m_JoTDFV6" role="1B3o_S" />
+      <node concept="3clFbS" id="6Y_FTmCDW8I" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmCDWqr" role="3cqZAp">
+          <node concept="37vLTI" id="6Y_FTmCE0dv" role="3clFbG">
+            <node concept="2ShNRf" id="6Y_FTmCE0xC" role="37vLTx">
+              <node concept="2Jqq0_" id="6Y_FTmCE0oX" role="2ShVmc">
+                <node concept="3uibUv" id="6Y_FTmCE0oY" role="HW$YZ">
+                  <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
+                  <node concept="3Tqbb2" id="6Y_FTmCE0oZ" role="11_B2D">
+                    <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                  </node>
+                  <node concept="3Tqbb2" id="6Y_FTmCE0p0" role="11_B2D">
+                    <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6Y_FTmCDWxR" role="37vLTJ">
+              <node concept="Xjq3P" id="6Y_FTmCDWqq" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6Y_FTmCDYAP" role="2OqNvi">
+                <ref role="2Oxat5" node="6Y_FTmCDzVV" resolve="items" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmDVVQf" role="jymVt" />
+    <node concept="3clFbW" id="6Y_FTmDW9tv" role="jymVt">
+      <node concept="3cqZAl" id="6Y_FTmDW9tx" role="3clF45" />
+      <node concept="3Tm1VV" id="6Y_FTmDW9ty" role="1B3o_S" />
+      <node concept="3clFbS" id="6Y_FTmDW9tz" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmDWkmQ" role="3cqZAp">
+          <node concept="37vLTI" id="6Y_FTmDWmKZ" role="3clFbG">
+            <node concept="2OqwBi" id="6Y_FTmDWo6C" role="37vLTx">
+              <node concept="37vLTw" id="6Y_FTmDWn0G" role="2Oq$k0">
+                <ref role="3cqZAo" node="6Y_FTmDWjn$" resolve="data" />
+              </node>
+              <node concept="ANE8D" id="6Y_FTmDWr5S" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="6Y_FTmDWkuo" role="37vLTJ">
+              <node concept="Xjq3P" id="6Y_FTmDWkmP" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6Y_FTmDWkWY" role="2OqNvi">
+                <ref role="2Oxat5" node="6Y_FTmCDzVV" resolve="items" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6Y_FTmDWjn$" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="A3Dl8" id="6Y_FTmDWjny" role="1tU5fm">
+          <node concept="3uibUv" id="6Y_FTmDWjxT" role="A3Ik2">
+            <ref role="3uigEE" to="1qo3:~Pair" resolve="Pair" />
+            <node concept="3Tqbb2" id="6Y_FTmDWjxU" role="11_B2D">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="3Tqbb2" id="6Y_FTmDWjxV" role="11_B2D">
+              <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmDHB1r" role="jymVt" />
+    <node concept="3clFb_" id="6Y_FTmDHQMI" role="jymVt">
+      <property role="TrG5h" value="asMap" />
+      <node concept="3clFbS" id="6Y_FTmDHQML" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmDHXWi" role="3cqZAp">
+          <node concept="2ShNRf" id="6Y_FTmDHXWg" role="3clFbG">
+            <node concept="1pGfFk" id="6Y_FTmDHZA7" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="6Y_FTmDHzKj" resolve="AssignmentValueMap" />
+              <node concept="37vLTw" id="6Y_FTmDI1qx" role="37wK5m">
+                <ref role="3cqZAo" node="6Y_FTmCDzVV" resolve="items" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="5$m_JoTDG4K" role="1B3o_S" />
+      <node concept="3uibUv" id="6Y_FTmDHQMw" role="3clF45">
+        <ref role="3uigEE" node="6Y_FTmCDhWp" resolve="AssignmentValueMap" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmDOqUx" role="jymVt" />
+    <node concept="3clFb_" id="6Y_FTmDOBNm" role="jymVt">
+      <property role="TrG5h" value="assignments" />
+      <node concept="3clFbS" id="6Y_FTmDOBNp" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmDOF5_" role="3cqZAp">
+          <node concept="2OqwBi" id="6Y_FTmDOIHX" role="3clFbG">
+            <node concept="2OqwBi" id="6Y_FTmDOG8J" role="2Oq$k0">
+              <node concept="Xjq3P" id="6Y_FTmDOF5$" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6Y_FTmDOGR8" role="2OqNvi">
+                <ref role="2Oxat5" node="6Y_FTmCDzVV" resolve="items" />
+              </node>
+            </node>
+            <node concept="3$u5V9" id="6Y_FTmDOLPz" role="2OqNvi">
+              <node concept="1bVj0M" id="6Y_FTmDOLP_" role="23t8la">
+                <node concept="3clFbS" id="6Y_FTmDOLPA" role="1bW5cS">
+                  <node concept="3clFbF" id="6Y_FTmDOMwE" role="3cqZAp">
+                    <node concept="2OqwBi" id="6Y_FTmDONBg" role="3clFbG">
+                      <node concept="37vLTw" id="6Y_FTmDOMwD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6Y_FTmDOLPB" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="6Y_FTmDOQl9" role="2OqNvi">
+                        <ref role="37wK5l" to="1qo3:~Pair.getRight()" resolve="getRight" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6Y_FTmDOLPB" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6Y_FTmDOLPC" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="5$m_JoTDGTy" role="1B3o_S" />
+      <node concept="A3Dl8" id="6Y_FTmDOBJ_" role="3clF45">
+        <node concept="3Tqbb2" id="6Y_FTmDOEsH" role="A3Ik2">
+          <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Y_FTmDKwIb" role="jymVt" />
+    <node concept="3clFb_" id="6Y_FTmDKL29" role="jymVt">
+      <property role="TrG5h" value="forEach" />
+      <node concept="3clFbS" id="6Y_FTmDKL2c" role="3clF47">
+        <node concept="3clFbF" id="6Y_FTmDKP94" role="3cqZAp">
+          <node concept="2OqwBi" id="6Y_FTmDKROG" role="3clFbG">
+            <node concept="2OqwBi" id="6Y_FTmDKPwF" role="2Oq$k0">
+              <node concept="Xjq3P" id="6Y_FTmDKP93" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6Y_FTmDKQix" role="2OqNvi">
+                <ref role="2Oxat5" node="6Y_FTmCDzVV" resolve="items" />
+              </node>
+            </node>
+            <node concept="2es0OD" id="6Y_FTmDKWZt" role="2OqNvi">
+              <node concept="1bVj0M" id="6Y_FTmDKWZv" role="23t8la">
+                <node concept="3clFbS" id="6Y_FTmDKWZw" role="1bW5cS">
+                  <node concept="3clFbF" id="6Y_FTmDKX$j" role="3cqZAp">
+                    <node concept="2OqwBi" id="6Y_FTmDKYfO" role="3clFbG">
+                      <node concept="37vLTw" id="6Y_FTmDKX$i" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6Y_FTmDKN5G" resolve="func" />
+                      </node>
+                      <node concept="1Bd96e" id="6Y_FTmDKZaj" role="2OqNvi">
+                        <node concept="2OqwBi" id="6Y_FTmDL1ew" role="1BdPVh">
+                          <node concept="37vLTw" id="6Y_FTmDL08l" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6Y_FTmDKWZx" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="6Y_FTmDL3Cs" role="2OqNvi">
+                            <ref role="37wK5l" to="1qo3:~Pair.getLeft()" resolve="getLeft" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="6Y_FTmDL6Pi" role="1BdPVh">
+                          <node concept="37vLTw" id="6Y_FTmDL5wM" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6Y_FTmDKWZx" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="6Y_FTmDL8Qu" role="2OqNvi">
+                            <ref role="37wK5l" to="1qo3:~Pair.getRight()" resolve="getRight" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6Y_FTmDKWZx" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6Y_FTmDKWZy" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="5$m_JoTDHOF" role="1B3o_S" />
+      <node concept="3cqZAl" id="6Y_FTmDKL1Z" role="3clF45" />
+      <node concept="37vLTG" id="6Y_FTmDKN5G" role="3clF46">
+        <property role="TrG5h" value="func" />
+        <node concept="1ajhzC" id="6Y_FTmDKN5E" role="1tU5fm">
+          <node concept="3Tqbb2" id="6Y_FTmDKNyi" role="1ajw0F">
+            <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+          </node>
+          <node concept="3Tqbb2" id="6Y_FTmDKOob" role="1ajw0F">
+            <ref role="ehGHo" to="4ndm:30ECcbtLqSm" resolve="FeatureAttributeAssignment" />
+          </node>
+          <node concept="3cqZAl" id="6Y_FTmDKOIf" role="1ajl9A" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -17438,6 +17438,31 @@
           <ref role="3bR37D" node="4O1MtdoYzuV" resolve="test.org.iets3.variability.configuration.base.ext" />
         </node>
       </node>
+      <node concept="1SiIV0" id="G2E4WstfbR" role="3bR37C">
+        <node concept="3bR9La" id="G2E4WstfbS" role="1SiIV1">
+          <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="G2E4WstfbT" role="3bR37C">
+        <node concept="3bR9La" id="G2E4WstfbU" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="G2E4WstfbV" role="3bR37C">
+        <node concept="3bR9La" id="G2E4WstfbW" role="1SiIV1">
+          <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="G2E4WstfbX" role="3bR37C">
+        <node concept="3bR9La" id="G2E4WstfbY" role="1SiIV1">
+          <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="G2E4WstfbZ" role="3bR37C">
+        <node concept="3bR9La" id="G2E4Wstfc0" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1xb0AuwN7WS" resolve="JUnit" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="7tVUji9MfSt" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.attribute@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.attribute@tests.mps
@@ -11,12 +11,15 @@
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="165f1d05-2506-4544-895e-1424f54166ec" name="org.iets3.variability.featuremodel.base" version="24" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="lte6" ref="r:dedd19c9-9ff3-4f30-aa73-ce61203b2296(org.iets3.variability.configuration.base.behavior)" />
     <import index="4ndm" ref="r:a9fe59d7-0b4f-42b0-925a-71cc04f93df1(org.iets3.variability.configuration.base.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
+    <import index="1qo3" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.tuple(org.apache.commons/)" />
+    <import index="ch50" ref="r:83d54567-d361-47ca-a949-7374ea89921d(org.iets3.variability.configuration.base.plugin)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -43,6 +46,7 @@
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
       </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
@@ -57,6 +61,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -68,6 +75,9 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -101,6 +111,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -118,6 +129,9 @@
       <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
@@ -205,9 +219,19 @@
       <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="7080278351417106679" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNotNull" flags="nn" index="2Hmddi">
+        <child id="7080278351417106681" name="expression" index="2Hmdds" />
+      </concept>
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
         <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -218,6 +242,9 @@
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -227,8 +254,19 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
         <child id="1225711182005" name="list" index="1y566C" />
@@ -355,6 +393,7 @@
   </node>
   <node concept="312cEu" id="5Bs7u20L7OV">
     <property role="TrG5h" value="AttributeTestHelper" />
+    <node concept="2tJIrI" id="G2E4Wss3$0" role="jymVt" />
     <node concept="2YIFZL" id="5Bs7u20L7SL" role="jymVt">
       <property role="TrG5h" value="checkDefaultValueAccess" />
       <node concept="3clFbS" id="5Bs7u20L7SN" role="3clF47">
@@ -574,6 +613,230 @@
           </node>
         </node>
         <node concept="12i7jc" id="wgC743w6mO" role="12i2BX" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="G2E4WsqSLu">
+    <property role="TrG5h" value="SolverRerunKeepsUnchangedAttributeValueNode" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <node concept="1qefOq" id="G2E4WsqSLv" role="1SKRRt">
+      <node concept="12icEM" id="G2E4WsqSLw" role="1qenE9">
+        <property role="TrG5h" value="VC" />
+        <node concept="12iwZl" id="G2E4WsqSLx" role="12i2BX">
+          <property role="TrG5h" value="FM" />
+          <property role="bVyBI" value="2057908090" />
+          <node concept="12iwV3" id="G2E4WsqSLy" role="12iwV8">
+            <property role="TrG5h" value="FM" />
+            <node concept="21IWn0" id="G2E4WsqSLz" role="21GevL">
+              <property role="TrG5h" value="x" />
+              <node concept="30bXR$" id="G2E4WsqSL$" role="21GYI0" />
+            </node>
+          </node>
+        </node>
+        <node concept="rqKB5" id="G2E4WsqSL_" role="12i2BX">
+          <property role="TrG5h" value="C" />
+          <property role="1n_0Gn" value="true" />
+          <property role="bVyBI" value="-369013230" />
+          <property role="26YOJW" value="" />
+          <property role="0Rz4W" value="630153620" />
+          <property role="bROok" value="2057908090" />
+          <property role="1nQUAq" value="true" />
+          <ref role="rqKBe" node="G2E4WsqSLy" resolve="FM" />
+          <node concept="rqCGG" id="G2E4WsqSLA" role="rqCGo">
+            <node concept="3HVKVk" id="G2E4WsqSLB" role="3HVKVh">
+              <property role="2fdZ4z" value="zJQZm6SRYR/manual" />
+              <ref role="3HS9Pa" node="G2E4WsqSLz" resolve="x" />
+              <node concept="30bXRB" id="G2E4WsqSLC" role="3HYO9C">
+                <property role="30bXRw" value="5" />
+              </node>
+              <node concept="3xLA65" id="G2E4WsqSLF" role="lGtFl">
+                <property role="TrG5h" value="assignX" />
+              </node>
+            </node>
+          </node>
+          <node concept="3xLA65" id="G2E4WsqSLG" role="lGtFl">
+            <property role="TrG5h" value="given" />
+          </node>
+        </node>
+        <node concept="12i7jc" id="G2E4WsqSLH" role="12i2BX" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="G2E4WsqSLI" role="1SL9yI">
+      <property role="TrG5h" value="solverRerunKeepsUnchangedAttributeValueNode" />
+      <node concept="3cqZAl" id="G2E4WsqSLJ" role="3clF45" />
+      <node concept="3clFbS" id="G2E4WsqSLK" role="3clF47">
+        <node concept="3cpWs8" id="G2E4WssHHP" role="3cqZAp">
+          <node concept="3cpWsn" id="G2E4WssHHQ" role="3cpWs9">
+            <property role="TrG5h" value="valueBefore" />
+            <node concept="3Tqbb2" id="G2E4WssHHR" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="2OqwBi" id="G2E4WssHHS" role="33vP2m">
+              <node concept="3xONca" id="G2E4WssJaI" role="2Oq$k0">
+                <ref role="3xOPvv" node="G2E4WsqSLF" resolve="assignX" />
+              </node>
+              <node concept="3TrEf2" id="G2E4WssHHU" role="2OqNvi">
+                <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Hmddi" id="G2E4WssHHV" role="3cqZAp">
+          <node concept="37vLTw" id="G2E4WssHHW" role="2Hmdds">
+            <ref role="3cqZAo" node="G2E4WssHHQ" resolve="valueBefore" />
+          </node>
+          <node concept="3_1$Yv" id="G2E4WssHHX" role="3_9lra">
+            <node concept="Xl_RD" id="G2E4WssHHY" role="3_1BAH">
+              <property role="Xl_RC" value="test setup: the attribute assignment must already carry a solver-assigned value" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="G2E4WssHHZ" role="3cqZAp" />
+        <node concept="3SKdUt" id="G2E4WssHI0" role="3cqZAp">
+          <node concept="1PaTwC" id="G2E4WssHI1" role="1aUNEU">
+            <node concept="3oM_SD" id="G2E4WssHI2" role="1PaTwD">
+              <property role="3oM_SC" value="simulate" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI3" role="1PaTwD">
+              <property role="3oM_SC" value="changing" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI4" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI5" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI6" role="1PaTwD">
+              <property role="3oM_SC" value="attribute" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI7" role="1PaTwD">
+              <property role="3oM_SC" value="value," />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI8" role="1PaTwD">
+              <property role="3oM_SC" value="but" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI9" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIa" role="1PaTwD">
+              <property role="3oM_SC" value="identical" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIb" role="1PaTwD">
+              <property role="3oM_SC" value="content" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="G2E4WssHIc" role="3cqZAp">
+          <node concept="3cpWsn" id="G2E4WssHId" role="3cpWs9">
+            <property role="TrG5h" value="recomputedSameValue" />
+            <node concept="3Tqbb2" id="G2E4WssHIe" role="1tU5fm">
+              <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+            </node>
+            <node concept="2pJPEk" id="G2E4WssHIf" role="33vP2m">
+              <node concept="2pJPED" id="G2E4WssHIg" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+                <node concept="2pJxcG" id="G2E4WssHIh" role="2pJxcM">
+                  <ref role="2pJxcJ" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                  <node concept="WxPPo" id="G2E4WssHIi" role="28ntcv">
+                    <node concept="Xl_RD" id="G2E4WssHIj" role="WxPPp">
+                      <property role="Xl_RC" value="5" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="G2E4WssHIk" role="3cqZAp">
+          <node concept="2YIFZM" id="G2E4WssHIl" role="3clFbG">
+            <ref role="37wK5l" to="ch50:5U0lJXzQlfQ" resolve="setAttributes" />
+            <ref role="1Pybhc" to="ch50:2OJr5rRLaPV" resolve="CommonBaseUtil" />
+            <node concept="2ShNRf" id="6Y_FTmE1Hbo" role="37wK5m">
+              <node concept="1pGfFk" id="6Y_FTmE1IdO" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ch50:6Y_FTmDW9tv" resolve="AssignmentValueList" />
+                <node concept="2ShNRf" id="G2E4WssHIm" role="37wK5m">
+                  <node concept="2HTt$P" id="G2E4WssHIn" role="2ShVmc">
+                    <node concept="2YIFZM" id="G2E4WssHIo" role="2HTEbv">
+                      <ref role="37wK5l" to="1qo3:~Pair.of(java.lang.Object,java.lang.Object)" resolve="of" />
+                      <ref role="1Pybhc" to="1qo3:~Pair" resolve="Pair" />
+                      <node concept="37vLTw" id="G2E4WssHIp" role="37wK5m">
+                        <ref role="3cqZAo" node="G2E4WssHId" resolve="recomputedSameValue" />
+                      </node>
+                      <node concept="3xONca" id="G2E4WssKxt" role="37wK5m">
+                        <ref role="3xOPvv" node="G2E4WsqSLF" resolve="assignX" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="G2E4WssHIr" role="3cqZAp">
+          <node concept="3cpWsn" id="G2E4WssHIs" role="3cpWs9">
+            <property role="TrG5h" value="valueAfter" />
+            <node concept="3Tqbb2" id="G2E4WssHIt" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="2OqwBi" id="G2E4WssHIu" role="33vP2m">
+              <node concept="3xONca" id="G2E4WssLLO" role="2Oq$k0">
+                <ref role="3xOPvv" node="G2E4WsqSLF" resolve="assignX" />
+              </node>
+              <node concept="3TrEf2" id="G2E4WssHIw" role="2OqNvi">
+                <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="G2E4WssHIx" role="3cqZAp" />
+        <node concept="3SKdUt" id="G2E4WssHIy" role="3cqZAp">
+          <node concept="1PaTwC" id="G2E4WssHIz" role="1aUNEU">
+            <node concept="3oM_SD" id="G2E4WssHI$" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHI_" role="1PaTwD">
+              <property role="3oM_SC" value="checks" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIA" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIB" role="1PaTwD">
+              <property role="3oM_SC" value="expressions" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIC" role="1PaTwD">
+              <property role="3oM_SC" value="being" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHID" role="1PaTwD">
+              <property role="3oM_SC" value="structurally" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIE" role="1PaTwD">
+              <property role="3oM_SC" value="identical," />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIF" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIG" role="1PaTwD">
+              <property role="3oM_SC" value="semantically" />
+            </node>
+            <node concept="3oM_SD" id="G2E4WssHIH" role="1PaTwD">
+              <property role="3oM_SC" value="&quot;same&quot;" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="G2E4WssHII" role="3cqZAp">
+          <node concept="37vLTw" id="G2E4WssHIJ" role="3tpDZB">
+            <ref role="3cqZAo" node="G2E4WssHIs" resolve="valueAfter" />
+          </node>
+          <node concept="37vLTw" id="G2E4WssHIK" role="3tpDZA">
+            <ref role="3cqZAo" node="G2E4WssHHQ" resolve="valueBefore" />
+          </node>
+          <node concept="3_1$Yv" id="G2E4WssHIL" role="3_9lra">
+            <node concept="Xl_RD" id="G2E4WssHIM" role="3_1BAH">
+              <property role="Xl_RC" value="issue #1921: setAttributes recreated an unchanged attribute value node (node-id churn)" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/test.org.iets3.variability.configuration.base.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/test.org.iets3.variability.configuration.base.msd
@@ -18,6 +18,11 @@
     <dependency reexport="false">c1fcd3e0-0603-4035-834f-14c6337eec24(test.org.iets3.common.base)</dependency>
     <dependency reexport="false">964a5657-7374-4fbd-970e-fec8637b6a01(test.org.iets3.variability.configuration.base.ext)</dependency>
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
+    <dependency reexport="false">49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
+    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -69,6 +74,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
     <module reference="920eaa0e-ecca-46bc-bee7-4e5c59213dd6(Testbench)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
@@ -104,6 +110,7 @@
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="20" />


### PR DESCRIPTION
When the solver runs on a configuration, compulsory attribute values are set if the value is mandatory. If the solver computes the previous value again, the value expression has been replaced. This has a couple of drawbacks, as the node identity of the value (e.g. a `NumberLiteral`) will be changed although the semantic value stays the same.

The PR adds a test which reproduces the problem and introduces the fix. It also does some API changes necessary for solving the companion PR in IETS3/iets3.core#1781.

Additionally, the helper classes `AssignmentValueMap` and `AssignmentValueList` have been introduced to make the new code more readable and also refactor the existing code. 

CHANGELOG has been updated.

Note: The API for iets3.core has been changed. So iets3.core has to be adapted to use this version of iets3.opensource. See also the companion PR in IETS3/iets3.core#1781.

TODO: I keep separate commits to make the review easier. Do not merge from maintenance/mps20241, instead squash the commits after the review.

This solves #1921.