### PR TITLE
fix: keep the interpreter trace when an evaluation throws.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## September 2026
+
+### Fixed
+- KernelF: an exception thrown by the interpreter no longer costs the whole trace. `Show Trace` now opens with everything that was computed before the exception, and the node that threw is marked with the exception and highlighted in the trace tree. This covers the generic trace roots (functions, constants, function calls) as well as the test items, whose `catch` branches used to drop the trace.
+
 ## August 2026
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -20431,31 +20431,23 @@
                     <node concept="3clFbS" id="5IR_boHRmeo" role="3clF47">
                       <node concept="3cpWs8" id="5af9jCuJP7w" role="3cqZAp">
                         <node concept="3cpWsn" id="5af9jCuJP7x" role="3cpWs9">
-                          <property role="TrG5h" value="result" />
+                          <property role="TrG5h" value="evaluator" />
                           <node concept="2OqwBi" id="5af9jCuJP7y" role="33vP2m">
-                            <node concept="2OqwBi" id="5af9jCuJP7z" role="2Oq$k0">
-                              <node concept="2ShNRf" id="5af9jCuJP7$" role="2Oq$k0">
-                                <node concept="HV5vD" id="5af9jCuJP7_" role="2ShVmc">
-                                  <property role="373rjd" value="true" />
-                                  <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="5af9jCuJP7A" role="2OqNvi">
-                                <ref role="37wK5l" node="2nydsCfvLxS" resolve="withComputationTrace" />
-                                <node concept="3clFbT" id="5af9jCuJP7B" role="37wK5m">
-                                  <property role="3clFbU" value="true" />
-                                </node>
+                            <node concept="2ShNRf" id="5HuXUSEi4d9" role="2Oq$k0">
+                              <node concept="HV5vD" id="5HuXUSEi4db" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
                               </node>
                             </node>
                             <node concept="liA8E" id="5af9jCuJP7C" role="2OqNvi">
-                              <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
-                              <node concept="37vLTw" id="5af9jCuJP7D" role="37wK5m">
-                                <ref role="3cqZAo" node="5IR_boHRjde" resolve="n" />
+                              <ref role="37wK5l" node="2nydsCfvLxS" resolve="withComputationTrace" />
+                              <node concept="3clFbT" id="5HuXUSEi4dc" role="37wK5m">
+                                <property role="3clFbU" value="true" />
                               </node>
                             </node>
                           </node>
                           <node concept="3uibUv" id="7LZDtvhtKCi" role="1tU5fm">
-                            <ref role="3uigEE" node="7LZDtvhtD$G" resolve="IValueAndTraceAndEnv" />
+                            <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
                           </node>
                         </node>
                       </node>
@@ -20465,24 +20457,188 @@
                           <node concept="3uibUv" id="5IR_boHR_I5" role="1tU5fm">
                             <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
                           </node>
-                          <node concept="2OqwBi" id="5IR_boHR_I9" role="33vP2m">
-                            <node concept="37vLTw" id="5IR_boHUGWC" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5af9jCuJP7x" resolve="result" />
+                        </node>
+                      </node>
+                      <node concept="3J1_TO" id="5HuXUSEi4dd" role="3cqZAp">
+                        <node concept="3clFbS" id="5HuXUSEi4df" role="1zxBo7">
+                          <node concept="3cpWs8" id="5HuXUSEi4dg" role="3cqZAp">
+                            <node concept="3cpWsn" id="5HuXUSEi4dj" role="3cpWs9">
+                              <property role="TrG5h" value="result" />
+                              <node concept="3uibUv" id="5HuXUSEi4dl" role="1tU5fm">
+                                <ref role="3uigEE" node="7LZDtvhtD$G" resolve="IValueAndTraceAndEnv" />
+                              </node>
+                              <node concept="2OqwBi" id="5HuXUSEi4dm" role="33vP2m">
+                                <node concept="37vLTw" id="5HuXUSEi4dp" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5af9jCuJP7x" resolve="evaluator" />
+                                </node>
+                                <node concept="liA8E" id="5HuXUSEi4dq" role="2OqNvi">
+                                  <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                                  <node concept="37vLTw" id="5HuXUSEi4dr" role="37wK5m">
+                                    <ref role="3cqZAo" node="5IR_boHRjde" resolve="n" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
-                            <node concept="liA8E" id="7LZDtvhoHM2" role="2OqNvi">
-                              <ref role="37wK5l" node="7LZDtvhogKU" resolve="getTrace" />
+                          </node>
+                          <node concept="3clFbF" id="5HuXUSEi4ds" role="3cqZAp">
+                            <node concept="37vLTI" id="5HuXUSEi4du" role="3clFbG">
+                              <node concept="37vLTw" id="5HuXUSEi4dx" role="37vLTJ">
+                                <ref role="3cqZAo" node="5IR_boHR_I8" resolve="trace" />
+                              </node>
+                              <node concept="2OqwBi" id="5HuXUSEi4dy" role="37vLTx">
+                                <node concept="37vLTw" id="5HuXUSEi4d_" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5HuXUSEi4dj" resolve="result" />
+                                </node>
+                                <node concept="liA8E" id="5HuXUSEi4dA" role="2OqNvi">
+                                  <ref role="37wK5l" node="7LZDtvhogKU" resolve="getTrace" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3uVAMA" id="5HuXUSEi4dB" role="1zxBo5">
+                          <node concept="XOnhg" id="5HuXUSEi4dF" role="1zc67B">
+                            <property role="TrG5h" value="t" />
+                            <node concept="nSUau" id="5HuXUSEi4dH" role="1tU5fm">
+                              <node concept="3uibUv" id="5HuXUSEi4dJ" role="nSUat">
+                                <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="5HuXUSEi4dK" role="1zc67A">
+                            <node concept="3SKdUt" id="5HuXUSEi4dL" role="3cqZAp">
+                              <node concept="1PaTwC" id="5HuXUSEi4dP" role="1aUNEU">
+                                <node concept="3oM_SD" id="5HuXUSEi4dR" role="1PaTwD">
+                                  <property role="3oM_SC" value="An" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dS" role="1PaTwD">
+                                  <property role="3oM_SC" value="exception" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dT" role="1PaTwD">
+                                  <property role="3oM_SC" value="must" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dU" role="1PaTwD">
+                                  <property role="3oM_SC" value="not" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dV" role="1PaTwD">
+                                  <property role="3oM_SC" value="cost" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dW" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dX" role="1PaTwD">
+                                  <property role="3oM_SC" value="whole" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dY" role="1PaTwD">
+                                  <property role="3oM_SC" value="trace:" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4dZ" role="1PaTwD">
+                                  <property role="3oM_SC" value="show" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4e0" role="1PaTwD">
+                                  <property role="3oM_SC" value="what" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4e1" role="1PaTwD">
+                                  <property role="3oM_SC" value="was" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4e2" role="1PaTwD">
+                                  <property role="3oM_SC" value="computed" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4e3" role="1PaTwD">
+                                  <property role="3oM_SC" value="before" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4e4" role="1PaTwD">
+                                  <property role="3oM_SC" value="it," />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3SKdUt" id="5HuXUSEi4e5" role="3cqZAp">
+                              <node concept="1PaTwC" id="5HuXUSEi4e9" role="1aUNEU">
+                                <node concept="3oM_SD" id="5HuXUSEi4eb" role="1PaTwD">
+                                  <property role="3oM_SC" value="with" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4ec" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4ed" role="1PaTwD">
+                                  <property role="3oM_SC" value="node" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4ee" role="1PaTwD">
+                                  <property role="3oM_SC" value="that" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4ef" role="1PaTwD">
+                                  <property role="3oM_SC" value="threw" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4eg" role="1PaTwD">
+                                  <property role="3oM_SC" value="marked" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4eh" role="1PaTwD">
+                                  <property role="3oM_SC" value="as" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4ei" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEi4ej" role="1PaTwD">
+                                  <property role="3oM_SC" value="failure." />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5HuXUSEi4ek" role="3cqZAp">
+                              <node concept="2OqwBi" id="5HuXUSEi4em" role="3clFbG">
+                                <node concept="37vLTw" id="5HuXUSEi4ep" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5HuXUSEi4dF" resolve="t" />
+                                </node>
+                                <node concept="liA8E" id="5HuXUSEi4eq" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5HuXUSEi4er" role="3cqZAp">
+                              <node concept="37vLTI" id="5HuXUSEi4et" role="3clFbG">
+                                <node concept="37vLTw" id="5HuXUSEi4ew" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5IR_boHR_I8" resolve="trace" />
+                                </node>
+                                <node concept="2YIFZM" id="5HuXUSEi4ex" role="37vLTx">
+                                  <ref role="1Pybhc" node="5HuXUSEfY1D" resolve="TraceFailures" />
+                                  <ref role="37wK5l" node="5HuXUSEfY6$" resolve="traceForFailure" />
+                                  <node concept="37vLTw" id="5HuXUSEi4ey" role="37wK5m">
+                                    <ref role="3cqZAo" node="5IR_boHRjde" resolve="n" />
+                                  </node>
+                                  <node concept="2OqwBi" id="5HuXUSEi4ez" role="37wK5m">
+                                    <node concept="37vLTw" id="5HuXUSEi4eA" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5af9jCuJP7x" resolve="evaluator" />
+                                    </node>
+                                    <node concept="liA8E" id="5HuXUSEi4eB" role="2OqNvi">
+                                      <ref role="37wK5l" node="7obiejCzFIg" resolve="getLastLog" />
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTw" id="5HuXUSEi4eC" role="37wK5m">
+                                    <ref role="3cqZAo" node="5HuXUSEi4dF" resolve="t" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="5IR_boHRAcK" role="3cqZAp">
-                        <node concept="2OqwBi" id="5IR_boHRAuR" role="3clFbG">
-                          <node concept="37vLTw" id="5IR_boHRAcI" role="2Oq$k0">
+                      <node concept="3clFbJ" id="5HuXUSEi4eD" role="3cqZAp">
+                        <node concept="3y3z36" id="5HuXUSEi4eG" role="3clFbw">
+                          <node concept="37vLTw" id="5HuXUSEi4eJ" role="3uHU7B">
                             <ref role="3cqZAo" node="5IR_boHR_I8" resolve="trace" />
                           </node>
-                          <node concept="liA8E" id="5IR_boHRASz" role="2OqNvi">
-                            <ref role="37wK5l" to="2ahs:5IR_boHQAxv" resolve="setRerunner" />
-                            <node concept="Xjq3P" id="5IR_boHS7zJ" role="37wK5m" />
+                          <node concept="10Nm6u" id="5HuXUSEi4eK" role="3uHU7w" />
+                        </node>
+                        <node concept="3clFbS" id="5HuXUSEi4eL" role="3clFbx">
+                          <node concept="3clFbF" id="5HuXUSEi4eM" role="3cqZAp">
+                            <node concept="2OqwBi" id="5HuXUSEi4eO" role="3clFbG">
+                              <node concept="37vLTw" id="5HuXUSEi4eR" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5IR_boHR_I8" resolve="trace" />
+                              </node>
+                              <node concept="liA8E" id="5HuXUSEi4eS" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:5IR_boHQAxv" resolve="setRerunner" />
+                                <node concept="Xjq3P" id="5HuXUSEi4eT" role="37wK5m" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -24798,16 +24954,76 @@
       <property role="od$2w" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7obiejCzFIi" role="3clF47">
-        <node concept="3clFbF" id="7obiejCzFIj" role="3cqZAp">
-          <node concept="2OqwBi" id="5cJmxjBjCia" role="3clFbG">
-            <node concept="2OqwBi" id="7obiejCzFIk" role="2Oq$k0">
-              <node concept="Xjq3P" id="7obiejCzFIl" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7obiejCzFIm" role="2OqNvi">
-                <ref role="2Oxat5" node="2nydsCfAaTv" resolve="helper" />
-              </node>
+        <node concept="3SKdUt" id="5HuXUSEhEQ6" role="3cqZAp">
+          <node concept="1PaTwC" id="5HuXUSEhEQa" role="1aUNEU">
+            <node concept="3oM_SD" id="5HuXUSEhEQc" role="1PaTwD">
+              <property role="3oM_SC" value="Null" />
             </node>
-            <node concept="liA8E" id="5cJmxjBjCU$" role="2OqNvi">
-              <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+            <node concept="3oM_SD" id="5HuXUSEhEQd" role="1PaTwD">
+              <property role="3oM_SC" value="before" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQe" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQf" role="1PaTwD">
+              <property role="3oM_SC" value="helper" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQg" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQh" role="1PaTwD">
+              <property role="3oM_SC" value="created," />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQi" role="1PaTwD">
+              <property role="3oM_SC" value="i.e." />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQj" role="1PaTwD">
+              <property role="3oM_SC" value="when" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQk" role="1PaTwD">
+              <property role="3oM_SC" value="evaluate()" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQl" role="1PaTwD">
+              <property role="3oM_SC" value="failed" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQm" role="1PaTwD">
+              <property role="3oM_SC" value="before" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQn" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQo" role="1PaTwD">
+              <property role="3oM_SC" value="started" />
+            </node>
+            <node concept="3oM_SD" id="5HuXUSEhEQp" role="1PaTwD">
+              <property role="3oM_SC" value="evaluating." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5HuXUSEhEQq" role="3cqZAp">
+          <node concept="1eOMI4" id="5HuXUSEhEQs" role="3clFbG">
+            <node concept="3K4zz7" id="5HuXUSEhEQu" role="1eOMHV">
+              <node concept="3clFbC" id="5HuXUSEhEQy" role="3K4Cdx">
+                <node concept="2OqwBi" id="5HuXUSEhEQ_" role="3uHU7B">
+                  <node concept="Xjq3P" id="5HuXUSEhEQC" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="5HuXUSEhEQD" role="2OqNvi">
+                    <ref role="2Oxat5" node="2nydsCfAaTv" resolve="helper" />
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="5HuXUSEhEQE" role="3uHU7w" />
+              </node>
+              <node concept="10Nm6u" id="5HuXUSEhEQF" role="3K4E3e" />
+              <node concept="2OqwBi" id="5HuXUSEhEQG" role="3K4GZi">
+                <node concept="2OqwBi" id="5HuXUSEhEQJ" role="2Oq$k0">
+                  <node concept="Xjq3P" id="5HuXUSEhEQM" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="5HuXUSEhEQN" role="2OqNvi">
+                    <ref role="2Oxat5" node="2nydsCfAaTv" resolve="helper" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5HuXUSEhEQO" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -32720,6 +32936,780 @@
     <node concept="3Tm1VV" id="7LZDtvhtD$H" role="1B3o_S" />
     <node concept="3uibUv" id="7LZDtvhtD_j" role="3HQHJm">
       <ref role="3uigEE" node="7LZDtvhnXHQ" resolve="IValueAndTrace" />
+    </node>
+  </node>
+  <node concept="312cEu" id="5HuXUSEfY1D">
+    <property role="TrG5h" value="TraceFailures" />
+    <node concept="3Tm1VV" id="5HuXUSEfY1F" role="1B3o_S" />
+    <node concept="2tJIrI" id="5HuXUSEfY1G" role="jymVt" />
+    <node concept="2YIFZL" id="5HuXUSEfY1H" role="jymVt">
+      <property role="TrG5h" value="markFailure" />
+      <node concept="3Tm1VV" id="5HuXUSEfY1L" role="1B3o_S" />
+      <node concept="3uibUv" id="5HuXUSEfY1M" role="3clF45">
+        <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="37vLTG" id="5HuXUSEfY1N" role="3clF46">
+        <property role="TrG5h" value="t" />
+        <node concept="3uibUv" id="5HuXUSEfY1P" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5HuXUSEfY1Q" role="3clF47">
+        <node concept="3cpWs8" id="5HuXUSEfY3K" role="3cqZAp">
+          <node concept="3cpWsn" id="5HuXUSEfY3N" role="3cpWs9">
+            <property role="TrG5h" value="failing" />
+            <node concept="3uibUv" id="5HuXUSEfY3P" role="1tU5fm">
+              <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfY3Q" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5HuXUSEfY3R" role="3cqZAp">
+          <node concept="3cpWsn" id="5HuXUSEfY3U" role="3cpWs9">
+            <property role="TrG5h" value="current" />
+            <node concept="3uibUv" id="5HuXUSEfY3W" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+            </node>
+            <node concept="37vLTw" id="5HuXUSEfY3X" role="33vP2m">
+              <ref role="3cqZAo" node="5HuXUSEfY1N" resolve="t" />
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="5HuXUSEfY3Y" role="3cqZAp">
+          <node concept="3y3z36" id="5HuXUSEfY41" role="2$JKZa">
+            <node concept="37vLTw" id="5HuXUSEfY44" role="3uHU7B">
+              <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfY45" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfY46" role="2LFqv$">
+            <node concept="3cpWs8" id="5HuXUSEfY47" role="3cqZAp">
+              <node concept="3cpWsn" id="5HuXUSEfY4a" role="3cpWs9">
+                <property role="TrG5h" value="candidate" />
+                <node concept="3uibUv" id="5HuXUSEfY4c" role="1tU5fm">
+                  <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+                </node>
+                <node concept="10Nm6u" id="5HuXUSEfY4d" role="33vP2m" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5HuXUSEfY4e" role="3cqZAp">
+              <node concept="2ZW3vV" id="5HuXUSEfY4h" role="3clFbw">
+                <node concept="37vLTw" id="5HuXUSEfY4k" role="2ZW6bz">
+                  <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                </node>
+                <node concept="3uibUv" id="5HuXUSEfY4l" role="2ZW6by">
+                  <ref role="3uigEE" to="2ahs:9nJ_zCA_CM" resolve="InterpreterRuntimeException" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="5HuXUSEfY4m" role="3clFbx">
+                <node concept="3clFbF" id="5HuXUSEfY4n" role="3cqZAp">
+                  <node concept="37vLTI" id="5HuXUSEfY4p" role="3clFbG">
+                    <node concept="37vLTw" id="5HuXUSEfY4s" role="37vLTJ">
+                      <ref role="3cqZAo" node="5HuXUSEfY4a" resolve="candidate" />
+                    </node>
+                    <node concept="2OqwBi" id="5HuXUSEfY4t" role="37vLTx">
+                      <node concept="1eOMI4" id="5HuXUSEfY4w" role="2Oq$k0">
+                        <node concept="10QFUN" id="5HuXUSEfY4y" role="1eOMHV">
+                          <node concept="3uibUv" id="5HuXUSEfY4_" role="10QFUM">
+                            <ref role="3uigEE" to="2ahs:9nJ_zCA_CM" resolve="InterpreterRuntimeException" />
+                          </node>
+                          <node concept="37vLTw" id="5HuXUSEfY4A" role="10QFUP">
+                            <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5HuXUSEfY4B" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:6LLJO$vY_c_" resolve="getFailureTrace" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3eNFk2" id="5HuXUSEfY4C" role="3eNLev">
+                <node concept="2ZW3vV" id="5HuXUSEfY4F" role="3eO9$A">
+                  <node concept="37vLTw" id="5HuXUSEfY4I" role="2ZW6bz">
+                    <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                  </node>
+                  <node concept="3uibUv" id="5HuXUSEfY4J" role="2ZW6by">
+                    <ref role="3uigEE" to="2ahs:78hTg1_i6bP" resolve="InterpreterEscapeException" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5HuXUSEfY4K" role="3eOfB_">
+                  <node concept="3clFbF" id="5HuXUSEfY4L" role="3cqZAp">
+                    <node concept="37vLTI" id="5HuXUSEfY4N" role="3clFbG">
+                      <node concept="37vLTw" id="5HuXUSEfY4Q" role="37vLTJ">
+                        <ref role="3cqZAo" node="5HuXUSEfY4a" resolve="candidate" />
+                      </node>
+                      <node concept="2OqwBi" id="5HuXUSEfY4R" role="37vLTx">
+                        <node concept="1eOMI4" id="5HuXUSEfY4U" role="2Oq$k0">
+                          <node concept="10QFUN" id="5HuXUSEfY4W" role="1eOMHV">
+                            <node concept="3uibUv" id="5HuXUSEfY4Z" role="10QFUM">
+                              <ref role="3uigEE" to="2ahs:78hTg1_i6bP" resolve="InterpreterEscapeException" />
+                            </node>
+                            <node concept="37vLTw" id="5HuXUSEfY50" role="10QFUP">
+                              <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OwXpG" id="5HuXUSEfY51" role="2OqNvi">
+                          <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5HuXUSEfY52" role="3cqZAp">
+              <node concept="3y3z36" id="5HuXUSEfY55" role="3clFbw">
+                <node concept="37vLTw" id="5HuXUSEfY58" role="3uHU7B">
+                  <ref role="3cqZAo" node="5HuXUSEfY4a" resolve="candidate" />
+                </node>
+                <node concept="10Nm6u" id="5HuXUSEfY59" role="3uHU7w" />
+              </node>
+              <node concept="3clFbS" id="5HuXUSEfY5a" role="3clFbx">
+                <node concept="3clFbF" id="5HuXUSEfY5b" role="3cqZAp">
+                  <node concept="37vLTI" id="5HuXUSEfY5d" role="3clFbG">
+                    <node concept="37vLTw" id="5HuXUSEfY5g" role="37vLTJ">
+                      <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+                    </node>
+                    <node concept="37vLTw" id="5HuXUSEfY5h" role="37vLTx">
+                      <ref role="3cqZAo" node="5HuXUSEfY4a" resolve="candidate" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5HuXUSEfY5i" role="3cqZAp">
+              <node concept="37vLTI" id="5HuXUSEfY5k" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfY5n" role="37vLTJ">
+                  <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                </node>
+                <node concept="1eOMI4" id="5HuXUSEfY5o" role="37vLTx">
+                  <node concept="3K4zz7" id="5HuXUSEfY5q" role="1eOMHV">
+                    <node concept="3clFbC" id="5HuXUSEfY5u" role="3K4Cdx">
+                      <node concept="2OqwBi" id="5HuXUSEfY5x" role="3uHU7B">
+                        <node concept="37vLTw" id="5HuXUSEfY5$" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                        </node>
+                        <node concept="liA8E" id="5HuXUSEfY5_" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Throwable.getCause()" resolve="getCause" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="5HuXUSEfY5A" role="3uHU7w">
+                        <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                      </node>
+                    </node>
+                    <node concept="10Nm6u" id="5HuXUSEfY5B" role="3K4E3e" />
+                    <node concept="2OqwBi" id="5HuXUSEfY5C" role="3K4GZi">
+                      <node concept="37vLTw" id="5HuXUSEfY5F" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5HuXUSEfY3U" resolve="current" />
+                      </node>
+                      <node concept="liA8E" id="5HuXUSEfY5G" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Throwable.getCause()" resolve="getCause" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfY5H" role="3cqZAp">
+          <node concept="3clFbC" id="5HuXUSEfY5K" role="3clFbw">
+            <node concept="37vLTw" id="5HuXUSEfY5N" role="3uHU7B">
+              <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfY5O" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfY5P" role="3clFbx">
+            <node concept="3cpWs6" id="5HuXUSEfY5Q" role="3cqZAp">
+              <node concept="10Nm6u" id="5HuXUSEfY5R" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfY5S" role="3cqZAp">
+          <node concept="3fqX7Q" id="5HuXUSEfY5V" role="3clFbw">
+            <node concept="2OqwBi" id="5HuXUSEfY5X" role="3fr31v">
+              <node concept="37vLTw" id="5HuXUSEfY60" role="2Oq$k0">
+                <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+              </node>
+              <node concept="liA8E" id="5HuXUSEfY61" role="2OqNvi">
+                <ref role="37wK5l" to="2ahs:2jL$v5BWpOw" resolve="hasConstraintFailure" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfY62" role="3clFbx">
+            <node concept="3clFbF" id="5HuXUSEfY63" role="3cqZAp">
+              <node concept="2OqwBi" id="5HuXUSEfY65" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfY68" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEfY69" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2jL$v5BV4RE" resolve="setConstraintFailure" />
+                  <node concept="1rXfSq" id="5HuXUSEfY6a" role="37wK5m">
+                    <ref role="37wK5l" node="5HuXUSEfYa9" resolve="describe" />
+                    <node concept="37vLTw" id="5HuXUSEfY6b" role="37wK5m">
+                      <ref role="3cqZAo" node="5HuXUSEfY1N" resolve="t" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5HuXUSEfY6c" role="3cqZAp">
+          <node concept="2OqwBi" id="5HuXUSEfY6e" role="3clFbG">
+            <node concept="37vLTw" id="5HuXUSEfY6h" role="2Oq$k0">
+              <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+            </node>
+            <node concept="liA8E" id="5HuXUSEfY6i" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:GAojRMRJl_" resolve="unmarkAsShowNever" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5HuXUSEfY6j" role="3cqZAp">
+          <node concept="2OqwBi" id="5HuXUSEfY6l" role="3clFbG">
+            <node concept="37vLTw" id="5HuXUSEfY6o" role="2Oq$k0">
+              <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+            </node>
+            <node concept="liA8E" id="5HuXUSEfY6p" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:5syY_AL3BL8" resolve="markAsShowInAnyCase" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5HuXUSEfY6q" role="3cqZAp">
+          <node concept="2OqwBi" id="5HuXUSEfY6s" role="3clFbG">
+            <node concept="37vLTw" id="5HuXUSEfY6v" role="2Oq$k0">
+              <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+            </node>
+            <node concept="liA8E" id="5HuXUSEfY6w" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:4hW8Ne0e_Tr" resolve="markForReveal" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5HuXUSEfY6x" role="3cqZAp">
+          <node concept="37vLTw" id="5HuXUSEfY6y" role="3cqZAk">
+            <ref role="3cqZAo" node="5HuXUSEfY3N" resolve="failing" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="48Zi1gzgsFA" role="lGtFl">
+        <node concept="TZ5HA" id="48Zi1gzgsFB" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFC" role="1dT_Ay">
+            <property role="1dT_AB" value="Locates the trace record of the node whose evaluation threw t and marks it as the failure," />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFD" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFE" role="1dT_Ay">
+            <property role="1dT_AB" value="so that the trace explorer renders it in red and its filters do not drop it." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFF" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFG" role="1dT_Ay">
+            <property role="1dT_AB" value="The interpreter wraps whatever escapes an evaluator into an InterpreterRuntimeException that" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFH" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFI" role="1dT_Ay">
+            <property role="1dT_AB" value="knows the node and its trace record, and every enclosing evaluator wraps that again, so the" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFJ" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFK" role="1dT_Ay">
+            <property role="1dT_AB" value="record of the node that actually threw is the last one along the cause chain." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFL" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFM" role="1dT_Ay">
+            <property role="1dT_AB" value="Returns null if t carries no trace record at all." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5HuXUSEfY6z" role="jymVt" />
+    <node concept="2YIFZL" id="5HuXUSEfY6$" role="jymVt">
+      <property role="TrG5h" value="traceForFailure" />
+      <node concept="3Tm1VV" id="5HuXUSEfY6C" role="1B3o_S" />
+      <node concept="3uibUv" id="5HuXUSEfY6D" role="3clF45">
+        <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="37vLTG" id="5HuXUSEfY6E" role="3clF46">
+        <property role="TrG5h" value="fallbackNode" />
+        <node concept="3Tqbb2" id="5HuXUSEfY6G" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5HuXUSEfY6H" role="3clF46">
+        <property role="TrG5h" value="partialTrace" />
+        <node concept="3uibUv" id="5HuXUSEfY6J" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5HuXUSEfY6K" role="3clF46">
+        <property role="TrG5h" value="t" />
+        <node concept="3uibUv" id="5HuXUSEfY6M" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5HuXUSEfY6N" role="3clF47">
+        <node concept="3cpWs8" id="5HuXUSEfY83" role="3cqZAp">
+          <node concept="3cpWsn" id="5HuXUSEfY86" role="3cpWs9">
+            <property role="TrG5h" value="failing" />
+            <node concept="3uibUv" id="5HuXUSEfY88" role="1tU5fm">
+              <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+            </node>
+            <node concept="1rXfSq" id="5HuXUSEfY89" role="33vP2m">
+              <ref role="37wK5l" node="5HuXUSEfY1H" resolve="markFailure" />
+              <node concept="37vLTw" id="5HuXUSEfY8a" role="37wK5m">
+                <ref role="3cqZAo" node="5HuXUSEfY6K" resolve="t" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5HuXUSEfY8b" role="3cqZAp">
+          <node concept="3cpWsn" id="5HuXUSEfY8e" role="3cpWs9">
+            <property role="TrG5h" value="root" />
+            <node concept="3uibUv" id="5HuXUSEfY8g" role="1tU5fm">
+              <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfY8h" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfY8i" role="3cqZAp">
+          <node concept="3y3z36" id="5HuXUSEfY8l" role="3clFbw">
+            <node concept="37vLTw" id="5HuXUSEfY8o" role="3uHU7B">
+              <ref role="3cqZAo" node="5HuXUSEfY6H" resolve="partialTrace" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfY8p" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfY8q" role="3clFbx">
+            <node concept="3clFbF" id="5HuXUSEfY8r" role="3cqZAp">
+              <node concept="37vLTI" id="5HuXUSEfY8t" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfY8w" role="37vLTJ">
+                  <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+                </node>
+                <node concept="2OqwBi" id="5HuXUSEfY8x" role="37vLTx">
+                  <node concept="37vLTw" id="5HuXUSEfY8$" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5HuXUSEfY6H" resolve="partialTrace" />
+                  </node>
+                  <node concept="liA8E" id="5HuXUSEfY8_" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:YcTL0gyvc" resolve="rootTrace" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="5HuXUSEfY8A" role="9aQIa">
+            <node concept="3y3z36" id="5HuXUSEfY8D" role="3clFbw">
+              <node concept="37vLTw" id="5HuXUSEfY8G" role="3uHU7B">
+                <ref role="3cqZAo" node="5HuXUSEfY86" resolve="failing" />
+              </node>
+              <node concept="10Nm6u" id="5HuXUSEfY8H" role="3uHU7w" />
+            </node>
+            <node concept="3clFbS" id="5HuXUSEfY8I" role="3clFbx">
+              <node concept="3clFbF" id="5HuXUSEfY8J" role="3cqZAp">
+                <node concept="37vLTI" id="5HuXUSEfY8L" role="3clFbG">
+                  <node concept="37vLTw" id="5HuXUSEfY8O" role="37vLTJ">
+                    <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+                  </node>
+                  <node concept="2OqwBi" id="5HuXUSEfY8P" role="37vLTx">
+                    <node concept="37vLTw" id="5HuXUSEfY8S" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5HuXUSEfY86" resolve="failing" />
+                    </node>
+                    <node concept="liA8E" id="5HuXUSEfY8T" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:YcTL0gyvc" resolve="rootTrace" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfY8U" role="3cqZAp">
+          <node concept="3clFbC" id="5HuXUSEfY8X" role="3clFbw">
+            <node concept="37vLTw" id="5HuXUSEfY90" role="3uHU7B">
+              <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfY91" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfY92" role="3clFbx">
+            <node concept="3SKdUt" id="5HuXUSEfY93" role="3cqZAp">
+              <node concept="1PaTwC" id="5HuXUSEfY97" role="1aUNEU">
+                <node concept="3oM_SD" id="5HuXUSEfY99" role="1PaTwD">
+                  <property role="3oM_SC" value="The" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9a" role="1PaTwD">
+                  <property role="3oM_SC" value="interpreter" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9b" role="1PaTwD">
+                  <property role="3oM_SC" value="did" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9c" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9d" role="1PaTwD">
+                  <property role="3oM_SC" value="get" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9e" role="1PaTwD">
+                  <property role="3oM_SC" value="far" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9f" role="1PaTwD">
+                  <property role="3oM_SC" value="enough" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9g" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9h" role="1PaTwD">
+                  <property role="3oM_SC" value="build" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9i" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9j" role="1PaTwD">
+                  <property role="3oM_SC" value="trace:" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9k" role="1PaTwD">
+                  <property role="3oM_SC" value="show" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9l" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9m" role="1PaTwD">
+                  <property role="3oM_SC" value="failure" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9n" role="1PaTwD">
+                  <property role="3oM_SC" value="by" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEfY9o" role="1PaTwD">
+                  <property role="3oM_SC" value="itself." />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5HuXUSEfY9p" role="3cqZAp">
+              <node concept="37vLTI" id="5HuXUSEfY9r" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfY9u" role="37vLTJ">
+                  <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+                </node>
+                <node concept="2ShNRf" id="5HuXUSEfY9v" role="37vLTx">
+                  <node concept="1pGfFk" id="5HuXUSEfY9x" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="2ahs:7cNsFS_gVK7" resolve="ComputationTrace" />
+                    <node concept="37vLTw" id="5HuXUSEfY9y" role="37wK5m">
+                      <ref role="3cqZAo" node="5HuXUSEfY6E" resolve="fallbackNode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfY9z" role="3cqZAp">
+          <node concept="1Wc70l" id="5HuXUSEfY9A" role="3clFbw">
+            <node concept="3clFbC" id="5HuXUSEfY9D" role="3uHU7B">
+              <node concept="37vLTw" id="5HuXUSEfY9G" role="3uHU7B">
+                <ref role="3cqZAo" node="5HuXUSEfY86" resolve="failing" />
+              </node>
+              <node concept="10Nm6u" id="5HuXUSEfY9H" role="3uHU7w" />
+            </node>
+            <node concept="3fqX7Q" id="5HuXUSEfY9I" role="3uHU7w">
+              <node concept="2OqwBi" id="5HuXUSEfY9K" role="3fr31v">
+                <node concept="37vLTw" id="5HuXUSEfY9N" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEfY9O" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2jL$v5BWpOw" resolve="hasConstraintFailure" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfY9P" role="3clFbx">
+            <node concept="3clFbF" id="5HuXUSEfY9Q" role="3cqZAp">
+              <node concept="2OqwBi" id="5HuXUSEfY9S" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfY9V" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEfY9W" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2jL$v5BV4RE" resolve="setConstraintFailure" />
+                  <node concept="1rXfSq" id="5HuXUSEfY9X" role="37wK5m">
+                    <ref role="37wK5l" node="5HuXUSEfYa9" resolve="describe" />
+                    <node concept="37vLTw" id="5HuXUSEfY9Y" role="37wK5m">
+                      <ref role="3cqZAo" node="5HuXUSEfY6K" resolve="t" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5HuXUSEfY9Z" role="3cqZAp">
+              <node concept="2OqwBi" id="5HuXUSEfYa1" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfYa4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEfYa5" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:4hW8Ne0e_Tr" resolve="markForReveal" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5HuXUSEfYa6" role="3cqZAp">
+          <node concept="37vLTw" id="5HuXUSEfYa7" role="3cqZAk">
+            <ref role="3cqZAo" node="5HuXUSEfY8e" resolve="root" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="48Zi1gzgsFN" role="lGtFl">
+        <node concept="TZ5HA" id="48Zi1gzgsFO" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFP" role="1dT_Ay">
+            <property role="1dT_AB" value="The root trace to show after t has aborted an evaluation; never null." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFQ" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFR" role="1dT_Ay">
+            <property role="1dT_AB" value="Everything that was computed before the exception is already in the trace, because the record" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFS" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFT" role="1dT_Ay">
+            <property role="1dT_AB" value="for a node is added to its parent before that node is evaluated. So the partial trace is worth" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="48Zi1gzgsFU" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFV" role="1dT_Ay">
+            <property role="1dT_AB" value="showing even though the exception unwound the evaluation." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5HuXUSEfYa8" role="jymVt" />
+    <node concept="2YIFZL" id="5HuXUSEfYa9" role="jymVt">
+      <property role="TrG5h" value="describe" />
+      <node concept="3Tm1VV" id="5HuXUSEfYad" role="1B3o_S" />
+      <node concept="17QB3L" id="5HuXUSEfYae" role="3clF45" />
+      <node concept="37vLTG" id="5HuXUSEfYaf" role="3clF46">
+        <property role="TrG5h" value="t" />
+        <node concept="3uibUv" id="5HuXUSEfYah" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5HuXUSEfYai" role="3clF47">
+        <node concept="3cpWs8" id="5HuXUSEfYa$" role="3cqZAp">
+          <node concept="3cpWsn" id="5HuXUSEfYaB" role="3cpWs9">
+            <property role="TrG5h" value="cause" />
+            <node concept="3uibUv" id="5HuXUSEfYaD" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+            </node>
+            <node concept="37vLTw" id="5HuXUSEfYaE" role="33vP2m">
+              <ref role="3cqZAo" node="5HuXUSEfYaf" resolve="t" />
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="5HuXUSEfYaF" role="3cqZAp">
+          <node concept="1Wc70l" id="5HuXUSEfYaI" role="2$JKZa">
+            <node concept="3y3z36" id="5HuXUSEfYaL" role="3uHU7B">
+              <node concept="2OqwBi" id="5HuXUSEfYaO" role="3uHU7B">
+                <node concept="37vLTw" id="5HuXUSEfYaR" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEfYaS" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Throwable.getCause()" resolve="getCause" />
+                </node>
+              </node>
+              <node concept="10Nm6u" id="5HuXUSEfYaT" role="3uHU7w" />
+            </node>
+            <node concept="3y3z36" id="5HuXUSEfYaU" role="3uHU7w">
+              <node concept="2OqwBi" id="5HuXUSEfYaX" role="3uHU7B">
+                <node concept="37vLTw" id="5HuXUSEfYb0" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEfYb1" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Throwable.getCause()" resolve="getCause" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5HuXUSEfYb2" role="3uHU7w">
+                <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfYb3" role="2LFqv$">
+            <node concept="3clFbF" id="5HuXUSEfYb4" role="3cqZAp">
+              <node concept="37vLTI" id="5HuXUSEfYb6" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfYb9" role="37vLTJ">
+                  <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+                </node>
+                <node concept="2OqwBi" id="5HuXUSEfYba" role="37vLTx">
+                  <node concept="37vLTw" id="5HuXUSEfYbd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+                  </node>
+                  <node concept="liA8E" id="5HuXUSEfYbe" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Throwable.getCause()" resolve="getCause" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5HuXUSEfYbf" role="3cqZAp">
+          <node concept="3cpWsn" id="5HuXUSEfYbi" role="3cpWs9">
+            <property role="TrG5h" value="message" />
+            <node concept="17QB3L" id="5HuXUSEfYbk" role="1tU5fm" />
+            <node concept="2OqwBi" id="5HuXUSEfYbl" role="33vP2m">
+              <node concept="37vLTw" id="5HuXUSEfYbo" role="2Oq$k0">
+                <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+              </node>
+              <node concept="liA8E" id="5HuXUSEfYbp" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfYbq" role="3cqZAp">
+          <node concept="3clFbC" id="5HuXUSEfYbt" role="3clFbw">
+            <node concept="37vLTw" id="5HuXUSEfYbw" role="3uHU7B">
+              <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+            </node>
+            <node concept="10Nm6u" id="5HuXUSEfYbx" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfYby" role="3clFbx">
+            <node concept="3clFbF" id="5HuXUSEfYbz" role="3cqZAp">
+              <node concept="37vLTI" id="5HuXUSEfYb_" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfYbC" role="37vLTJ">
+                  <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+                </node>
+                <node concept="Xl_RD" id="5HuXUSEfYbD" role="37vLTx">
+                  <property role="Xl_RC" value="" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="5HuXUSEfYbE" role="9aQIa">
+            <node concept="3clFbS" id="5HuXUSEfYbG" role="9aQI4">
+              <node concept="3clFbF" id="5HuXUSEfYbH" role="3cqZAp">
+                <node concept="37vLTI" id="5HuXUSEfYbJ" role="3clFbG">
+                  <node concept="37vLTw" id="5HuXUSEfYbM" role="37vLTJ">
+                    <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+                  </node>
+                  <node concept="3cpWs3" id="5HuXUSEfYbN" role="37vLTx">
+                    <node concept="Xl_RD" id="5HuXUSEfYbQ" role="3uHU7B">
+                      <property role="Xl_RC" value=": " />
+                    </node>
+                    <node concept="2OqwBi" id="5HuXUSEfYbR" role="3uHU7w">
+                      <node concept="2OqwBi" id="5HuXUSEfYbU" role="2Oq$k0">
+                        <node concept="37vLTw" id="5HuXUSEfYbX" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+                        </node>
+                        <node concept="liA8E" id="5HuXUSEfYbY" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
+                          <node concept="10QFUN" id="5HuXUSEfYbZ" role="37wK5m">
+                            <node concept="10Pfzv" id="5HuXUSEfYc2" role="10QFUM" />
+                            <node concept="3cmrfG" id="5HuXUSEfYc3" role="10QFUP">
+                              <property role="3cmrfH" value="10" />
+                            </node>
+                          </node>
+                          <node concept="10QFUN" id="5HuXUSEfYc4" role="37wK5m">
+                            <node concept="10Pfzv" id="5HuXUSEfYc7" role="10QFUM" />
+                            <node concept="3cmrfG" id="5HuXUSEfYc8" role="10QFUP">
+                              <property role="3cmrfH" value="32" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5HuXUSEfYc9" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
+                        <node concept="10QFUN" id="5HuXUSEfYca" role="37wK5m">
+                          <node concept="10Pfzv" id="5HuXUSEfYcd" role="10QFUM" />
+                          <node concept="3cmrfG" id="5HuXUSEfYce" role="10QFUP">
+                            <property role="3cmrfH" value="13" />
+                          </node>
+                        </node>
+                        <node concept="10QFUN" id="5HuXUSEfYcf" role="37wK5m">
+                          <node concept="10Pfzv" id="5HuXUSEfYci" role="10QFUM" />
+                          <node concept="3cmrfG" id="5HuXUSEfYcj" role="10QFUP">
+                            <property role="3cmrfH" value="32" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEfYck" role="3cqZAp">
+          <node concept="3eOSWO" id="5HuXUSEfYcn" role="3clFbw">
+            <node concept="2OqwBi" id="5HuXUSEfYcq" role="3uHU7B">
+              <node concept="37vLTw" id="5HuXUSEfYct" role="2Oq$k0">
+                <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+              </node>
+              <node concept="liA8E" id="5HuXUSEfYcu" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+              </node>
+            </node>
+            <node concept="3cmrfG" id="5HuXUSEfYcv" role="3uHU7w">
+              <property role="3cmrfH" value="200" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5HuXUSEfYcw" role="3clFbx">
+            <node concept="3clFbF" id="5HuXUSEfYcx" role="3cqZAp">
+              <node concept="37vLTI" id="5HuXUSEfYcz" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEfYcA" role="37vLTJ">
+                  <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+                </node>
+                <node concept="3cpWs3" id="5HuXUSEfYcB" role="37vLTx">
+                  <node concept="2OqwBi" id="5HuXUSEfYcE" role="3uHU7B">
+                    <node concept="37vLTw" id="5HuXUSEfYcH" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+                    </node>
+                    <node concept="liA8E" id="5HuXUSEfYcI" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                      <node concept="3cmrfG" id="5HuXUSEfYcJ" role="37wK5m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="3cmrfG" id="5HuXUSEfYcK" role="37wK5m">
+                        <property role="3cmrfH" value="200" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="5HuXUSEfYcL" role="3uHU7w">
+                    <property role="Xl_RC" value=" ..." />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5HuXUSEfYcM" role="3cqZAp">
+          <node concept="3cpWs3" id="5HuXUSEfYcN" role="3cqZAk">
+            <node concept="3cpWs3" id="5HuXUSEfYcQ" role="3uHU7B">
+              <node concept="Xl_RD" id="5HuXUSEfYcT" role="3uHU7B">
+                <property role="Xl_RC" value="failed with " />
+              </node>
+              <node concept="2OqwBi" id="5HuXUSEfYcU" role="3uHU7w">
+                <node concept="2OqwBi" id="5HuXUSEfYcX" role="2Oq$k0">
+                  <node concept="37vLTw" id="5HuXUSEfYd0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5HuXUSEfYaB" resolve="cause" />
+                  </node>
+                  <node concept="liA8E" id="5HuXUSEfYd1" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5HuXUSEfYd2" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Class.getSimpleName()" resolve="getSimpleName" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="5HuXUSEfYd3" role="3uHU7w">
+              <ref role="3cqZAo" node="5HuXUSEfYbi" resolve="message" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="48Zi1gzgsFW" role="lGtFl">
+        <node concept="TZ5HA" id="48Zi1gzgsFX" role="TZ5H$">
+          <node concept="1dT_AC" id="48Zi1gzgsFY" role="1dT_Ay">
+            <property role="1dT_AB" value="A one-line rendering of the exception for a trace record label." />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -33478,6 +33478,9 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="19sG5ctcBCw" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
     </node>
     <node concept="2tJIrI" id="5HuXUSEfYa8" role="jymVt" />
     <node concept="2YIFZL" id="5HuXUSEfYa9" role="jymVt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -1086,12 +1086,11 @@
                       </node>
                       <node concept="liA8E" id="7LZDtvgIA1I" role="2OqNvi">
                         <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
-                        <node concept="2OqwBi" id="2jL$v5BJ9C1" role="37wK5m">
-                          <node concept="37vLTw" id="2jL$v5BJ9gV" role="2Oq$k0">
+                        <node concept="2YIFZM" id="5HuXUSEzqDS" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEzqDT" role="37wK5m">
                             <ref role="3cqZAo" node="5E2FDFNID$X" resolve="ex" />
-                          </node>
-                          <node concept="2OwXpG" id="2jL$v5BJaeM" role="2OqNvi">
-                            <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                           </node>
                         </node>
                       </node>
@@ -1184,12 +1183,11 @@
                       </node>
                       <node concept="liA8E" id="7LZDtvgIVNd" role="2OqNvi">
                         <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
-                        <node concept="2OqwBi" id="2jL$v5BJ7mq" role="37wK5m">
-                          <node concept="37vLTw" id="2jL$v5BJ6Uj" role="2Oq$k0">
+                        <node concept="2YIFZM" id="5HuXUSEzqDU" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEzqDV" role="37wK5m">
                             <ref role="3cqZAo" node="TuTPrvzYsc" resolve="ex" />
-                          </node>
-                          <node concept="2OwXpG" id="2jL$v5BJ7SK" role="2OqNvi">
-                            <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                           </node>
                         </node>
                       </node>
@@ -1258,12 +1256,11 @@
                       </node>
                       <node concept="liA8E" id="7LZDtvgJhQh" role="2OqNvi">
                         <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
-                        <node concept="2OqwBi" id="1RzljfOdmoq" role="37wK5m">
-                          <node concept="37vLTw" id="1RzljfOdmor" role="2Oq$k0">
+                        <node concept="2YIFZM" id="5HuXUSEzqDW" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEzqDX" role="37wK5m">
                             <ref role="3cqZAo" node="1RzljfOdmnP" resolve="ex" />
-                          </node>
-                          <node concept="2OwXpG" id="1RzljfOdmos" role="2OqNvi">
-                            <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                           </node>
                         </node>
                       </node>
@@ -1319,6 +1316,75 @@
                             <property role="Xl_RC" value="interpreter failed internally" />
                           </node>
                           <node concept="37vLTw" id="3YhAT14QvsQ" role="37wK5m">
+                            <ref role="3cqZAo" node="51fdngf$kEG" resolve="t" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3SKdUt" id="5HuXUSEzqDY" role="3cqZAp">
+                    <node concept="1PaTwC" id="5HuXUSEzqE2" role="1aUNEU">
+                      <node concept="3oM_SD" id="5HuXUSEzqE4" role="1PaTwD">
+                        <property role="3oM_SC" value="Keep" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqE5" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqE6" role="1PaTwD">
+                        <property role="3oM_SC" value="trace" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqE7" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqE8" role="1PaTwD">
+                        <property role="3oM_SC" value="interpreter" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqE9" role="1PaTwD">
+                        <property role="3oM_SC" value="had" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEa" role="1PaTwD">
+                        <property role="3oM_SC" value="built" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEb" role="1PaTwD">
+                        <property role="3oM_SC" value="when" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEc" role="1PaTwD">
+                        <property role="3oM_SC" value="it" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEd" role="1PaTwD">
+                        <property role="3oM_SC" value="threw," />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEe" role="1PaTwD">
+                        <property role="3oM_SC" value="so" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEf" role="1PaTwD">
+                        <property role="3oM_SC" value="that" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEg" role="1PaTwD">
+                        <property role="3oM_SC" value="Show" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEh" role="1PaTwD">
+                        <property role="3oM_SC" value="Trace" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEi" role="1PaTwD">
+                        <property role="3oM_SC" value="still" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEzqEj" role="1PaTwD">
+                        <property role="3oM_SC" value="works." />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5HuXUSEzqEk" role="3cqZAp">
+                    <node concept="2OqwBi" id="5HuXUSEzqEm" role="3clFbG">
+                      <node concept="37vLTw" id="5HuXUSEzqEp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="ub9nkyOIWH" resolve="result" />
+                      </node>
+                      <node concept="liA8E" id="5HuXUSEzqEq" role="2OqNvi">
+                        <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
+                        <node concept="2YIFZM" id="5HuXUSEzqEr" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEzqEs" role="37wK5m">
                             <ref role="3cqZAo" node="51fdngf$kEG" resolve="t" />
                           </node>
                         </node>
@@ -1494,6 +1560,98 @@
               </node>
               <node concept="Xl_RD" id="2kg0xI3y527" role="37wK5m">
                 <property role="Xl_RC" value="expected" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5HuXUSEzqEt" role="3cqZAp">
+          <node concept="2OqwBi" id="5HuXUSEzqEw" role="3clFbw">
+            <node concept="37vLTw" id="5HuXUSEzqEz" role="2Oq$k0">
+              <ref role="3cqZAo" node="2kg0xI3w$9L" resolve="ct" />
+            </node>
+            <node concept="liA8E" id="5HuXUSEzqE$" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:2jL$v5BWpOw" resolve="hasConstraintFailure" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5HuXUSEzqE_" role="3clFbx">
+            <node concept="3SKdUt" id="5HuXUSEzqEA" role="3cqZAp">
+              <node concept="1PaTwC" id="5HuXUSEzqEE" role="1aUNEU">
+                <node concept="3oM_SD" id="5HuXUSEzqEG" role="1PaTwD">
+                  <property role="3oM_SC" value="A" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEH" role="1PaTwD">
+                  <property role="3oM_SC" value="failure" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEI" role="1PaTwD">
+                  <property role="3oM_SC" value="recorded" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEJ" role="1PaTwD">
+                  <property role="3oM_SC" value="on" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEK" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEL" role="1PaTwD">
+                  <property role="3oM_SC" value="trace" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEM" role="1PaTwD">
+                  <property role="3oM_SC" value="root" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEN" role="1PaTwD">
+                  <property role="3oM_SC" value="must" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEO" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEP" role="1PaTwD">
+                  <property role="3oM_SC" value="be" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEQ" role="1PaTwD">
+                  <property role="3oM_SC" value="lost" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqER" role="1PaTwD">
+                  <property role="3oM_SC" value="when" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqES" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqET" role="1PaTwD">
+                  <property role="3oM_SC" value="frame" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEU" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5HuXUSEzqEV" role="1PaTwD">
+                  <property role="3oM_SC" value="rebuilt." />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5HuXUSEzqEW" role="3cqZAp">
+              <node concept="2OqwBi" id="5HuXUSEzqEY" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEzqF1" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2kg0xI3wI6M" resolve="res" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEzqF2" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2jL$v5BV4RE" resolve="setConstraintFailure" />
+                  <node concept="2OqwBi" id="5HuXUSEzqF3" role="37wK5m">
+                    <node concept="37vLTw" id="5HuXUSEzqF6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2kg0xI3w$9L" resolve="ct" />
+                    </node>
+                    <node concept="liA8E" id="5HuXUSEzqF7" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:2jL$v5BWagj" resolve="getConstrainFailureMessage" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5HuXUSEzqF8" role="3cqZAp">
+              <node concept="2OqwBi" id="5HuXUSEzqFa" role="3clFbG">
+                <node concept="37vLTw" id="5HuXUSEzqFd" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2kg0xI3wI6M" resolve="res" />
+                </node>
+                <node concept="liA8E" id="5HuXUSEzqFe" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:4hW8Ne0e_Tr" resolve="markForReveal" />
+                </node>
               </node>
             </node>
           </node>
@@ -4438,32 +4596,163 @@
                     <node concept="3clFbS" id="5IR_boHRmeo" role="3clF47">
                       <node concept="3cpWs8" id="5IR_boHRzJQ" role="3cqZAp">
                         <node concept="3cpWsn" id="5IR_boHRzJR" role="3cpWs9">
-                          <property role="TrG5h" value="r" />
+                          <property role="TrG5h" value="t" />
                           <node concept="3uibUv" id="5IR_boHRzJS" role="1tU5fm">
-                            <ref role="3uigEE" node="7LZDtvgGNLS" resolve="IEvalResult" />
-                          </node>
-                          <node concept="2OqwBi" id="5IR_boHRmeq" role="33vP2m">
-                            <node concept="2qgKlT" id="4KZjPKUfw$y" role="2OqNvi">
-                              <ref role="37wK5l" node="4KZjPKUdEYm" resolve="executeTest" />
-                            </node>
-                            <node concept="37vLTw" id="5IR_boHRmer" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5IR_boHRjde" resolve="testItem" />
-                            </node>
+                            <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3cpWs8" id="6LLJO$xAqHz" role="3cqZAp">
-                        <node concept="3cpWsn" id="6LLJO$xAqH$" role="3cpWs9">
-                          <property role="TrG5h" value="t" />
-                          <node concept="3uibUv" id="6LLJO$xAqH_" role="1tU5fm">
-                            <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
-                          </node>
-                          <node concept="2OqwBi" id="6LLJO$xArum" role="33vP2m">
-                            <node concept="37vLTw" id="6LLJO$xArjH" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5IR_boHRzJR" resolve="r" />
+                      <node concept="3J1_TO" id="5HuXUSEwPYM" role="3cqZAp">
+                        <node concept="3clFbS" id="5HuXUSEwPYO" role="1zxBo7">
+                          <node concept="3cpWs8" id="5HuXUSEwPYP" role="3cqZAp">
+                            <node concept="3cpWsn" id="5HuXUSEwPYS" role="3cpWs9">
+                              <property role="TrG5h" value="r" />
+                              <node concept="3uibUv" id="5HuXUSEwPYU" role="1tU5fm">
+                                <ref role="3uigEE" node="7LZDtvgGNLS" resolve="IEvalResult" />
+                              </node>
+                              <node concept="2OqwBi" id="5HuXUSEwPYV" role="33vP2m">
+                                <node concept="37vLTw" id="5HuXUSEwPYY" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5IR_boHRjde" resolve="testItem" />
+                                </node>
+                                <node concept="2qgKlT" id="5HuXUSEwPYZ" role="2OqNvi">
+                                  <ref role="37wK5l" node="4KZjPKUdEYm" resolve="executeTest" />
+                                </node>
+                              </node>
                             </node>
-                            <node concept="liA8E" id="7LZDtvgOrKw" role="2OqNvi">
-                              <ref role="37wK5l" node="7LZDtvgGPoM" resolve="getTrace" />
+                          </node>
+                          <node concept="3clFbF" id="5HuXUSEwPZ0" role="3cqZAp">
+                            <node concept="37vLTI" id="5HuXUSEwPZ2" role="3clFbG">
+                              <node concept="37vLTw" id="5HuXUSEwPZ5" role="37vLTJ">
+                                <ref role="3cqZAo" node="5IR_boHRzJR" resolve="t" />
+                              </node>
+                              <node concept="2OqwBi" id="5HuXUSEwPZ6" role="37vLTx">
+                                <node concept="37vLTw" id="5HuXUSEwPZ9" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5HuXUSEwPYS" resolve="r" />
+                                </node>
+                                <node concept="liA8E" id="5HuXUSEwPZa" role="2OqNvi">
+                                  <ref role="37wK5l" node="7LZDtvgGPoM" resolve="getTrace" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3uVAMA" id="5HuXUSEwPZb" role="1zxBo5">
+                          <node concept="XOnhg" id="5HuXUSEwPZf" role="1zc67B">
+                            <property role="TrG5h" value="ex" />
+                            <node concept="nSUau" id="5HuXUSEwPZh" role="1tU5fm">
+                              <node concept="3uibUv" id="5HuXUSEwPZj" role="nSUat">
+                                <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="5HuXUSEwPZk" role="1zc67A">
+                            <node concept="3SKdUt" id="5HuXUSEwPZl" role="3cqZAp">
+                              <node concept="1PaTwC" id="5HuXUSEwPZp" role="1aUNEU">
+                                <node concept="3oM_SD" id="5HuXUSEwPZr" role="1PaTwD">
+                                  <property role="3oM_SC" value="An" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZs" role="1PaTwD">
+                                  <property role="3oM_SC" value="exception" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZt" role="1PaTwD">
+                                  <property role="3oM_SC" value="must" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZu" role="1PaTwD">
+                                  <property role="3oM_SC" value="not" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZv" role="1PaTwD">
+                                  <property role="3oM_SC" value="cost" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZw" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZx" role="1PaTwD">
+                                  <property role="3oM_SC" value="whole" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZy" role="1PaTwD">
+                                  <property role="3oM_SC" value="trace:" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZz" role="1PaTwD">
+                                  <property role="3oM_SC" value="show" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZ$" role="1PaTwD">
+                                  <property role="3oM_SC" value="what" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZ_" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZA" role="1PaTwD">
+                                  <property role="3oM_SC" value="interpreter" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZB" role="1PaTwD">
+                                  <property role="3oM_SC" value="computed" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3SKdUt" id="5HuXUSEwPZC" role="3cqZAp">
+                              <node concept="1PaTwC" id="5HuXUSEwPZG" role="1aUNEU">
+                                <node concept="3oM_SD" id="5HuXUSEwPZI" role="1PaTwD">
+                                  <property role="3oM_SC" value="before" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZJ" role="1PaTwD">
+                                  <property role="3oM_SC" value="it," />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZK" role="1PaTwD">
+                                  <property role="3oM_SC" value="with" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZL" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZM" role="1PaTwD">
+                                  <property role="3oM_SC" value="node" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZN" role="1PaTwD">
+                                  <property role="3oM_SC" value="that" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZO" role="1PaTwD">
+                                  <property role="3oM_SC" value="threw" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZP" role="1PaTwD">
+                                  <property role="3oM_SC" value="marked" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZQ" role="1PaTwD">
+                                  <property role="3oM_SC" value="as" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZR" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="5HuXUSEwPZS" role="1PaTwD">
+                                  <property role="3oM_SC" value="failure." />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5HuXUSEwPZT" role="3cqZAp">
+                              <node concept="2OqwBi" id="5HuXUSEwPZV" role="3clFbG">
+                                <node concept="37vLTw" id="5HuXUSEwPZY" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5HuXUSEwPZf" resolve="ex" />
+                                </node>
+                                <node concept="liA8E" id="5HuXUSEwPZZ" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5HuXUSEwQ00" role="3cqZAp">
+                              <node concept="37vLTI" id="5HuXUSEwQ02" role="3clFbG">
+                                <node concept="37vLTw" id="5HuXUSEwQ05" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5IR_boHRzJR" resolve="t" />
+                                </node>
+                                <node concept="2YIFZM" id="5HuXUSEwQ06" role="37vLTx">
+                                  <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                                  <ref role="37wK5l" to="pbu6:5HuXUSEfY6$" resolve="traceForFailure" />
+                                  <node concept="37vLTw" id="5HuXUSEwQ07" role="37wK5m">
+                                    <ref role="3cqZAo" node="5IR_boHRjde" resolve="testItem" />
+                                  </node>
+                                  <node concept="10Nm6u" id="5HuXUSEwQ08" role="37wK5m" />
+                                  <node concept="37vLTw" id="5HuXUSEwQ09" role="37wK5m">
+                                    <ref role="3cqZAo" node="5HuXUSEwPZf" resolve="ex" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -4473,7 +4762,7 @@
                           <node concept="3clFbF" id="5IR_boHRAcK" role="3cqZAp">
                             <node concept="2OqwBi" id="5IR_boHRAuR" role="3clFbG">
                               <node concept="37vLTw" id="5IR_boHRAcI" role="2Oq$k0">
-                                <ref role="3cqZAo" node="6LLJO$xAqH$" resolve="t" />
+                                <ref role="3cqZAo" node="5IR_boHRzJR" resolve="t" />
                               </node>
                               <node concept="liA8E" id="5IR_boHRASz" role="2OqNvi">
                                 <ref role="37wK5l" to="2ahs:5IR_boHQAxv" resolve="setRerunner" />
@@ -4485,13 +4774,13 @@
                         <node concept="3y3z36" id="5syY_AKG2TS" role="3clFbw">
                           <node concept="10Nm6u" id="5syY_AKG37i" role="3uHU7w" />
                           <node concept="37vLTw" id="5syY_AKG2vl" role="3uHU7B">
-                            <ref role="3cqZAo" node="6LLJO$xAqH$" resolve="t" />
+                            <ref role="3cqZAo" node="5IR_boHRzJR" resolve="t" />
                           </node>
                         </node>
                       </node>
                       <node concept="3cpWs6" id="5IR_boHRnMO" role="3cqZAp">
                         <node concept="37vLTw" id="5IR_boHR_Ic" role="3cqZAk">
-                          <ref role="3cqZAo" node="6LLJO$xAqH$" resolve="t" />
+                          <ref role="3cqZAo" node="5IR_boHRzJR" resolve="t" />
                         </node>
                       </node>
                     </node>
@@ -5308,6 +5597,75 @@
                         <ref role="37wK5l" node="7LZDtvgGM7R" resolve="setException" />
                         <node concept="37vLTw" id="7LZDtvgNWxP" role="37wK5m">
                           <ref role="3cqZAo" node="78hTg1_hS2r" resolve="ire" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3SKdUt" id="5HuXUSEF9v1" role="3cqZAp">
+                    <node concept="1PaTwC" id="5HuXUSEF9v2" role="1aUNEU">
+                      <node concept="3oM_SD" id="5HuXUSEF9v3" role="1PaTwD">
+                        <property role="3oM_SC" value="Keep" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9v4" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9v5" role="1PaTwD">
+                        <property role="3oM_SC" value="trace" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9v6" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9v7" role="1PaTwD">
+                        <property role="3oM_SC" value="interpreter" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9v8" role="1PaTwD">
+                        <property role="3oM_SC" value="had" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9v9" role="1PaTwD">
+                        <property role="3oM_SC" value="built" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9va" role="1PaTwD">
+                        <property role="3oM_SC" value="when" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vb" role="1PaTwD">
+                        <property role="3oM_SC" value="it" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vc" role="1PaTwD">
+                        <property role="3oM_SC" value="threw," />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vd" role="1PaTwD">
+                        <property role="3oM_SC" value="so" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9ve" role="1PaTwD">
+                        <property role="3oM_SC" value="that" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vf" role="1PaTwD">
+                        <property role="3oM_SC" value="Show" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vg" role="1PaTwD">
+                        <property role="3oM_SC" value="Trace" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vh" role="1PaTwD">
+                        <property role="3oM_SC" value="still" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEF9vi" role="1PaTwD">
+                        <property role="3oM_SC" value="works." />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5HuXUSEF9vj" role="3cqZAp">
+                    <node concept="2OqwBi" id="5HuXUSEF9vk" role="3clFbG">
+                      <node concept="37vLTw" id="5HuXUSEF9vl" role="2Oq$k0">
+                        <ref role="3cqZAo" node="78hTg1$TLoy" resolve="result" />
+                      </node>
+                      <node concept="liA8E" id="5HuXUSEF9vm" role="2OqNvi">
+                        <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
+                        <node concept="2YIFZM" id="5HuXUSEF9vn" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEF9vo" role="37wK5m">
+                            <ref role="3cqZAo" node="78hTg1_hS2r" resolve="ire" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -9625,6 +9983,75 @@
                   </node>
                 </node>
               </node>
+              <node concept="3SKdUt" id="5HuXUSEA$kx" role="3cqZAp">
+                <node concept="1PaTwC" id="5HuXUSEA$k_" role="1aUNEU">
+                  <node concept="3oM_SD" id="5HuXUSEA$kB" role="1PaTwD">
+                    <property role="3oM_SC" value="Keep" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kC" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kD" role="1PaTwD">
+                    <property role="3oM_SC" value="trace" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kE" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kF" role="1PaTwD">
+                    <property role="3oM_SC" value="interpreter" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kG" role="1PaTwD">
+                    <property role="3oM_SC" value="had" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kH" role="1PaTwD">
+                    <property role="3oM_SC" value="built" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kI" role="1PaTwD">
+                    <property role="3oM_SC" value="when" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kJ" role="1PaTwD">
+                    <property role="3oM_SC" value="it" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kK" role="1PaTwD">
+                    <property role="3oM_SC" value="threw," />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kL" role="1PaTwD">
+                    <property role="3oM_SC" value="so" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kM" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kN" role="1PaTwD">
+                    <property role="3oM_SC" value="Show" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kO" role="1PaTwD">
+                    <property role="3oM_SC" value="Trace" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kP" role="1PaTwD">
+                    <property role="3oM_SC" value="still" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$kQ" role="1PaTwD">
+                    <property role="3oM_SC" value="works." />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5HuXUSEA$kR" role="3cqZAp">
+                <node concept="2OqwBi" id="5HuXUSEA$kT" role="3clFbG">
+                  <node concept="37vLTw" id="5HuXUSEA$kW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="713ZPaW1oD7" resolve="result" />
+                  </node>
+                  <node concept="liA8E" id="5HuXUSEA$kX" role="2OqNvi">
+                    <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
+                    <node concept="2YIFZM" id="5HuXUSEA$kY" role="37wK5m">
+                      <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                      <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                      <node concept="37vLTw" id="5HuXUSEA$kZ" role="37wK5m">
+                        <ref role="3cqZAo" node="713ZPaW1oEg" resolve="ex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
           <node concept="3uVAMA" id="713ZPaW1oEN" role="1zxBo5">
@@ -9675,6 +10102,75 @@
                         <property role="Xl_RC" value="invalid value" />
                       </node>
                       <node concept="37vLTw" id="3YhAT14QjGp" role="37wK5m">
+                        <ref role="3cqZAo" node="713ZPaW1oEO" resolve="ex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3SKdUt" id="5HuXUSEA$l0" role="3cqZAp">
+                <node concept="1PaTwC" id="5HuXUSEA$l4" role="1aUNEU">
+                  <node concept="3oM_SD" id="5HuXUSEA$l6" role="1PaTwD">
+                    <property role="3oM_SC" value="Keep" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$l7" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$l8" role="1PaTwD">
+                    <property role="3oM_SC" value="trace" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$l9" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$la" role="1PaTwD">
+                    <property role="3oM_SC" value="interpreter" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lb" role="1PaTwD">
+                    <property role="3oM_SC" value="had" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lc" role="1PaTwD">
+                    <property role="3oM_SC" value="built" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$ld" role="1PaTwD">
+                    <property role="3oM_SC" value="when" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$le" role="1PaTwD">
+                    <property role="3oM_SC" value="it" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lf" role="1PaTwD">
+                    <property role="3oM_SC" value="threw," />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lg" role="1PaTwD">
+                    <property role="3oM_SC" value="so" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lh" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$li" role="1PaTwD">
+                    <property role="3oM_SC" value="Show" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lj" role="1PaTwD">
+                    <property role="3oM_SC" value="Trace" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$lk" role="1PaTwD">
+                    <property role="3oM_SC" value="still" />
+                  </node>
+                  <node concept="3oM_SD" id="5HuXUSEA$ll" role="1PaTwD">
+                    <property role="3oM_SC" value="works." />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5HuXUSEA$lm" role="3cqZAp">
+                <node concept="2OqwBi" id="5HuXUSEA$lo" role="3clFbG">
+                  <node concept="37vLTw" id="5HuXUSEA$lr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="713ZPaW1oD7" resolve="result" />
+                  </node>
+                  <node concept="liA8E" id="5HuXUSEA$ls" role="2OqNvi">
+                    <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
+                    <node concept="2YIFZM" id="5HuXUSEA$lt" role="37wK5m">
+                      <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                      <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                      <node concept="37vLTw" id="5HuXUSEA$lu" role="37wK5m">
                         <ref role="3cqZAo" node="713ZPaW1oEO" resolve="ex" />
                       </node>
                     </node>
@@ -14099,12 +14595,11 @@
                       </node>
                       <node concept="liA8E" id="7LZDtvgKEBa" role="2OqNvi">
                         <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
-                        <node concept="2OqwBi" id="5Pgo_AS66U2" role="37wK5m">
-                          <node concept="37vLTw" id="5Pgo_AS66U3" role="2Oq$k0">
+                        <node concept="2YIFZM" id="5HuXUSEPT8f" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEPT8g" role="37wK5m">
                             <ref role="3cqZAo" node="5Pgo_AS66T_" resolve="ex" />
-                          </node>
-                          <node concept="2OwXpG" id="5Pgo_AS66U4" role="2OqNvi">
-                            <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                           </node>
                         </node>
                       </node>
@@ -14173,12 +14668,11 @@
                       </node>
                       <node concept="liA8E" id="7LZDtvgKRJg" role="2OqNvi">
                         <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
-                        <node concept="2OqwBi" id="5Pgo_AS66UA" role="37wK5m">
-                          <node concept="37vLTw" id="5Pgo_AS66UB" role="2Oq$k0">
+                        <node concept="2YIFZM" id="5HuXUSEPT8h" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEPT8i" role="37wK5m">
                             <ref role="3cqZAo" node="5Pgo_AS66U9" resolve="ex" />
-                          </node>
-                          <node concept="2OwXpG" id="5Pgo_AS66UC" role="2OqNvi">
-                            <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                           </node>
                         </node>
                       </node>
@@ -14247,12 +14741,11 @@
                       </node>
                       <node concept="liA8E" id="7LZDtvgL4TZ" role="2OqNvi">
                         <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
-                        <node concept="2OqwBi" id="5Pgo_AS66Va" role="37wK5m">
-                          <node concept="37vLTw" id="5Pgo_AS66Vb" role="2Oq$k0">
+                        <node concept="2YIFZM" id="5HuXUSEPT8j" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEPT8k" role="37wK5m">
                             <ref role="3cqZAo" node="5Pgo_AS66UH" resolve="ex" />
-                          </node>
-                          <node concept="2OwXpG" id="5Pgo_AS66Vc" role="2OqNvi">
-                            <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                           </node>
                         </node>
                       </node>
@@ -14321,6 +14814,75 @@
                       </node>
                       <node concept="liA8E" id="5Pgo_AS66VP" role="2OqNvi">
                         <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3SKdUt" id="5HuXUSEPT7R" role="3cqZAp">
+                    <node concept="1PaTwC" id="5HuXUSEPT7S" role="1aUNEU">
+                      <node concept="3oM_SD" id="5HuXUSEPT7T" role="1PaTwD">
+                        <property role="3oM_SC" value="Keep" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT7U" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT7V" role="1PaTwD">
+                        <property role="3oM_SC" value="trace" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT7W" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT7X" role="1PaTwD">
+                        <property role="3oM_SC" value="interpreter" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT7Y" role="1PaTwD">
+                        <property role="3oM_SC" value="had" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT7Z" role="1PaTwD">
+                        <property role="3oM_SC" value="built" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT80" role="1PaTwD">
+                        <property role="3oM_SC" value="when" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT81" role="1PaTwD">
+                        <property role="3oM_SC" value="it" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT82" role="1PaTwD">
+                        <property role="3oM_SC" value="threw," />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT83" role="1PaTwD">
+                        <property role="3oM_SC" value="so" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT84" role="1PaTwD">
+                        <property role="3oM_SC" value="that" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT85" role="1PaTwD">
+                        <property role="3oM_SC" value="Show" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT86" role="1PaTwD">
+                        <property role="3oM_SC" value="Trace" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT87" role="1PaTwD">
+                        <property role="3oM_SC" value="still" />
+                      </node>
+                      <node concept="3oM_SD" id="5HuXUSEPT88" role="1PaTwD">
+                        <property role="3oM_SC" value="works." />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5HuXUSEPT89" role="3cqZAp">
+                    <node concept="2OqwBi" id="5HuXUSEPT8a" role="3clFbG">
+                      <node concept="37vLTw" id="5HuXUSEPT8b" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5Pgo_AS66To" resolve="result" />
+                      </node>
+                      <node concept="liA8E" id="5HuXUSEPT8c" role="2OqNvi">
+                        <ref role="37wK5l" node="7LZDtvgGM7z" resolve="setTrace" />
+                        <node concept="2YIFZM" id="5HuXUSEPT8d" role="37wK5m">
+                          <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                          <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                          <node concept="37vLTw" id="5HuXUSEPT8e" role="37wK5m">
+                            <ref role="3cqZAo" node="5Pgo_AS66Vh" resolve="t" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -15076,12 +15638,11 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="1IvwIN_uecY" role="37wK5m">
-                      <node concept="37vLTw" id="1IvwIN_udCI" role="2Oq$k0">
+                    <node concept="2YIFZM" id="5HuXUSEPT8l" role="37wK5m">
+                      <ref role="1Pybhc" to="pbu6:5HuXUSEfY1D" resolve="TraceFailures" />
+                      <ref role="37wK5l" to="pbu6:5HuXUSEfY1H" resolve="markFailure" />
+                      <node concept="37vLTw" id="5HuXUSEPT8m" role="37wK5m">
                         <ref role="3cqZAo" node="1IvwIN_tX7F" resolve="ex" />
-                      </node>
-                      <node concept="2OwXpG" id="1IvwIN_ufjY" role="2OqNvi">
-                        <ref role="2Oxat5" to="2ahs:2jL$v5BnuLX" resolve="failedTrace" />
                       </node>
                     </node>
                   </node>


### PR DESCRIPTION
## Problem

When the interpreter throws an exception while a trace is being built, **Show Trace** shows nothing at all: no
tab opens and the exception surfaces as an IDE error. Everything the interpreter had already
computed is discarded with it.

The trace is not actually lost when that happens. A node's `ComputationTrace` record is added to its
parent *before* that node is evaluated, and every generated evaluator wraps whatever escapes into an
`InterpreterRuntimeException` carrying the node and its record — re-wrapping at each enclosing
level, so the innermost record sits at the end of the cause chain. `InterpreterEscapeException`
carries the same thing in `failedTrace`. Nothing was using any of it:

- `ITraceRoot.defaultRerunnableInterpreted` (the path behind Show Trace on functions, constants and
  function calls) and `AbstractTestItem.getRootTrace` did not catch at all.
- The test items' `catch` branches set an error message but never called `setTrace`.

## Fix

New `TraceFailures` in `org.iets3.core.expr.base.behavior`:

- `markFailure(Throwable)` walks the cause chain to the innermost record, stamps it with a one-line
  `failed with <Exception>: <message>` (an existing message is not overwritten), clears `showNever`
  and sets `showInAnyCase` + `markForReveal`, so the trace explorer's filters keep it and render it
  in red.
- `traceForFailure(node, partialTrace, throwable)` returns the root trace to show and never returns
  null — it falls back to a single record for the node when the interpreter did not get far enough
  to build one.

Wired into both trace roots and into the `catch` branches of `AssertTestItem`,
`AssertThatTestItem`, `AssertOptionTestItem` and `ConstraintFailedTestItem`.
`AssertTestItem.constructCustomFrame` rebuilds the root record, so it now carries a failure
recorded there over to the frame. `IETS3ExprEvaluator.getLastLog` no longer throws when `evaluate()`
failed before the helper existed.

Everything this uses (`getFailureTrace`, `failedTrace`, `unmarkAsShowNever`, `markAsShowInAnyCase`,
`markForReveal`, `rootTrace`) is already present in the released
`com.mbeddr.mpsutil.interpreter.rt` artifact, so no platform change is needed.

## Reproducing

Any trace root whose evaluation throws will do. For the screenshots below, a `Constant` in a
`Library` with one sub-expression that is fine and one that blows up at runtime:

```
val boom = (1 + 2) * (3 + 4) + 10 / (5 - 5)
```

The model is legal — the type checker reports no problem on it — but `10 / (5 - 5)` raises
`ConstraintFailedException` after `(1 + 2) * (3 + 4)` has already been computed. Invoke **Show
Trace** on it.

## Before

No tab opens. The exception escapes `ITraceRoot.defaultRerunnableInterpreted` into action dispatch
and lands in the IDE error log:

```
Action dispatch failed. Thread AWT-EventQueue-0, state ACTIVE, 1 active clients.
org.iets3.core.expr.base.plugin.ConstraintFailedException: division by zero
    at o.i.c.expr.base//org.iets3.core.expr.base.plugin.ArithmeticErrorHelper...
    at c.m.m.interpreter.rt//com.mbeddr.mpsutil.interpreter.rt.InterpreterBase...
    ...
    at o.i.c.expr.base//org.iets3.core.expr.base.behavior.IETS3ExprEvaluator...
    at o.i.c.expr.base//org.iets3.core.expr.base.behavior.ITraceRoot__Behavior...
```

<img width="1137" height="229" src="https://github.com/user-attachments/assets/3cb8413d-3181-4d7d-a7e5-6a20d6ac9689" />

## After

The tab opens with the trace as it stood when the exception was raised. `(1 + 2) * (3 + 4) ⇒ 21`
and its sub-results are there with their timings, and the node that threw is marked in red with the
exception and flagged `[R]`.

<img width="1172" height="465" src="https://github.com/user-attachments/assets/8bde8ac3-1693-4419-8fc1-79cd9d361cab" />

> The screenshot uses the *show all non-skippable trace nodes* filter so the whole tree is visible.
> Under the default *reduced* filter the same trace shows the marked failing node on its own — that
> filter keeps frames and show-in-any-case nodes, and a constant has no frames, so this is its
> normal behaviour rather than something this change introduces.
