### PR TITLE
fix: use indent layout consistently in Expression editors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 - Improve uniqueness name check of `IFunctionLike` `getUniquelyNamedElements()` behavior to avoid overzealous checking.
 - Variability: Feature attribute values are not overwritten anymore if the value stays the same. This avoids changing the model if not necessary, esp. it avoids merge conflicts.
+- KernelF: Consistent usage of indent layout in Expression concepts.
 
 ## July 2026
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.logic.operator/models/org.iets3.analysis.logic.operator.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.logic.operator/models/org.iets3.analysis.logic.operator.editor.mps
@@ -26,7 +26,6 @@
         <child id="928328222691832421" name="separatorTextQuery" index="2gpyvW" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="709996738298806197" name="jetbrains.mps.lang.editor.structure.QueryFunction_SeparatorText" flags="in" index="2o9xnK" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
@@ -156,7 +155,7 @@
       </node>
       <node concept="3F2HdR" id="42uExpDJfCI" role="3EZMnx">
         <ref role="1NtTu8" to="5nv3:42uExpDspr4" resolve="exprs" />
-        <node concept="2iRfu4" id="42uExpDJfCK" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVK2" role="2czzBx" />
         <node concept="2o9xnK" id="42uExpDJjWa" role="2gpyvW">
           <node concept="3clFbS" id="42uExpDJjWb" role="2VODD2">
             <node concept="3clFbF" id="42uExpDJk0J" role="3cqZAp">
@@ -167,7 +166,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="42uExpDsprC" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVK1" role="2iSdaV" />
       <node concept="3F0ifn" id="42uExpDsprF" role="3EZMnx">
         <property role="3F0ifm" value="," />
         <node concept="11L4FC" id="42uExpDJo6z" role="3F10Kt">
@@ -200,7 +199,7 @@
       <node concept="3F1sOY" id="kLIXBTspbO" role="3EZMnx">
         <ref role="1NtTu8" to="5nv3:2rOWEwsF5w1" resolve="expr" />
       </node>
-      <node concept="2iRfu4" id="kLIXBTspbH" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVK3" role="2iSdaV" />
       <node concept="3F0ifn" id="kLIXBTspbW" role="3EZMnx">
         <property role="3F0ifm" value=")" />
         <node concept="11L4FC" id="2rOWEwsF5_A" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/editor.mps
@@ -2037,7 +2037,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="7wKyBbUYP$v" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVJX" role="2iSdaV" />
       <node concept="3F0ifn" id="7wKyBbUYP$Z" role="3EZMnx">
         <property role="3F0ifm" value="[" />
         <node concept="11L4FC" id="7wKyBbUYPAZ" role="3F10Kt">
@@ -2050,7 +2050,7 @@
       <node concept="3F2HdR" id="7wKyBbUYPD1" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="874t:7wKyBbUYPCM" resolve="values" />
-        <node concept="2iRfu4" id="7wKyBbUYPD3" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVJY" role="2czzBx" />
         <node concept="3F0ifn" id="7wKyBbUYPDg" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="7wKyBbUYPE6" role="3F10Kt">
@@ -3679,7 +3679,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="5mAeI2ovjMq" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVJZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3xyc5wR2n97">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
@@ -804,7 +804,7 @@
         <node concept="3F2HdR" id="5a_u3Oz7hIu" role="3EZMnx">
           <property role="2czwfO" value="," />
           <ref role="1NtTu8" to="v0r8:5a_u3OyMSNE" resolve="args" />
-          <node concept="2iRfu4" id="5a_u3Oz7hIv" role="2czzBx" />
+          <node concept="l2Vlx" id="4L4_gU2zVJT" role="2czzBx" />
           <node concept="3F0ifn" id="5a_u3Oz7hIw" role="2czzBI">
             <property role="3F0ifm" value="" />
             <node concept="VPxyj" id="5a_u3Oz7hIx" role="3F10Kt">
@@ -1221,7 +1221,7 @@
           <node concept="3F2HdR" id="7aipPVpTAJa" role="3EZMnx">
             <property role="2czwfO" value="," />
             <ref role="1NtTu8" to="v0r8:5a_u3OyMSNE" resolve="args" />
-            <node concept="2iRfu4" id="7aipPVpTAJb" role="2czzBx" />
+            <node concept="l2Vlx" id="4L4_gU2zVJU" role="2czzBx" />
             <node concept="3F0ifn" id="7aipPVpTAJc" role="2czzBI">
               <property role="3F0ifm" value="" />
               <node concept="VPxyj" id="7aipPVpTAJd" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -5874,7 +5874,7 @@
       <node concept="3F2HdR" id="S$tO8ocnq3" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="hm2y:S$tO8ocnpr" resolve="values" />
-        <node concept="2iRfu4" id="S$tO8ocnq5" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVK4" role="2czzBx" />
         <node concept="3F0ifn" id="S$tO8ocnq9" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="S$tO8ocnrs" role="3F10Kt">
@@ -6197,7 +6197,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="1OEjBB5BzwQ" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVK5" role="2iSdaV" />
       <node concept="gc7cB" id="6cw1FA3OVWd" role="3EZMnx">
         <node concept="3VJUX4" id="6cw1FA3OVWf" role="3YsKMw">
           <node concept="3clFbS" id="6cw1FA3OVWh" role="2VODD2">
@@ -8884,7 +8884,7 @@
       <node concept="3F2HdR" id="1RwPUjzgk1_" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="hm2y:1RwPUjzgk0z" resolve="values" />
-        <node concept="2iRfu4" id="1RwPUjzgk1B" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVK6" role="2czzBx" />
         <node concept="3F0ifn" id="1RwPUjzgk2r" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="1RwPUjzgk2u" role="3F10Kt">
@@ -9206,7 +9206,7 @@
     <property role="3GE5qa" value="group" />
     <ref role="1XX52x" to="hm2y:4CksDrmwc1V" resolve="OperatorGroup" />
     <node concept="3EZMnI" id="4CksDrmwcd_" role="2wV5jI">
-      <node concept="2iRfu4" id="1OEjBB5E03X" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVK7" role="2iSdaV" />
       <node concept="PMmxH" id="1znK7yZeswL" role="3EZMnx">
         <ref role="PMmxG" node="1znK7yZhztN" resolve="ExpressionKeywordAlias" />
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
@@ -4714,7 +4714,7 @@
         <node concept="3F2HdR" id="2vkvJYT6dN6" role="3EZMnx">
           <property role="2czwfO" value="," />
           <ref role="1NtTu8" to="gx5r:2vkvJYT6dHx" resolve="paramValues" />
-          <node concept="2iRfu4" id="2vkvJYT6dN8" role="2czzBx" />
+          <node concept="l2Vlx" id="4L4_gU2zVJN" role="2czzBx" />
           <node concept="3F0ifn" id="2vkvJYT6dNn" role="2czzBI">
             <property role="3F0ifm" value="" />
             <node concept="VPxyj" id="2vkvJYT6dNp" role="3F10Kt">
@@ -4765,7 +4765,7 @@
       <node concept="3F2HdR" id="2vkvJYT6dVh" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="gx5r:2vkvJYT6dH$" resolve="inputs" />
-        <node concept="2iRfu4" id="2vkvJYT6dVj" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVJO" role="2czzBx" />
         <node concept="3F0ifn" id="2vkvJYT6dVE" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="2vkvJYT6dVG" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/editor.mps
@@ -26,7 +26,6 @@
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -761,7 +760,7 @@
       <node concept="3F2HdR" id="1RwPUjzgk1_" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="mi3w:1RwPUjzgk0z" resolve="values" />
-        <node concept="2iRfu4" id="1RwPUjzgk1B" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVJP" role="2czzBx" />
         <node concept="3F0ifn" id="1RwPUjzgk2r" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="1RwPUjzgk2u" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
@@ -800,7 +800,7 @@
         <property role="2czwfO" value="," />
         <property role="1cu_pB" value="hQNNVxO/attractsRecursively" />
         <ref role="1NtTu8" to="zzzn:6zmBjqUkws7" resolve="args" />
-        <node concept="2iRfu4" id="6zmBjqUkwHI" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVJV" role="2czzBx" />
         <node concept="3F0ifn" id="6zmBjqUkwHM" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="6zmBjqUkwIC" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/editor.mps
@@ -2876,7 +2876,7 @@
       <node concept="3F2HdR" id="4IV0h47Jb4J" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="8lgj:4IV0h47Jb3L" resolve="contextValues" />
-        <node concept="2iRfu4" id="4IV0h47Jb4L" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVJL" role="2czzBx" />
         <node concept="3F0ifn" id="4IV0h47Jb4R" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="4IV0h47Jb4T" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
@@ -21,7 +21,6 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
@@ -104,7 +103,7 @@
   <node concept="24kQdi" id="5QDPRL$oihD">
     <ref role="1XX52x" to="ysgh:5QDPRL$ohHz" resolve="QueryExpr" />
     <node concept="3EZMnI" id="5QDPRL$oimO" role="2wV5jI">
-      <node concept="2iRfu4" id="1OEjBB5GrGS" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVJR" role="2iSdaV" />
       <node concept="PMmxH" id="1znK7yZdfgD" role="3EZMnx">
         <ref role="PMmxG" to="buwp:1znK7yZhztN" resolve="ExpressionKeywordAlias" />
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -6398,7 +6398,7 @@
       <node concept="3F2HdR" id="5xEoEMrFs7E" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="wtll:5xEoEMrFs7k" resolve="actuals" />
-        <node concept="2iRfu4" id="5xEoEMrFs7G" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVK8" role="2czzBx" />
         <node concept="3F0ifn" id="5xEoEMrFs86" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="5xEoEMrFs89" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -784,6 +784,9 @@
           <ref role="1NtTu8" to="5qo5:4rZeNQ6OYRb" resolve="value" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6OYRX" resolve="IETS3String" />
           <node concept="bYqrx" id="1cHKpSpdbs5" role="2lD6_D" />
+          <node concept="34QqEe" id="4L4_gU2$c1V" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
         <node concept="3F0ifn" id="5jmmCdx$f6s" role="3EZMnx">
           <property role="3F0ifm" value="&quot;" />
@@ -795,7 +798,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="4_VVT2YyEm1" role="2iSdaV" />
+        <node concept="l2Vlx" id="4L4_gU2zVJW" role="2iSdaV" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
@@ -41,7 +41,6 @@
       </concept>
       <concept id="671290755174094691" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_parameterObject" flags="nn" index="2itN01" />
       <concept id="671290755174094686" name="jetbrains.mps.lang.editor.structure.QueryFunction_MethodPresentation" flags="in" index="2itN0W" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="4203201205844553978" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_selectedNode" flags="nn" index="jzRn0" />
       <concept id="4531786690998636238" name="jetbrains.mps.lang.editor.structure.AbstractStyledTextOperation" flags="nn" index="kdiOM">
@@ -1781,7 +1780,7 @@
         <node concept="3F2HdR" id="1mDdTG8NhB" role="3EZMnx">
           <property role="2czwfO" value="," />
           <ref role="1NtTu8" to="19m5:1mDdTG8NgS" resolve="paramValues" />
-          <node concept="2iRfu4" id="1mDdTG8NhD" role="2czzBx" />
+          <node concept="l2Vlx" id="4L4_gU2zVJS" role="2czzBx" />
           <node concept="3F0ifn" id="1mDdTG8NhQ" role="2czzBI">
             <property role="3F0ifm" value="" />
             <node concept="VPxyj" id="1mDdTG8NhS" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -184,7 +184,7 @@
   <node concept="24kQdi" id="4lCUG7Orjh$">
     <ref role="1XX52x" to="3r88:4lCUG7OqbH2" resolve="ValidateStringExpr" />
     <node concept="3EZMnI" id="2LaXqmXxyBp" role="2wV5jI">
-      <node concept="2iRfu4" id="1OEjBB5KJEL" role="2iSdaV" />
+      <node concept="l2Vlx" id="4L4_gU2zVJM" role="2iSdaV" />
       <node concept="PMmxH" id="1znK7yZdgew" role="3EZMnx">
         <ref role="PMmxG" to="buwp:1znK7yZhztN" resolve="ExpressionKeywordAlias" />
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -1485,7 +1485,7 @@
       <node concept="3F2HdR" id="7aRvJQF6gla" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="l462:7aRvJQF6gkp" resolve="values" />
-        <node concept="2iRfu4" id="7aRvJQF6glc" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVK0" role="2czzBx" />
         <node concept="3F0ifn" id="7aRvJQF6glD" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="7aRvJQF6glF" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -4273,7 +4273,7 @@
       <node concept="3F2HdR" id="7FuUjk_n1M_" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="kfo3:7FuUjk_n1Mw" resolve="values" />
-        <node concept="2iRfu4" id="7FuUjk_n1MB" role="2czzBx" />
+        <node concept="l2Vlx" id="4L4_gU2zVJQ" role="2czzBx" />
         <node concept="3F0ifn" id="7EYe2PMegvB" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="7EYe2PMegvD" role="3F10Kt">


### PR DESCRIPTION
## Problem

Expression concepts accidentally mixed indent and horizontal layout making multi line expressions unreadable. Main reason is probably that horizontal layout is the default.

## Change

`Expression` has 289 sub-concepts with 221 concept editors. All 24 remaining `CellLayout_Horizontal` cells (20 editor roots in 15 models) are switched to `CellLayout_Indent`:

- **Root collections** of `AlternativesExpression`, `OperatorGroup`, `ValidateStringExpr`, `QueryExpr`, `DataItemConstructor`, `OldExpression`, `AbstractCountTrue`, `ValOptExpression` and `StringLiteral`
- **Argument and value lists** of `TupleValue`, `AbstractMinMaxExpression`, `LambdaExpression`, `AlgebraicTerm`, `BlockCallExpr`, `WithContextExpression`, `AbstractEarliestLastestExpression`, `TableCallExpression`, `StartExpr`, `FullOverlapExpr`, `DataItemConstructor`, `AbstractCountTrue`, and the `argList` editor component of `org.iets3.core.expr.repl`

`StringLiteral` additionally gets `indent-layout-no-wrap` on its `SplittableCell`. Only `PUNCTUATION_LEFT` and `INDENT_LAYOUT_NO_WRAP` stop a wrap in `CellLayout_Indent`, so without it the literal could break after the opening quote. This mirrors the `StringLiteral` editor of `jetbrains.mps.baseLanguage`.

## Deliberately unchanged

- **Separators.** `separator-constraint noflow` only affects `CellLayout_Flow`, and 77 of the 78 indent comma lists in baseLanguage set no separator style at all — so plain `list X indent separator ","` is the convention on both sides.
- **The 7 vertical and 7 vertical-grid layouts.** They are intentional multi-line constructs: `MatchExpr`, `DecTab`, `AlgebraicTerm`'s constructor table, `AlternativesExpression`'s alternatives, `BuilderExpression`, `SplitExpression`, `TemporalLiteral` and `QueryExpr`'s clause block.