### PR TITLE
Variability: Adapt all transitively extending configurations from an abstract configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## September 2026
+
+### Added
+- Variability: New intention "Adapt Extending Configurations to Changes" on abstract feature model configurations. It propagates changes of the abstract configuration to *all* transitively extending configurations in one step (with progress reporting), instead of applying the per-configuration fix "Adapt this Configuration to the extended Configuration" one-by-one.
+
+### Changed
+- Variability: The update-configurations tasks were refactored - the common functionality of the tasks updating one, all, or all extending configurations now lives in the shared base classes `AbstractUpdateConfigsTask` / `ConfigFromFeatureModelUpdater`.
+
 ## August 2026
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
@@ -25482,25 +25482,51 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6IPgvt9CNFG" role="3cqZAp">
-          <node concept="2OqwBi" id="6IPgvt9DciF" role="3clFbG">
-            <node concept="1eOMI4" id="6IPgvt9D9MA" role="2Oq$k0">
-              <node concept="10QFUN" id="6IPgvt9CQ81" role="1eOMHV">
-                <node concept="3uibUv" id="6IPgvt9D3ww" role="10QFUM">
-                  <ref role="3uigEE" to="mhbf:~EditableSModel" resolve="EditableSModel" />
-                </node>
-                <node concept="2OqwBi" id="5BtXES5opZX" role="10QFUP">
-                  <node concept="Xjq3P" id="5BtXES5onB7" role="2Oq$k0" />
-                  <node concept="2OwXpG" id="5BtXES5otak" role="2OqNvi">
-                    <ref role="2Oxat5" node="5BtXES5m45o" resolve="model" />
+        <node concept="3clFbJ" id="2FiNa4PSxEb" role="3cqZAp">
+          <node concept="3fqX7Q" id="2FiNa4PSxEc" role="3clFbw">
+            <node concept="1eOMI4" id="2FiNa4PSxEd" role="3fr31v">
+              <node concept="2OqwBi" id="2FiNa4PSxEe" role="1eOMHV">
+                <node concept="1eOMI4" id="2FiNa4PSxEf" role="2Oq$k0">
+                  <node concept="10QFUN" id="2FiNa4PSxEg" role="1eOMHV">
+                    <node concept="3uibUv" id="2FiNa4PSxEh" role="10QFUM">
+                      <ref role="3uigEE" to="g3l6:~SModelBase" resolve="SModelBase" />
+                    </node>
+                    <node concept="2OqwBi" id="2FiNa4PSxEi" role="10QFUP">
+                      <node concept="Xjq3P" id="2FiNa4PSxEj" role="2Oq$k0" />
+                      <node concept="2OwXpG" id="2FiNa4PSxEk" role="2OqNvi">
+                        <ref role="2Oxat5" node="5BtXES5m45o" resolve="model" />
+                      </node>
+                    </node>
                   </node>
+                </node>
+                <node concept="liA8E" id="2FiNa4PSxEl" role="2OqNvi">
+                  <ref role="37wK5l" to="g3l6:~SModelBase.isReadOnly()" resolve="isReadOnly" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="6IPgvt9DeDq" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~EditableSModel.setChanged(boolean)" resolve="setChanged" />
-              <node concept="3clFbT" id="6IPgvt9Dh2p" role="37wK5m">
-                <property role="3clFbU" value="true" />
+          </node>
+          <node concept="3clFbS" id="2FiNa4PSxEm" role="3clFbx">
+            <node concept="3clFbF" id="2FiNa4PSxEn" role="3cqZAp">
+              <node concept="2OqwBi" id="2FiNa4PSxEo" role="3clFbG">
+                <node concept="1eOMI4" id="2FiNa4PSxEp" role="2Oq$k0">
+                  <node concept="10QFUN" id="2FiNa4PSxEq" role="1eOMHV">
+                    <node concept="3uibUv" id="2FiNa4PSxEr" role="10QFUM">
+                      <ref role="3uigEE" to="mhbf:~EditableSModel" resolve="EditableSModel" />
+                    </node>
+                    <node concept="2OqwBi" id="2FiNa4PSxEs" role="10QFUP">
+                      <node concept="Xjq3P" id="2FiNa4PSxEt" role="2Oq$k0" />
+                      <node concept="2OwXpG" id="2FiNa4PSxEu" role="2OqNvi">
+                        <ref role="2Oxat5" node="5BtXES5m45o" resolve="model" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="2FiNa4PSxEv" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~EditableSModel.setChanged(boolean)" resolve="setChanged" />
+                  <node concept="3clFbT" id="2FiNa4PSxEw" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -26400,7 +26426,7 @@
       <node concept="3Tm1VV" id="5BtXES5l607" role="1B3o_S" />
       <node concept="3clFbS" id="5BtXES5l60q" role="3clF47">
         <node concept="XkiVB" id="5BtXES5l60r" role="3cqZAp">
-          <ref role="37wK5l" node="64l_37QMsaA" />
+          <ref role="37wK5l" node="64l_37QMsaA" resolve="ConfigFromFeatureModelUpdater" />
           <node concept="37vLTw" id="5BtXES5l60s" role="37wK5m">
             <ref role="3cqZAo" node="5BtXES5l601" resolve="project" />
           </node>
@@ -26728,7 +26754,7 @@
       <node concept="3Tm1VV" id="5BtXES5l64I" role="1B3o_S" />
       <node concept="3clFbS" id="5BtXES5l651" role="3clF47">
         <node concept="XkiVB" id="5BtXES5l652" role="3cqZAp">
-          <ref role="37wK5l" node="64l_37QMsaA" />
+          <ref role="37wK5l" node="64l_37QMsaA" resolve="ConfigFromFeatureModelUpdater" />
           <node concept="37vLTw" id="5BtXES5l653" role="37wK5m">
             <ref role="3cqZAo" node="5BtXES5l64C" resolve="project" />
           </node>
@@ -27757,7 +27783,7 @@
     <node concept="2tJIrI" id="6WUl45aDBz1" role="jymVt" />
     <node concept="3Tm1VV" id="6WUl45aDiYJ" role="1B3o_S" />
     <node concept="3uibUv" id="64l_37QMtYb" role="1zkMxy">
-      <ref role="3uigEE" node="64l_37QMs40" resolve="AbstractExtendingConfigs" />
+      <ref role="3uigEE" node="64l_37QMs40" resolve="ConfigFromFeatureModelUpdater" />
     </node>
     <node concept="Wx3nA" id="6WUl45aQ0Gy" role="jymVt">
       <property role="TrG5h" value="LOG" />
@@ -27808,7 +27834,7 @@
       <node concept="3Tm1VV" id="6WUl45aDBqG" role="1B3o_S" />
       <node concept="3clFbS" id="6WUl45aDBr5" role="3clF47">
         <node concept="XkiVB" id="6WUl45aDBr6" role="3cqZAp">
-          <ref role="37wK5l" node="64l_37QMsaA" />
+          <ref role="37wK5l" node="64l_37QMsaA" resolve="ConfigFromFeatureModelUpdater" />
           <node concept="37vLTw" id="6WUl45aDBr7" role="37wK5m">
             <ref role="3cqZAo" node="6WUl45aDBq$" resolve="project" />
           </node>
@@ -27957,7 +27983,7 @@
                           <node concept="3clFbF" id="6WUl45aFJur" role="3cqZAp">
                             <node concept="2OqwBi" id="6WUl45aFJus" role="3clFbG">
                               <node concept="37vLTw" id="6WUl45aFJut" role="2Oq$k0">
-                                <ref role="3cqZAo" node="6WUl45aE0Da" resolve="firstLvl" />
+                                <ref role="3cqZAo" node="6WUl45aE0Da" resolve="currLvl" />
                               </node>
                               <node concept="3JPx81" id="6WUl45aFJuu" role="2OqNvi">
                                 <node concept="2OqwBi" id="6WUl45aFJuv" role="25WWJ7">
@@ -28076,12 +28102,12 @@
         </node>
         <node concept="3clFbF" id="6WUl45aDCJV" role="3cqZAp">
           <node concept="37vLTw" id="6WUl45aGfA9" role="3clFbG">
-            <ref role="3cqZAo" node="6WUl45aFS_o" resolve="resu" />
+            <ref role="3cqZAo" node="6WUl45aFS_o" resolve="result" />
           </node>
         </node>
       </node>
       <node concept="2AHcQZ" id="6WUl45aDBb3" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="6WUl45aDBAv" role="jymVt" />
@@ -28132,7 +28158,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="6WUl45aDBbb" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="6WUl45aHikh" role="jymVt" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
@@ -25270,7 +25270,7 @@
                     <node concept="3clFbS" id="65lm1C8R8_j" role="1bW5cS">
                       <node concept="3clFbF" id="6WUl45aDePE" role="3cqZAp">
                         <node concept="1rXfSq" id="6WUl45aDePD" role="3clFbG">
-                          <ref role="37wK5l" node="6WUl45aDeP_" resolve="propagate" />
+                          <ref role="37wK5l" node="64l_37QOe9U" resolve="propagate" />
                           <node concept="2GrUjf" id="6WUl45aDePC" role="37wK5m">
                             <ref role="2Gs0qQ" node="7SHUXR9KQNM" resolve="config" />
                           </node>
@@ -25617,38 +25617,24 @@
     <node concept="2tJIrI" id="64l_37Q8Bap" role="jymVt" />
     <node concept="3clFb_" id="64l_37Q8zJE" role="jymVt">
       <property role="TrG5h" value="updateReason" />
+      <property role="1EzhhJ" value="true" />
       <node concept="3Tmbuc" id="64l_37Q8zJF" role="1B3o_S" />
       <node concept="17QB3L" id="64l_37Q8zJG" role="3clF45" />
-      <node concept="3clFbS" id="64l_37Q8zJA" role="3clF47">
-        <node concept="3cpWs6" id="64l_37Q8zJB" role="3cqZAp">
-          <node concept="Xl_RD" id="64l_37Q8zJC" role="3cqZAk">
-            <property role="Xl_RC" value="Updating structure according to feature model..." />
-          </node>
-        </node>
-      </node>
+      <node concept="3clFbS" id="64l_37Q8zJA" role="3clF47" />
     </node>
     <node concept="2tJIrI" id="6WUl45aDgn5" role="jymVt" />
-    <node concept="3clFb_" id="6WUl45aDeP_" role="jymVt">
+    <node concept="3clFb_" id="64l_37QOe9U" role="jymVt">
       <property role="TrG5h" value="propagate" />
-      <node concept="3Tmbuc" id="6WUl45aDePA" role="1B3o_S" />
-      <node concept="3cqZAl" id="6WUl45aDePB" role="3clF45" />
-      <node concept="37vLTG" id="6WUl45aDePt" role="3clF46">
+      <property role="1EzhhJ" value="true" />
+      <node concept="3Tmbuc" id="64l_37QOe9V" role="1B3o_S" />
+      <node concept="3cqZAl" id="64l_37QOe9W" role="3clF45" />
+      <node concept="37vLTG" id="64l_37QOe9X" role="3clF46">
         <property role="TrG5h" value="config" />
-        <node concept="3Tqbb2" id="6WUl45aDePu" role="1tU5fm">
+        <node concept="3Tqbb2" id="64l_37QOe9Y" role="1tU5fm">
           <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
         </node>
       </node>
-      <node concept="3clFbS" id="6WUl45aDePp" role="3clF47">
-        <node concept="3clFbF" id="6WUl45aDePq" role="3cqZAp">
-          <node concept="2YIFZM" id="6WUl45aDePr" role="3clFbG">
-            <ref role="37wK5l" node="5cx1lEoXpx1" resolve="propagateFeatureModelChangesToConfig" />
-            <ref role="1Pybhc" node="5LYvV_xuyl9" resolve="ConfigUpdateHelper" />
-            <node concept="37vLTw" id="6WUl45aDePy" role="37wK5m">
-              <ref role="3cqZAo" node="6WUl45aDePt" resolve="config" />
-            </node>
-          </node>
-        </node>
-      </node>
+      <node concept="3clFbS" id="64l_37QOe9Z" role="3clF47" />
     </node>
     <node concept="2tJIrI" id="5BtXES5hV4K" role="jymVt" />
     <node concept="3clFb_" id="5BtXES5io$$" role="jymVt">
@@ -26385,8 +26371,8 @@
     </node>
     <node concept="2tJIrI" id="5BtXES5lwDm" role="jymVt" />
     <node concept="3Tm1VV" id="5BtXES5l5MW" role="1B3o_S" />
-    <node concept="3uibUv" id="5BtXES5l5ZA" role="1zkMxy">
-      <ref role="3uigEE" node="5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+    <node concept="3uibUv" id="64l_37QMHdW" role="1zkMxy">
+      <ref role="3uigEE" node="64l_37QMs40" resolve="ConfigFromFeatureModelUpdater" />
     </node>
     <node concept="3clFbW" id="5BtXES5l600" role="jymVt">
       <node concept="37vLTG" id="5BtXES5l601" role="3clF46">
@@ -26414,7 +26400,7 @@
       <node concept="3Tm1VV" id="5BtXES5l607" role="1B3o_S" />
       <node concept="3clFbS" id="5BtXES5l60q" role="3clF47">
         <node concept="XkiVB" id="5BtXES5l60r" role="3cqZAp">
-          <ref role="37wK5l" node="5szxK3gJ221" resolve="AbstractUpdateConfigsTask" />
+          <ref role="37wK5l" node="64l_37QMsaA" />
           <node concept="37vLTw" id="5BtXES5l60s" role="37wK5m">
             <ref role="3cqZAo" node="5BtXES5l601" resolve="project" />
           </node>
@@ -26713,8 +26699,8 @@
     </node>
     <node concept="2tJIrI" id="5BtXES5p02c" role="jymVt" />
     <node concept="3Tm1VV" id="5BtXES5l632" role="1B3o_S" />
-    <node concept="3uibUv" id="5BtXES5l64d" role="1zkMxy">
-      <ref role="3uigEE" node="5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+    <node concept="3uibUv" id="64l_37QMHEc" role="1zkMxy">
+      <ref role="3uigEE" node="64l_37QMs40" resolve="ConfigFromFeatureModelUpdater" />
     </node>
     <node concept="3clFbW" id="5BtXES5l64B" role="jymVt">
       <node concept="37vLTG" id="5BtXES5l64C" role="3clF46">
@@ -26742,7 +26728,7 @@
       <node concept="3Tm1VV" id="5BtXES5l64I" role="1B3o_S" />
       <node concept="3clFbS" id="5BtXES5l651" role="3clF47">
         <node concept="XkiVB" id="5BtXES5l652" role="3cqZAp">
-          <ref role="37wK5l" node="5szxK3gJ221" resolve="AbstractUpdateConfigsTask" />
+          <ref role="37wK5l" node="64l_37QMsaA" />
           <node concept="37vLTw" id="5BtXES5l653" role="37wK5m">
             <ref role="3cqZAo" node="5BtXES5l64C" resolve="project" />
           </node>
@@ -27770,8 +27756,8 @@
     <property role="TrG5h" value="UpdateAllExtendingConfigs" />
     <node concept="2tJIrI" id="6WUl45aDBz1" role="jymVt" />
     <node concept="3Tm1VV" id="6WUl45aDiYJ" role="1B3o_S" />
-    <node concept="3uibUv" id="6WUl45aDBar" role="1zkMxy">
-      <ref role="3uigEE" node="5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+    <node concept="3uibUv" id="64l_37QMtYb" role="1zkMxy">
+      <ref role="3uigEE" node="64l_37QMs40" resolve="AbstractExtendingConfigs" />
     </node>
     <node concept="Wx3nA" id="6WUl45aQ0Gy" role="jymVt">
       <property role="TrG5h" value="LOG" />
@@ -27822,7 +27808,7 @@
       <node concept="3Tm1VV" id="6WUl45aDBqG" role="1B3o_S" />
       <node concept="3clFbS" id="6WUl45aDBr5" role="3clF47">
         <node concept="XkiVB" id="6WUl45aDBr6" role="3cqZAp">
-          <ref role="37wK5l" node="5szxK3gJ221" resolve="AbstractUpdateConfigsTask" />
+          <ref role="37wK5l" node="64l_37QMsaA" />
           <node concept="37vLTw" id="6WUl45aDBr7" role="37wK5m">
             <ref role="3cqZAo" node="6WUl45aDBq$" resolve="project" />
           </node>
@@ -28176,7 +28162,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="64l_37Q8Gks" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="64l_37Q9E1g" role="jymVt" />
@@ -28202,9 +28188,94 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="6WUl45aHj$W" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="64l_37QMs40">
+    <property role="TrG5h" value="ConfigFromFeatureModelUpdater" />
+    <property role="1sVAO0" value="true" />
+    <node concept="3Tm1VV" id="64l_37QMs41" role="1B3o_S" />
+    <node concept="3uibUv" id="64l_37QMs9N" role="1zkMxy">
+      <ref role="3uigEE" node="5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+    </node>
+    <node concept="2tJIrI" id="64l_37QMscp" role="jymVt" />
+    <node concept="3clFbW" id="64l_37QMsaA" role="jymVt">
+      <node concept="37vLTG" id="64l_37QMsaB" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="2AHcQZ" id="64l_37QMsaC" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+        <node concept="3uibUv" id="64l_37QMsaD" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="64l_37QMsaE" role="3clF46">
+        <property role="TrG5h" value="model" />
+        <node concept="3uibUv" id="64l_37QMsaF" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="64l_37QMsaG" role="3clF46">
+        <property role="TrG5h" value="LOG" />
+        <node concept="3uibUv" id="64l_37QMsaH" role="1tU5fm">
+          <ref role="3uigEE" to="wwqx:~Logger" resolve="Logger" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="64l_37QMsaI" role="3clF45" />
+      <node concept="3Tm1VV" id="64l_37QMsaJ" role="1B3o_S" />
+      <node concept="3clFbS" id="64l_37QMsb8" role="3clF47">
+        <node concept="XkiVB" id="64l_37QMsb9" role="3cqZAp">
+          <ref role="37wK5l" node="5szxK3gJ221" resolve="AbstractUpdateConfigsTask" />
+          <node concept="37vLTw" id="64l_37QMsba" role="37wK5m">
+            <ref role="3cqZAo" node="64l_37QMsaB" resolve="project" />
+          </node>
+          <node concept="37vLTw" id="64l_37QMsbb" role="37wK5m">
+            <ref role="3cqZAo" node="64l_37QMsaE" resolve="model" />
+          </node>
+          <node concept="37vLTw" id="64l_37QMsbc" role="37wK5m">
+            <ref role="3cqZAo" node="64l_37QMsaG" resolve="LOG" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="64l_37QMsy6" role="jymVt" />
+    <node concept="3clFb_" id="6WUl45aDeP_" role="jymVt">
+      <property role="TrG5h" value="propagate" />
+      <node concept="3Tmbuc" id="6WUl45aDePA" role="1B3o_S" />
+      <node concept="3cqZAl" id="6WUl45aDePB" role="3clF45" />
+      <node concept="37vLTG" id="6WUl45aDePt" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6WUl45aDePu" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WUl45aDePp" role="3clF47">
+        <node concept="3clFbF" id="6WUl45aDePq" role="3cqZAp">
+          <node concept="2YIFZM" id="6WUl45aDePr" role="3clFbG">
+            <ref role="37wK5l" node="5cx1lEoXpx1" resolve="propagateFeatureModelChangesToConfig" />
+            <ref role="1Pybhc" node="5LYvV_xuyl9" resolve="ConfigUpdateHelper" />
+            <node concept="37vLTw" id="6WUl45aDePy" role="37wK5m">
+              <ref role="3cqZAo" node="6WUl45aDePt" resolve="config" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="64l_37QMsy7" role="jymVt" />
+    <node concept="3clFb_" id="64l_37QOn$C" role="jymVt">
+      <property role="TrG5h" value="updateReason" />
+      <node concept="3Tmbuc" id="64l_37QOn$D" role="1B3o_S" />
+      <node concept="17QB3L" id="64l_37QOn$E" role="3clF45" />
+      <node concept="3clFbS" id="64l_37QOn$F" role="3clF47">
+        <node concept="3cpWs6" id="64l_37QOn$G" role="3cqZAp">
+          <node concept="Xl_RD" id="64l_37QOn$H" role="3cqZAk">
+            <property role="Xl_RC" value="Updating structure according to feature model..." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="64l_37QOnxH" role="jymVt" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
@@ -61,6 +61,7 @@
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="nzwl" ref="r:dfaa2422-aef5-456d-a8cd-942c81b870e6(org.iets3.variability.configuration.base.intentions)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -631,6 +632,7 @@
         <child id="5633809102336885320" name="fromIndex" index="3b24Rf" />
       </concept>
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
+      <concept id="1173946412755" name="jetbrains.mps.baseLanguage.collections.structure.RemoveAllElementsOperation" flags="nn" index="1kEaZ2" />
       <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
@@ -25142,6 +25144,104 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="3SKdUt" id="65lm1C8RteU" role="3cqZAp">
+                    <node concept="1PaTwC" id="65lm1C8RteV" role="1aUNEU">
+                      <node concept="3oM_SD" id="65lm1C8RteW" role="1PaTwD">
+                        <property role="3oM_SC" value="step" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8Ru8b" role="1PaTwD">
+                        <property role="3oM_SC" value="1" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxOt" role="1PaTwD">
+                        <property role="3oM_SC" value="(adapt" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxOu" role="1PaTwD">
+                        <property role="3oM_SC" value="configuration" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxOJ" role="1PaTwD">
+                        <property role="3oM_SC" value="to" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxOK" role="1PaTwD">
+                        <property role="3oM_SC" value="changes" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxP1" role="1PaTwD">
+                        <property role="3oM_SC" value="in" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxP2" role="1PaTwD">
+                        <property role="3oM_SC" value="feature" />
+                      </node>
+                      <node concept="3oM_SD" id="65lm1C8RxP3" role="1PaTwD">
+                        <property role="3oM_SC" value="model)" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="7ba8F5CZeOD" role="3cqZAp">
+                    <node concept="2OqwBi" id="7ba8F5CZeOE" role="3clFbG">
+                      <node concept="37vLTw" id="7ba8F5CZeOF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5szxK3gIZzG" resolve="indicator" />
+                      </node>
+                      <node concept="liA8E" id="7ba8F5CZeOG" role="2OqNvi">
+                        <ref role="37wK5l" to="xygl:~ProgressIndicator.setText(java.lang.String)" resolve="setText" />
+                        <node concept="2YIFZM" id="7ba8F5DpBRL" role="37wK5m">
+                          <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                          <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                          <node concept="Xl_RD" id="7ba8F5DpBRM" role="37wK5m">
+                            <property role="Xl_RC" value="Updating configuration %d/%d: %s" />
+                          </node>
+                          <node concept="37vLTw" id="7ba8F5DpBRN" role="37wK5m">
+                            <ref role="3cqZAo" node="5szxK3h2oQP" resolve="idx" />
+                          </node>
+                          <node concept="2OqwBi" id="7ba8F5DpBRO" role="37wK5m">
+                            <node concept="37vLTw" id="7ba8F5DpBRP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3gfwQZKCY0_" resolve="updatedConfigs" />
+                            </node>
+                            <node concept="34oBXx" id="7ba8F5DpBRQ" role="2OqNvi" />
+                          </node>
+                          <node concept="37vLTw" id="7ba8F5DpBRR" role="37wK5m">
+                            <ref role="3cqZAo" node="4AbM3h6gPc6" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="3gfwQZKNNkr" role="3cqZAp">
+                    <node concept="2OqwBi" id="3gfwQZKNPiL" role="3clFbG">
+                      <node concept="37vLTw" id="3gfwQZKNNkp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5szxK3gIZzG" resolve="indicator" />
+                      </node>
+                      <node concept="liA8E" id="3gfwQZKNQyW" role="2OqNvi">
+                        <ref role="37wK5l" to="xygl:~ProgressIndicator.setText2(java.lang.String)" resolve="setText2" />
+                        <node concept="1rXfSq" id="64l_37Q8zJH" role="37wK5m">
+                          <ref role="37wK5l" node="64l_37Q8zJE" resolve="updateReason" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="7ba8F5CZeOv" role="3cqZAp">
+                    <node concept="2OqwBi" id="7ba8F5CZeOw" role="3clFbG">
+                      <node concept="37vLTw" id="7ba8F5CZeOx" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5szxK3gIZzG" resolve="indicator" />
+                      </node>
+                      <node concept="liA8E" id="7ba8F5CZeOy" role="2OqNvi">
+                        <ref role="37wK5l" to="xygl:~ProgressIndicator.setFraction(double)" resolve="setFraction" />
+                        <node concept="FJ1c_" id="7ba8F5CZeOz" role="37wK5m">
+                          <node concept="1eOMI4" id="7ba8F5CZeO$" role="3uHU7B">
+                            <node concept="10QFUN" id="7ba8F5CZeO_" role="1eOMHV">
+                              <node concept="10P55v" id="7ba8F5CZeOA" role="10QFUM" />
+                              <node concept="3uNrnE" id="7ba8F5DpU0W" role="10QFUP">
+                                <node concept="37vLTw" id="7ba8F5DpU0Y" role="2$L3a6">
+                                  <ref role="3cqZAo" node="7ba8F5CZ3Mc" resolve="iTask" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="7ba8F5CZeOC" role="3uHU7w">
+                            <ref role="3cqZAo" node="7ba8F5CYuPV" resolve="nTasks" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
               <node concept="37vLTw" id="5szxK3h48WD" role="ukAjM">
@@ -25149,104 +25249,6 @@
               </node>
             </node>
             <node concept="3clFbH" id="65lm1C8RpVl" role="3cqZAp" />
-            <node concept="3SKdUt" id="65lm1C8RteU" role="3cqZAp">
-              <node concept="1PaTwC" id="65lm1C8RteV" role="1aUNEU">
-                <node concept="3oM_SD" id="65lm1C8RteW" role="1PaTwD">
-                  <property role="3oM_SC" value="step" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8Ru8b" role="1PaTwD">
-                  <property role="3oM_SC" value="1" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxOt" role="1PaTwD">
-                  <property role="3oM_SC" value="(adapt" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxOu" role="1PaTwD">
-                  <property role="3oM_SC" value="configuration" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxOJ" role="1PaTwD">
-                  <property role="3oM_SC" value="to" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxOK" role="1PaTwD">
-                  <property role="3oM_SC" value="changes" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxP1" role="1PaTwD">
-                  <property role="3oM_SC" value="in" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxP2" role="1PaTwD">
-                  <property role="3oM_SC" value="feature" />
-                </node>
-                <node concept="3oM_SD" id="65lm1C8RxP3" role="1PaTwD">
-                  <property role="3oM_SC" value="model)" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7ba8F5CZeOD" role="3cqZAp">
-              <node concept="2OqwBi" id="7ba8F5CZeOE" role="3clFbG">
-                <node concept="37vLTw" id="7ba8F5CZeOF" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5szxK3gIZzG" resolve="indicator" />
-                </node>
-                <node concept="liA8E" id="7ba8F5CZeOG" role="2OqNvi">
-                  <ref role="37wK5l" to="xygl:~ProgressIndicator.setText(java.lang.String)" resolve="setText" />
-                  <node concept="2YIFZM" id="7ba8F5DpBRL" role="37wK5m">
-                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
-                    <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
-                    <node concept="Xl_RD" id="7ba8F5DpBRM" role="37wK5m">
-                      <property role="Xl_RC" value="Updating configuration %d/%d: %s" />
-                    </node>
-                    <node concept="37vLTw" id="7ba8F5DpBRN" role="37wK5m">
-                      <ref role="3cqZAo" node="5szxK3h2oQP" resolve="idx" />
-                    </node>
-                    <node concept="2OqwBi" id="7ba8F5DpBRO" role="37wK5m">
-                      <node concept="37vLTw" id="7ba8F5DpBRP" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3gfwQZKCY0_" resolve="updatedConfigs" />
-                      </node>
-                      <node concept="34oBXx" id="7ba8F5DpBRQ" role="2OqNvi" />
-                    </node>
-                    <node concept="37vLTw" id="7ba8F5DpBRR" role="37wK5m">
-                      <ref role="3cqZAo" node="4AbM3h6gPc6" resolve="name" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3gfwQZKNNkr" role="3cqZAp">
-              <node concept="2OqwBi" id="3gfwQZKNPiL" role="3clFbG">
-                <node concept="37vLTw" id="3gfwQZKNNkp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5szxK3gIZzG" resolve="indicator" />
-                </node>
-                <node concept="liA8E" id="3gfwQZKNQyW" role="2OqNvi">
-                  <ref role="37wK5l" to="xygl:~ProgressIndicator.setText2(java.lang.String)" resolve="setText2" />
-                  <node concept="Xl_RD" id="3gfwQZKNTL4" role="37wK5m">
-                    <property role="Xl_RC" value="Updating structure according to feature model..." />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7ba8F5CZeOv" role="3cqZAp">
-              <node concept="2OqwBi" id="7ba8F5CZeOw" role="3clFbG">
-                <node concept="37vLTw" id="7ba8F5CZeOx" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5szxK3gIZzG" resolve="indicator" />
-                </node>
-                <node concept="liA8E" id="7ba8F5CZeOy" role="2OqNvi">
-                  <ref role="37wK5l" to="xygl:~ProgressIndicator.setFraction(double)" resolve="setFraction" />
-                  <node concept="FJ1c_" id="7ba8F5CZeOz" role="37wK5m">
-                    <node concept="1eOMI4" id="7ba8F5CZeO$" role="3uHU7B">
-                      <node concept="10QFUN" id="7ba8F5CZeO_" role="1eOMHV">
-                        <node concept="10P55v" id="7ba8F5CZeOA" role="10QFUM" />
-                        <node concept="3uNrnE" id="7ba8F5DpU0W" role="10QFUP">
-                          <node concept="37vLTw" id="7ba8F5DpU0Y" role="2$L3a6">
-                            <ref role="3cqZAo" node="7ba8F5CZ3Mc" resolve="iTask" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="7ba8F5CZeOC" role="3uHU7w">
-                      <ref role="3cqZAo" node="7ba8F5CYuPV" resolve="nTasks" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbF" id="5BtXES5iREf" role="3cqZAp">
               <node concept="1rXfSq" id="5BtXES5iREd" role="3clFbG">
                 <ref role="37wK5l" node="5BtXES5io$$" resolve="giveWayToUI" />
@@ -25266,11 +25268,10 @@
                   </node>
                   <node concept="1bVj0M" id="65lm1C8R8_i" role="37wK5m">
                     <node concept="3clFbS" id="65lm1C8R8_j" role="1bW5cS">
-                      <node concept="3clFbF" id="65lm1C8R8_k" role="3cqZAp">
-                        <node concept="2YIFZM" id="65lm1C8R8_l" role="3clFbG">
-                          <ref role="37wK5l" node="5cx1lEoXpx1" resolve="propagateFeatureModelChangesToConfig" />
-                          <ref role="1Pybhc" node="5LYvV_xuyl9" resolve="ConfigUpdateHelper" />
-                          <node concept="2GrUjf" id="65lm1C8R8_m" role="37wK5m">
+                      <node concept="3clFbF" id="6WUl45aDePE" role="3cqZAp">
+                        <node concept="1rXfSq" id="6WUl45aDePD" role="3clFbG">
+                          <ref role="37wK5l" node="6WUl45aDeP_" resolve="propagate" />
+                          <node concept="2GrUjf" id="6WUl45aDePC" role="37wK5m">
                             <ref role="2Gs0qQ" node="7SHUXR9KQNM" resolve="config" />
                           </node>
                         </node>
@@ -25611,6 +25612,42 @@
       </node>
       <node concept="2AHcQZ" id="5szxK3gIZzO" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="64l_37Q8Bap" role="jymVt" />
+    <node concept="3clFb_" id="64l_37Q8zJE" role="jymVt">
+      <property role="TrG5h" value="updateReason" />
+      <node concept="3Tmbuc" id="64l_37Q8zJF" role="1B3o_S" />
+      <node concept="17QB3L" id="64l_37Q8zJG" role="3clF45" />
+      <node concept="3clFbS" id="64l_37Q8zJA" role="3clF47">
+        <node concept="3cpWs6" id="64l_37Q8zJB" role="3cqZAp">
+          <node concept="Xl_RD" id="64l_37Q8zJC" role="3cqZAk">
+            <property role="Xl_RC" value="Updating structure according to feature model..." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6WUl45aDgn5" role="jymVt" />
+    <node concept="3clFb_" id="6WUl45aDeP_" role="jymVt">
+      <property role="TrG5h" value="propagate" />
+      <node concept="3Tmbuc" id="6WUl45aDePA" role="1B3o_S" />
+      <node concept="3cqZAl" id="6WUl45aDePB" role="3clF45" />
+      <node concept="37vLTG" id="6WUl45aDePt" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6WUl45aDePu" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WUl45aDePp" role="3clF47">
+        <node concept="3clFbF" id="6WUl45aDePq" role="3cqZAp">
+          <node concept="2YIFZM" id="6WUl45aDePr" role="3clFbG">
+            <ref role="37wK5l" node="5cx1lEoXpx1" resolve="propagateFeatureModelChangesToConfig" />
+            <ref role="1Pybhc" node="5LYvV_xuyl9" resolve="ConfigUpdateHelper" />
+            <node concept="37vLTw" id="6WUl45aDePy" role="37wK5m">
+              <ref role="3cqZAo" node="6WUl45aDePt" resolve="config" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5BtXES5hV4K" role="jymVt" />
@@ -27726,6 +27763,446 @@
         <node concept="3Tqbb2" id="6u_oBd1VKT3" role="A3Ik2">
           <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6WUl45aDiYI">
+    <property role="TrG5h" value="UpdateAllExtendingConfigs" />
+    <node concept="2tJIrI" id="6WUl45aDBz1" role="jymVt" />
+    <node concept="3Tm1VV" id="6WUl45aDiYJ" role="1B3o_S" />
+    <node concept="3uibUv" id="6WUl45aDBar" role="1zkMxy">
+      <ref role="3uigEE" node="5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+    </node>
+    <node concept="Wx3nA" id="6WUl45aQ0Gy" role="jymVt">
+      <property role="TrG5h" value="LOG" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="6WUl45aQ0Gz" role="1tU5fm">
+        <ref role="3uigEE" to="wwqx:~Logger" resolve="Logger" />
+      </node>
+      <node concept="2YIFZM" id="6WUl45aQ0G$" role="33vP2m">
+        <ref role="37wK5l" to="wwqx:~Logger.getLogger(java.lang.Class)" resolve="getLogger" />
+        <ref role="1Pybhc" to="wwqx:~Logger" resolve="Logger" />
+        <node concept="3VsKOn" id="6WUl45aQ0G_" role="37wK5m">
+          <ref role="3VsUkX" node="5BtXES5l5MV" resolve="UpdateAllConfigsTask" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6WUl45aQ0GA" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6WUl45aDCRJ" role="jymVt" />
+    <node concept="312cEg" id="6WUl45aDD6i" role="jymVt">
+      <property role="TrG5h" value="fmc" />
+      <node concept="3Tm6S6" id="6WUl45aDD0P" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6WUl45aDDcd" role="1tU5fm">
+        <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="6WUl45aDBqz" role="jymVt">
+      <node concept="37vLTG" id="6WUl45aDBq$" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="2AHcQZ" id="6WUl45aDBq_" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+        <node concept="3uibUv" id="6WUl45aDBqA" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6WUl45aDBqB" role="3clF46">
+        <property role="TrG5h" value="model" />
+        <node concept="3uibUv" id="6WUl45aDBqC" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6WUl45aDBDX" role="3clF46">
+        <property role="TrG5h" value="fmc" />
+        <node concept="3Tqbb2" id="6WUl45aDBJ6" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6WUl45aDBqF" role="3clF45" />
+      <node concept="3Tm1VV" id="6WUl45aDBqG" role="1B3o_S" />
+      <node concept="3clFbS" id="6WUl45aDBr5" role="3clF47">
+        <node concept="XkiVB" id="6WUl45aDBr6" role="3cqZAp">
+          <ref role="37wK5l" node="5szxK3gJ221" resolve="AbstractUpdateConfigsTask" />
+          <node concept="37vLTw" id="6WUl45aDBr7" role="37wK5m">
+            <ref role="3cqZAo" node="6WUl45aDBq$" resolve="project" />
+          </node>
+          <node concept="37vLTw" id="6WUl45aDBr8" role="37wK5m">
+            <ref role="3cqZAo" node="6WUl45aDBqB" resolve="model" />
+          </node>
+          <node concept="37vLTw" id="6WUl45aDBr9" role="37wK5m">
+            <ref role="3cqZAo" node="6WUl45aQ0Gy" resolve="LOG" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="6WUl45aDDqR" role="3cqZAp">
+          <node concept="37vLTI" id="6WUl45aDFNp" role="3clFbG">
+            <node concept="37vLTw" id="6WUl45aDFTw" role="37vLTx">
+              <ref role="3cqZAo" node="6WUl45aDBDX" resolve="fmc" />
+            </node>
+            <node concept="2OqwBi" id="6WUl45aDElp" role="37vLTJ">
+              <node concept="Xjq3P" id="6WUl45aDDqP" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6WUl45aDFn9" role="2OqNvi">
+                <ref role="2Oxat5" node="6WUl45aDD6i" resolve="fmc" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6WUl45aDBvo" role="jymVt" />
+    <node concept="3clFb_" id="6WUl45aDBaX" role="jymVt">
+      <property role="TrG5h" value="getConfigs" />
+      <node concept="3Tmbuc" id="6WUl45aDBaZ" role="1B3o_S" />
+      <node concept="A3Dl8" id="6WUl45aDBb0" role="3clF45">
+        <node concept="3Tqbb2" id="6WUl45aDBb1" role="A3Ik2">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WUl45aDBb2" role="3clF47">
+        <node concept="3cpWs8" id="6WUl45aDIOk" role="3cqZAp">
+          <node concept="3cpWsn" id="6WUl45aDIOl" role="3cpWs9">
+            <property role="TrG5h" value="featureModel" />
+            <node concept="3Tqbb2" id="6WUl45aDI$I" role="1tU5fm">
+              <ref role="ehGHo" to="s6b7:3tsFshP5E8h" resolve="FeatureModel" />
+            </node>
+            <node concept="2OqwBi" id="6WUl45aDIOm" role="33vP2m">
+              <node concept="37vLTw" id="6WUl45aDIOn" role="2Oq$k0">
+                <ref role="3cqZAo" node="6WUl45aDD6i" resolve="fmc" />
+              </node>
+              <node concept="2qgKlT" id="6WUl45aDIOo" role="2OqNvi">
+                <ref role="37wK5l" node="7PHwTKCuj99" resolve="getFeatureModel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6WUl45aE9IZ" role="3cqZAp">
+          <node concept="3cpWsn" id="6WUl45aE9J0" role="3cpWs9">
+            <property role="TrG5h" value="configs" />
+            <node concept="_YKpA" id="6WUl45aE9CA" role="1tU5fm">
+              <node concept="3Tqbb2" id="6WUl45aE9CD" role="_ZDj9">
+                <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6WUl45aE9J1" role="33vP2m">
+              <node concept="2OqwBi" id="6WUl45aE9J2" role="2Oq$k0">
+                <node concept="2OqwBi" id="6WUl45aE9J3" role="2Oq$k0">
+                  <node concept="2YIFZM" id="6WUl45aE9J4" role="2Oq$k0">
+                    <ref role="37wK5l" to="ch50:5_Pacxxew8P" resolve="configurationsScope" />
+                    <ref role="1Pybhc" to="ch50:5_PacxxcWVk" resolve="ConfigurationScopeProvider" />
+                    <node concept="37vLTw" id="6WUl45aE9J5" role="37wK5m">
+                      <ref role="3cqZAo" node="6WUl45aDIOl" resolve="featureModel" />
+                    </node>
+                    <node concept="2OqwBi" id="6WUl45aE9J6" role="37wK5m">
+                      <node concept="37vLTw" id="6WUl45aE9J7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6WUl45aDIOl" resolve="featureModel" />
+                      </node>
+                      <node concept="3TrEf2" id="6WUl45aE9J8" role="2OqNvi">
+                        <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6WUl45aE9J9" role="2OqNvi">
+                    <ref role="37wK5l" to="o8zo:3fifI_xCtP7" resolve="getAvailableElements" />
+                    <node concept="10Nm6u" id="6WUl45aE9Ja" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="v3k3i" id="6WUl45aE9Jb" role="2OqNvi">
+                  <node concept="chp4Y" id="6WUl45aE9Jc" role="v3oSu">
+                    <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="6WUl45aE9Jd" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6WUl45aFS_n" role="3cqZAp">
+          <node concept="3cpWsn" id="6WUl45aFS_o" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="2YIFZM" id="6WUl45aFS_p" role="33vP2m">
+              <ref role="37wK5l" to="3o3z:~Lists.newLinkedList()" resolve="newLinkedList" />
+              <ref role="1Pybhc" to="3o3z:~Lists" resolve="Lists" />
+            </node>
+            <node concept="_YKpA" id="6WUl45aFT56" role="1tU5fm">
+              <node concept="3Tqbb2" id="6WUl45aFT57" role="_ZDj9">
+                <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6WUl45aE0D9" role="3cqZAp">
+          <node concept="3cpWsn" id="6WUl45aE0Da" role="3cpWs9">
+            <property role="TrG5h" value="currLvl" />
+            <node concept="_YKpA" id="6WUl45aE0zV" role="1tU5fm">
+              <node concept="3Tqbb2" id="6WUl45aE0zY" role="_ZDj9">
+                <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="6WUl45aGqdO" role="33vP2m">
+              <ref role="37wK5l" to="33ny:~Collections.singletonList(java.lang.Object)" resolve="singletonList" />
+              <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+              <node concept="2OqwBi" id="6WUl45aGsF1" role="37wK5m">
+                <node concept="Xjq3P" id="6WUl45aGre8" role="2Oq$k0" />
+                <node concept="2OwXpG" id="6WUl45aGt$g" role="2OqNvi">
+                  <ref role="2Oxat5" node="6WUl45aDD6i" resolve="fmc" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6WUl45aE2_e" role="3cqZAp" />
+        <node concept="2$JKZl" id="6WUl45aExR7" role="3cqZAp">
+          <node concept="3clFbS" id="6WUl45aExR9" role="2LFqv$">
+            <node concept="3cpWs8" id="6WUl45aFJuj" role="3cqZAp">
+              <node concept="3cpWsn" id="6WUl45aFJuk" role="3cpWs9">
+                <property role="TrG5h" value="nextLvl" />
+                <node concept="_YKpA" id="6WUl45aFJoC" role="1tU5fm">
+                  <node concept="3Tqbb2" id="6WUl45aFJoF" role="_ZDj9">
+                    <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6WUl45aFJul" role="33vP2m">
+                  <node concept="2OqwBi" id="6WUl45aFJum" role="2Oq$k0">
+                    <node concept="37vLTw" id="6WUl45aFJun" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6WUl45aE9J0" resolve="configs" />
+                    </node>
+                    <node concept="3zZkjj" id="6WUl45aFJuo" role="2OqNvi">
+                      <node concept="1bVj0M" id="6WUl45aFJup" role="23t8la">
+                        <node concept="3clFbS" id="6WUl45aFJuq" role="1bW5cS">
+                          <node concept="3clFbF" id="6WUl45aFJur" role="3cqZAp">
+                            <node concept="2OqwBi" id="6WUl45aFJus" role="3clFbG">
+                              <node concept="37vLTw" id="6WUl45aFJut" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6WUl45aE0Da" resolve="firstLvl" />
+                              </node>
+                              <node concept="3JPx81" id="6WUl45aFJuu" role="2OqNvi">
+                                <node concept="2OqwBi" id="6WUl45aFJuv" role="25WWJ7">
+                                  <node concept="2OqwBi" id="6WUl45aFJuw" role="2Oq$k0">
+                                    <node concept="37vLTw" id="6WUl45aFJux" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="6WUl45aFJu$" resolve="it" />
+                                    </node>
+                                    <node concept="3TrEf2" id="6WUl45aFJuy" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="4ndm:4onczE6iX1P" resolve="extendedFMC" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrEf2" id="6WUl45aFJuz" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="4ndm:4onczE6iX19" resolve="config" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gl6BB" id="6WUl45aFJu$" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="6WUl45aFJu_" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="ANE8D" id="6WUl45aFJuA" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6WUl45aFQMI" role="3cqZAp">
+              <node concept="2OqwBi" id="6WUl45aG13o" role="3clFbG">
+                <node concept="37vLTw" id="6WUl45aFS_q" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6WUl45aFS_o" resolve="result" />
+                </node>
+                <node concept="X8dFx" id="6WUl45aGdeB" role="2OqNvi">
+                  <node concept="37vLTw" id="6WUl45aGedU" role="25WWJ7">
+                    <ref role="3cqZAo" node="6WUl45aFJuk" resolve="nextLvl" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6WUl45aEe8n" role="3cqZAp">
+              <node concept="2OqwBi" id="6WUl45aEjQU" role="3clFbG">
+                <node concept="37vLTw" id="6WUl45aEe8l" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6WUl45aE9J0" resolve="configs" />
+                </node>
+                <node concept="1kEaZ2" id="6WUl45aEw7A" role="2OqNvi">
+                  <node concept="37vLTw" id="6WUl45aEwv6" role="25WWJ7">
+                    <ref role="3cqZAo" node="6WUl45aFJuk" resolve="nextLvl" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6WUl45aGyxc" role="3cqZAp">
+              <node concept="37vLTI" id="6WUl45aGCWY" role="3clFbG">
+                <node concept="37vLTw" id="6WUl45aGE36" role="37vLTx">
+                  <ref role="3cqZAo" node="6WUl45aFJuk" resolve="nextLvl" />
+                </node>
+                <node concept="37vLTw" id="6WUl45aGyxa" role="37vLTJ">
+                  <ref role="3cqZAo" node="6WUl45aE0Da" resolve="currLvl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="64l_37Qabmx" role="2$JKZa">
+            <node concept="37vLTw" id="64l_37Qa3E4" role="2Oq$k0">
+              <ref role="3cqZAo" node="6WUl45aE0Da" resolve="currLvl" />
+            </node>
+            <node concept="3GX2aA" id="64l_37Qat1b" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="64l_37Q9JIk" role="3cqZAp">
+          <node concept="2OqwBi" id="64l_37Q9JIl" role="3clFbG">
+            <node concept="liA8E" id="64l_37Q9JIm" role="2OqNvi">
+              <ref role="37wK5l" to="wwqx:~Logger.info(java.lang.String)" resolve="info" />
+              <node concept="3cpWs3" id="64l_37Q9JIn" role="37wK5m">
+                <node concept="Xl_RD" id="64l_37Q9JIo" role="3uHU7w">
+                  <property role="Xl_RC" value=" configurations" />
+                </node>
+                <node concept="3cpWs3" id="64l_37Q9JIp" role="3uHU7B">
+                  <node concept="3cpWs3" id="64l_37Q9JIq" role="3uHU7B">
+                    <node concept="3cpWs3" id="64l_37Q9JIr" role="3uHU7B">
+                      <node concept="Xl_RD" id="64l_37Q9JIs" role="3uHU7B">
+                        <property role="Xl_RC" value="Update all extending configurations for '" />
+                      </node>
+                      <node concept="2OqwBi" id="64l_37Q9JIt" role="3uHU7w">
+                        <node concept="2OqwBi" id="64l_37Q9JIu" role="2Oq$k0">
+                          <node concept="Xjq3P" id="64l_37Q9JIv" role="2Oq$k0" />
+                          <node concept="2OwXpG" id="64l_37Q9JIw" role="2OqNvi">
+                            <ref role="2Oxat5" node="6WUl45aDD6i" resolve="fmc" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="64l_37Q9JIx" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="64l_37Q9JIy" role="3uHU7w">
+                      <property role="Xl_RC" value="' with " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="64l_37Q9JIz" role="3uHU7w">
+                    <node concept="37vLTw" id="64l_37Q9JI$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6WUl45aFS_o" resolve="result" />
+                    </node>
+                    <node concept="34oBXx" id="64l_37Q9JI_" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="64l_37Q9PPf" role="2Oq$k0">
+              <ref role="3cqZAo" node="6WUl45aQ0Gy" resolve="LOG" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6WUl45aDCJV" role="3cqZAp">
+          <node concept="37vLTw" id="6WUl45aGfA9" role="3clFbG">
+            <ref role="3cqZAo" node="6WUl45aFS_o" resolve="resu" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6WUl45aDBb3" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6WUl45aDBAv" role="jymVt" />
+    <node concept="3clFb_" id="6WUl45aDBb4" role="jymVt">
+      <property role="TrG5h" value="logFinalMessage" />
+      <node concept="3Tmbuc" id="6WUl45aDBb6" role="1B3o_S" />
+      <node concept="3cqZAl" id="6WUl45aDBb7" role="3clF45" />
+      <node concept="37vLTG" id="6WUl45aDBb8" role="3clF46">
+        <property role="TrG5h" value="tTotal" />
+        <node concept="3cpWsb" id="6WUl45aDBb9" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="6WUl45aDBba" role="3clF47">
+        <node concept="3clFbF" id="64l_37Q7ZRh" role="3cqZAp">
+          <node concept="2OqwBi" id="64l_37Q7ZRi" role="3clFbG">
+            <node concept="liA8E" id="64l_37Q7ZRj" role="2OqNvi">
+              <ref role="37wK5l" to="wwqx:~Logger.info(java.lang.String)" resolve="info" />
+              <node concept="3cpWs3" id="64l_37Q7ZRk" role="37wK5m">
+                <node concept="Xl_RD" id="64l_37Q7ZRl" role="3uHU7w">
+                  <property role="Xl_RC" value=" milliseconds)" />
+                </node>
+                <node concept="3cpWs3" id="64l_37Q7ZRm" role="3uHU7B">
+                  <node concept="3cpWs3" id="64l_37Q7ZRn" role="3uHU7B">
+                    <node concept="3cpWs3" id="64l_37Q7ZRo" role="3uHU7B">
+                      <node concept="Xl_RD" id="64l_37Q7ZRp" role="3uHU7B">
+                        <property role="Xl_RC" value="Updated all extended configurations (n=" />
+                      </node>
+                      <node concept="2OqwBi" id="64l_37Q7ZRq" role="3uHU7w">
+                        <node concept="1rXfSq" id="64l_37Q7ZRr" role="2Oq$k0">
+                          <ref role="37wK5l" node="3gfwQZKDcmQ" resolve="getUpdatedConfigs" />
+                        </node>
+                        <node concept="34oBXx" id="64l_37Q7ZRs" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="64l_37Q7ZRt" role="3uHU7w">
+                      <property role="Xl_RC" value=", dt=" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="64l_37Q7ZRu" role="3uHU7w">
+                    <ref role="3cqZAo" node="6WUl45aDBb8" resolve="tTotal" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="64l_37Q8aNW" role="2Oq$k0">
+              <ref role="3cqZAo" node="6WUl45aQ0Gy" resolve="LOG" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6WUl45aDBbb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6WUl45aHikh" role="jymVt" />
+    <node concept="2tJIrI" id="6WUl45aHiki" role="jymVt" />
+    <node concept="3clFb_" id="64l_37Q8Gkl" role="jymVt">
+      <property role="TrG5h" value="updateReason" />
+      <node concept="3Tmbuc" id="64l_37Q8Gkm" role="1B3o_S" />
+      <node concept="17QB3L" id="64l_37Q8Gkn" role="3clF45" />
+      <node concept="3clFbS" id="64l_37Q8Gkr" role="3clF47">
+        <node concept="3clFbF" id="64l_37Q8MoQ" role="3cqZAp">
+          <node concept="3cpWs3" id="64l_37Q9nYu" role="3clFbG">
+            <node concept="2OqwBi" id="64l_37Q9wVB" role="3uHU7w">
+              <node concept="2OqwBi" id="64l_37Q9qzA" role="2Oq$k0">
+                <node concept="Xjq3P" id="64l_37Q9o31" role="2Oq$k0" />
+                <node concept="2OwXpG" id="64l_37Q9tSP" role="2OqNvi">
+                  <ref role="2Oxat5" node="6WUl45aDD6i" resolve="fmc" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="64l_37Q9zdd" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="64l_37Q8MoP" role="3uHU7B">
+              <property role="Xl_RC" value="Updating transitively extending configurations of abstract configuration " />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="64l_37Q8Gks" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="64l_37Q9E1g" role="jymVt" />
+    <node concept="3clFb_" id="6WUl45aHj$M" role="jymVt">
+      <property role="TrG5h" value="propagate" />
+      <node concept="3Tmbuc" id="6WUl45aHj$N" role="1B3o_S" />
+      <node concept="3cqZAl" id="6WUl45aHj$O" role="3clF45" />
+      <node concept="37vLTG" id="6WUl45aHj$P" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6WUl45aHj$Q" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WUl45aHj$V" role="3clF47">
+        <node concept="3clFbF" id="BUsxZFHC7p" role="3cqZAp">
+          <node concept="2YIFZM" id="438P21CdXNQ" role="3clFbG">
+            <ref role="37wK5l" to="ch50:BUsxZFHBLi" resolve="run" />
+            <ref role="1Pybhc" to="ch50:BUsxZFHAtC" resolve="FixAdaptToExtendedFMC" />
+            <node concept="37vLTw" id="BUsxZFHCio" role="37wK5m">
+              <ref role="3cqZAo" node="6WUl45aHj$P" resolve="config" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6WUl45aHj$W" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.intentions.mps
@@ -3488,6 +3488,7 @@
   </node>
   <node concept="2S6QgY" id="6WUl45aPI72">
     <property role="TrG5h" value="adaptExtendingFMCs" />
+    <property role="3GE5qa" value="adapt" />
     <ref role="2ZfgGC" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
     <node concept="2S6ZIM" id="6WUl45aPI73" role="2ZfVej">
       <node concept="3clFbS" id="6WUl45aPI74" role="2VODD2">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.intentions.mps
@@ -36,6 +36,7 @@
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -3482,6 +3483,159 @@
       </node>
     </node>
     <node concept="1SWQZ3" id="6iLh$uBJJLK" role="lGtFl">
+      <property role="1SWRpm" value="VARIABILITY" />
+    </node>
+  </node>
+  <node concept="2S6QgY" id="6WUl45aPI72">
+    <property role="TrG5h" value="adaptExtendingFMCs" />
+    <ref role="2ZfgGC" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+    <node concept="2S6ZIM" id="6WUl45aPI73" role="2ZfVej">
+      <node concept="3clFbS" id="6WUl45aPI74" role="2VODD2">
+        <node concept="3clFbF" id="6WUl45aPIob" role="3cqZAp">
+          <node concept="Xl_RD" id="6WUl45aPIoa" role="3clFbG">
+            <property role="Xl_RC" value="Adapt Extending Configurations to Changes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="6WUl45aPI75" role="2ZfgGD">
+      <node concept="3clFbS" id="6WUl45aPI76" role="2VODD2">
+        <node concept="3cpWs8" id="6WUl45aPMcG" role="3cqZAp">
+          <node concept="3cpWsn" id="6WUl45aPMcH" role="3cpWs9">
+            <property role="TrG5h" value="model" />
+            <node concept="H_c77" id="6WUl45aPMcI" role="1tU5fm" />
+            <node concept="2OqwBi" id="6WUl45aPMcJ" role="33vP2m">
+              <node concept="2Sf5sV" id="6WUl45aPMcK" role="2Oq$k0" />
+              <node concept="I4A8Y" id="6WUl45aPMcL" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6WUl45aPMcM" role="3cqZAp">
+          <node concept="2OqwBi" id="6WUl45aPMcN" role="3clFbG">
+            <node concept="2YIFZM" id="6WUl45aPMcO" role="2Oq$k0">
+              <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+              <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+            </node>
+            <node concept="liA8E" id="6WUl45aPMcP" role="2OqNvi">
+              <ref role="37wK5l" to="bd8o:~Application.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
+              <node concept="1bVj0M" id="6WUl45aPMcQ" role="37wK5m">
+                <node concept="3clFbS" id="6WUl45aPMcR" role="1bW5cS">
+                  <node concept="3cpWs8" id="6WUl45aPMcS" role="3cqZAp">
+                    <node concept="3cpWsn" id="6WUl45aPMcT" role="3cpWs9">
+                      <property role="TrG5h" value="project" />
+                      <node concept="3uibUv" id="6WUl45aPMcU" role="1tU5fm">
+                        <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+                      </node>
+                      <node concept="2OqwBi" id="6WUl45aPMcV" role="33vP2m">
+                        <node concept="2OqwBi" id="6WUl45aPMcW" role="2Oq$k0">
+                          <node concept="1XNTG" id="6WUl45aPMcX" role="2Oq$k0" />
+                          <node concept="liA8E" id="6WUl45aPMcY" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorContext.getOperationContext()" resolve="getOperationContext" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="6WUl45aPMcZ" role="2OqNvi">
+                          <ref role="37wK5l" to="w1kc:~IOperationContext.getProject()" resolve="getProject" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="6WUl45aPMd0" role="3cqZAp">
+                    <node concept="3cpWsn" id="6WUl45aPMd1" role="3cpWs9">
+                      <property role="TrG5h" value="task" />
+                      <node concept="3uibUv" id="6WUl45aPMd2" role="1tU5fm">
+                        <ref role="3uigEE" to="lte6:5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+                      </node>
+                      <node concept="2ShNRf" id="6WUl45aPMd3" role="33vP2m">
+                        <node concept="1pGfFk" id="6WUl45aPZbF" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="lte6:6WUl45aDBqz" resolve="UpadteAllExtendingConfigs" />
+                          <node concept="37vLTw" id="6WUl45aQ2vm" role="37wK5m">
+                            <ref role="3cqZAo" node="6WUl45aPMcT" resolve="project" />
+                          </node>
+                          <node concept="37vLTw" id="6WUl45aQ2Cw" role="37wK5m">
+                            <ref role="3cqZAo" node="6WUl45aPMcH" resolve="model" />
+                          </node>
+                          <node concept="2Sf5sV" id="6WUl45aQ2JJ" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="6WUl45aPMd8" role="3cqZAp">
+                    <node concept="2OqwBi" id="6WUl45aPMd9" role="3clFbG">
+                      <node concept="2YIFZM" id="6WUl45aPMda" role="2Oq$k0">
+                        <ref role="37wK5l" to="xygl:~ProgressManager.getInstance()" resolve="getInstance" />
+                        <ref role="1Pybhc" to="xygl:~ProgressManager" resolve="ProgressManager" />
+                      </node>
+                      <node concept="liA8E" id="6WUl45aPMdb" role="2OqNvi">
+                        <ref role="37wK5l" to="xygl:~ProgressManager.run(com.intellij.openapi.progress.Task)" resolve="run" />
+                        <node concept="37vLTw" id="6WUl45aPMdc" role="37wK5m">
+                          <ref role="3cqZAo" node="6WUl45aPMd1" resolve="task" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="6WUl45aPMdd" role="3cqZAp">
+                    <node concept="2OqwBi" id="6WUl45aPMde" role="3clFbG">
+                      <node concept="37vLTw" id="6WUl45aPMdf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6WUl45aPMd1" resolve="task" />
+                      </node>
+                      <node concept="liA8E" id="6WUl45aPMdg" role="2OqNvi">
+                        <ref role="37wK5l" to="lte6:5BtXES5TsZg" resolve="forceEditorUpdates" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6WUl45aPMdh" role="3cqZAp" />
+        <node concept="3clFbF" id="6WUl45aPMdi" role="3cqZAp">
+          <node concept="2OqwBi" id="6WUl45aPMdj" role="3clFbG">
+            <node concept="2Sf5sV" id="6WUl45aPMdk" role="2Oq$k0" />
+            <node concept="1OKiuA" id="6WUl45aPMdl" role="2OqNvi">
+              <node concept="1XNTG" id="6WUl45aPMdm" role="lBI5i" />
+              <node concept="2B6iha" id="6WUl45aPMdn" role="lGT1i">
+                <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+              </node>
+              <node concept="3cmrfG" id="6WUl45aPMdo" role="3dN3m$">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="3cmrfG" id="6WUl45aPMdp" role="mNZMC">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6WUl45aPMdq" role="3cqZAp">
+          <node concept="2OqwBi" id="6WUl45aPMdr" role="3clFbG">
+            <node concept="2OqwBi" id="6WUl45aPMds" role="2Oq$k0">
+              <node concept="1XNTG" id="6WUl45aPMdt" role="2Oq$k0" />
+              <node concept="liA8E" id="6WUl45aPMdu" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+              </node>
+            </node>
+            <node concept="liA8E" id="6WUl45aPMdv" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorComponent.scrollToNode(org.jetbrains.mps.openapi.model.SNode)" resolve="scrollToNode" />
+              <node concept="2Sf5sV" id="6WUl45aPMdw" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="6WUl45aPIX7" role="2ZfVeh">
+      <node concept="3clFbS" id="6WUl45aPIX8" role="2VODD2">
+        <node concept="3clFbF" id="6WUl45aPJc8" role="3cqZAp">
+          <node concept="2OqwBi" id="6WUl45aPJMq" role="3clFbG">
+            <node concept="2Sf5sV" id="6WUl45aPJc7" role="2Oq$k0" />
+            <node concept="3TrcHB" id="6WUl45aPL$P" role="2OqNvi">
+              <ref role="3TsBF5" to="4ndm:4onczE5U5c$" resolve="abstract" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1SWQZ3" id="64l_37QnWsb" role="lGtFl">
       <property role="1SWRpm" value="VARIABILITY" />
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.intentions.mps
@@ -3549,7 +3549,7 @@
                       <node concept="2ShNRf" id="6WUl45aPMd3" role="33vP2m">
                         <node concept="1pGfFk" id="6WUl45aPZbF" role="2ShVmc">
                           <property role="373rjd" value="true" />
-                          <ref role="37wK5l" to="lte6:6WUl45aDBqz" resolve="UpadteAllExtendingConfigs" />
+                          <ref role="37wK5l" to="lte6:6WUl45aDBqz" resolve="UpdateAllExtendingConfigs" />
                           <node concept="37vLTw" id="6WUl45aQ2vm" role="37wK5m">
                             <ref role="3cqZAo" node="6WUl45aPMcT" resolve="project" />
                           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/org.iets3.variability.configuration.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/org.iets3.variability.configuration.base.mpl
@@ -30,6 +30,7 @@
     <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
     <dependency reexport="false">5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)</dependency>
     <dependency reexport="false">7ee265bd-5986-4709-86ed-2c6daa33cd8c(org.iets3.core.expr.typetags.physunits)</dependency>
+    <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
@@ -102,6 +103,7 @@
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="5fef253e-34b0-443d-8035-9a2928b716d3(com.mbeddr.mpsutil.editor.displayControl)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
+    <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
     <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2145,6 +2145,11 @@
             <ref role="3bR37D" node="JUiQTzdslj" resolve="org.iets3.core.expr.typetags" />
           </node>
         </node>
+        <node concept="1SiIV0" id="64l_37QnW2n" role="3bR37C">
+          <node concept="3bR9La" id="64l_37QnW2o" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:54z9_KDR0Ol" resolve="com.mbeddr.mpsutil.intentions" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="7yHH$DDpBOh" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -4431,11 +4436,6 @@
         <node concept="1SiIV0" id="6csBVzcR5Qe" role="3bR37C">
           <node concept="3bR9La" id="6csBVzcR5Qf" role="1SiIV1">
             <ref role="3bR37D" node="44TucI3cjtV" resolve="org.iets3.core.expr.math.interpreter" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4bxCLc4VaO0" role="3bR37C">
-          <node concept="3bR9La" id="4bxCLc4VaO1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
@@ -29,7 +29,11 @@
     <import index="s6b7" ref="r:a7e2f963-3e46-49e0-a385-e8c7f33c91b7(org.iets3.variability.featuremodel.base.structure)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="gr5k" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.intellij.ide.plugins.newui(MPS.ThirdParty/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -87,6 +91,15 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -101,16 +114,32 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+      </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -118,23 +147,35 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
         <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
       <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
@@ -2642,9 +2683,9 @@
                 <node concept="liA8E" id="5l1CINTT9oy" role="2OqNvi">
                   <ref role="37wK5l" to="lte6:5szxK3gIZzC" resolve="run" />
                   <node concept="2ShNRf" id="5l1CINTUyN1" role="37wK5m">
-                    <node concept="1pGfFk" id="5l1CINTUyN2" role="2ShVmc">
+                    <node concept="HV5vD" id="5l1CINTWug6" role="2ShVmc">
                       <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="gr5k:~OneLineProgressIndicator.&lt;init&gt;()" resolve="OneLineProgressIndicator" />
+                      <ref role="HV5vE" node="5szxK3gIrkz" resolve="DummyIndicator" />
                     </node>
                   </node>
                 </node>
@@ -2846,6 +2887,297 @@
         <node concept="3xLA65" id="64l_37QrLBa" role="lGtFl">
           <property role="TrG5h" value="chunkOut" />
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5szxK3gIrkz">
+    <property role="TrG5h" value="DummyIndicator" />
+    <node concept="3Tm1VV" id="5szxK3gIrk$" role="1B3o_S" />
+    <node concept="3uibUv" id="5l1CINTVF$6" role="EKbjA">
+      <ref role="3uigEE" to="xygl:~ProgressIndicator" resolve="ProgressIndicator" />
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFB1" role="jymVt">
+      <property role="TrG5h" value="start" />
+      <node concept="3Tm1VV" id="5l1CINTVFB2" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFB4" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFB5" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFB6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFB7" role="jymVt">
+      <property role="TrG5h" value="stop" />
+      <node concept="3Tm1VV" id="5l1CINTVFB8" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFBa" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFBb" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFBc" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBd" role="jymVt">
+      <property role="TrG5h" value="isRunning" />
+      <node concept="3Tm1VV" id="5l1CINTVFBe" role="1B3o_S" />
+      <node concept="10P_77" id="5l1CINTVFBg" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFBh" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFBk" role="3cqZAp">
+          <node concept="3clFbT" id="5l1CINTVFBj" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFBi" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBl" role="jymVt">
+      <property role="TrG5h" value="cancel" />
+      <node concept="3Tm1VV" id="5l1CINTVFBm" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFBo" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFBp" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFBq" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBr" role="jymVt">
+      <property role="TrG5h" value="isCanceled" />
+      <node concept="3Tm1VV" id="5l1CINTVFBs" role="1B3o_S" />
+      <node concept="10P_77" id="5l1CINTVFBu" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFBv" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFBy" role="3cqZAp">
+          <node concept="3clFbT" id="5l1CINTVFBx" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFBw" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBz" role="jymVt">
+      <property role="TrG5h" value="setText" />
+      <node concept="3Tm1VV" id="5l1CINTVFB$" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFBA" role="3clF45" />
+      <node concept="37vLTG" id="5l1CINTVFBB" role="3clF46">
+        <property role="TrG5h" value="string" />
+        <node concept="3uibUv" id="5l1CINTVFBC" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+        <node concept="2AHcQZ" id="5l1CINTVFBD" role="2AJF6D">
+          <ref role="2AI5Lk" to="zn9m:~NlsContexts$ProgressText" resolve="NlsContexts.ProgressText" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFBE" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFBF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBG" role="jymVt">
+      <property role="TrG5h" value="getText" />
+      <node concept="3Tm1VV" id="5l1CINTVFBH" role="1B3o_S" />
+      <node concept="2AHcQZ" id="5l1CINTVFBJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="zn9m:~NlsContexts$ProgressText" resolve="NlsContexts.ProgressText" />
+      </node>
+      <node concept="3uibUv" id="5l1CINTVFBK" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFBL" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFBO" role="3cqZAp">
+          <node concept="10Nm6u" id="5l1CINTVFBN" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFBM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBP" role="jymVt">
+      <property role="TrG5h" value="setText2" />
+      <node concept="3Tm1VV" id="5l1CINTVFBQ" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFBS" role="3clF45" />
+      <node concept="37vLTG" id="5l1CINTVFBT" role="3clF46">
+        <property role="TrG5h" value="string" />
+        <node concept="3uibUv" id="5l1CINTVFBU" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+        <node concept="2AHcQZ" id="5l1CINTVFBV" role="2AJF6D">
+          <ref role="2AI5Lk" to="zn9m:~NlsContexts$ProgressDetails" resolve="NlsContexts.ProgressDetails" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFBW" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFBX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFBY" role="jymVt">
+      <property role="TrG5h" value="getText2" />
+      <node concept="3Tm1VV" id="5l1CINTVFBZ" role="1B3o_S" />
+      <node concept="2AHcQZ" id="5l1CINTVFC1" role="2AJF6D">
+        <ref role="2AI5Lk" to="zn9m:~NlsContexts$ProgressDetails" resolve="NlsContexts.ProgressDetails" />
+      </node>
+      <node concept="3uibUv" id="5l1CINTVFC2" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFC3" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFC6" role="3cqZAp">
+          <node concept="10Nm6u" id="5l1CINTVFC5" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFC4" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFC7" role="jymVt">
+      <property role="TrG5h" value="getFraction" />
+      <node concept="3Tm1VV" id="5l1CINTVFC8" role="1B3o_S" />
+      <node concept="10P55v" id="5l1CINTVFCa" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFCb" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFCe" role="3cqZAp">
+          <node concept="3b6qkQ" id="5l1CINTVFCd" role="3clFbG">
+            <property role="$nhwW" value="0.0d" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFCc" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCf" role="jymVt">
+      <property role="TrG5h" value="setFraction" />
+      <node concept="3Tm1VV" id="5l1CINTVFCg" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFCi" role="3clF45" />
+      <node concept="37vLTG" id="5l1CINTVFCj" role="3clF46">
+        <property role="TrG5h" value="d" />
+        <node concept="10P55v" id="5l1CINTVFCk" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFCl" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFCm" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCn" role="jymVt">
+      <property role="TrG5h" value="pushState" />
+      <node concept="3Tm1VV" id="5l1CINTVFCo" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFCq" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFCr" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFCs" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCt" role="jymVt">
+      <property role="TrG5h" value="popState" />
+      <node concept="3Tm1VV" id="5l1CINTVFCu" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFCw" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFCx" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFCy" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCz" role="jymVt">
+      <property role="TrG5h" value="isModal" />
+      <node concept="3Tm1VV" id="5l1CINTVFC$" role="1B3o_S" />
+      <node concept="10P_77" id="5l1CINTVFCA" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFCB" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFCE" role="3cqZAp">
+          <node concept="3clFbT" id="5l1CINTVFCD" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFCC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCF" role="jymVt">
+      <property role="TrG5h" value="getModalityState" />
+      <node concept="3Tm1VV" id="5l1CINTVFCG" role="1B3o_S" />
+      <node concept="2AHcQZ" id="5l1CINTVFCI" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3uibUv" id="5l1CINTVFCJ" role="3clF45">
+        <ref role="3uigEE" to="bd8o:~ModalityState" resolve="ModalityState" />
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFCK" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFCN" role="3cqZAp">
+          <node concept="10Nm6u" id="5l1CINTVFCM" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFCL" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCO" role="jymVt">
+      <property role="TrG5h" value="setModalityProgress" />
+      <node concept="3Tm1VV" id="5l1CINTVFCP" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFCR" role="3clF45" />
+      <node concept="37vLTG" id="5l1CINTVFCS" role="3clF46">
+        <property role="TrG5h" value="indicator" />
+        <node concept="3uibUv" id="5l1CINTVFCT" role="1tU5fm">
+          <ref role="3uigEE" to="xygl:~ProgressIndicator" resolve="ProgressIndicator" />
+        </node>
+        <node concept="2AHcQZ" id="5l1CINTVFCU" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFCV" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFCW" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFCX" role="jymVt">
+      <property role="TrG5h" value="isIndeterminate" />
+      <node concept="3Tm1VV" id="5l1CINTVFCY" role="1B3o_S" />
+      <node concept="10P_77" id="5l1CINTVFD0" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFD1" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFD4" role="3cqZAp">
+          <node concept="3clFbT" id="5l1CINTVFD3" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFD2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFD5" role="jymVt">
+      <property role="TrG5h" value="setIndeterminate" />
+      <node concept="3Tm1VV" id="5l1CINTVFD6" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFD8" role="3clF45" />
+      <node concept="37vLTG" id="5l1CINTVFD9" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="10P_77" id="5l1CINTVFDa" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFDb" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFDc" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFDd" role="jymVt">
+      <property role="TrG5h" value="checkCanceled" />
+      <node concept="3Tm1VV" id="5l1CINTVFDe" role="1B3o_S" />
+      <node concept="3cqZAl" id="5l1CINTVFDg" role="3clF45" />
+      <node concept="3uibUv" id="5l1CINTVFDh" role="Sfmx6">
+        <ref role="3uigEE" to="xygl:~ProcessCanceledException" resolve="ProcessCanceledException" />
+      </node>
+      <node concept="3clFbS" id="5l1CINTVFDi" role="3clF47" />
+      <node concept="2AHcQZ" id="5l1CINTVFDj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFDk" role="jymVt">
+      <property role="TrG5h" value="isPopupWasShown" />
+      <node concept="3Tm1VV" id="5l1CINTVFDl" role="1B3o_S" />
+      <node concept="10P_77" id="5l1CINTVFDn" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFDo" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFDr" role="3cqZAp">
+          <node concept="3clFbT" id="5l1CINTVFDq" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFDp" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5l1CINTVFDs" role="jymVt">
+      <property role="TrG5h" value="isShowing" />
+      <node concept="3Tm1VV" id="5l1CINTVFDt" role="1B3o_S" />
+      <node concept="10P_77" id="5l1CINTVFDv" role="3clF45" />
+      <node concept="3clFbS" id="5l1CINTVFDw" role="3clF47">
+        <node concept="3clFbF" id="5l1CINTVFDz" role="3cqZAp">
+          <node concept="3clFbT" id="5l1CINTVFDy" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5l1CINTVFDx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
@@ -2902,7 +2902,7 @@
       <node concept="3cqZAl" id="5l1CINTVFB4" role="3clF45" />
       <node concept="3clFbS" id="5l1CINTVFB5" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFB6" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFB7" role="jymVt">
@@ -2911,7 +2911,7 @@
       <node concept="3cqZAl" id="5l1CINTVFBa" role="3clF45" />
       <node concept="3clFbS" id="5l1CINTVFBb" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFBc" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBd" role="jymVt">
@@ -2924,7 +2924,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFBi" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBl" role="jymVt">
@@ -2933,7 +2933,7 @@
       <node concept="3cqZAl" id="5l1CINTVFBo" role="3clF45" />
       <node concept="3clFbS" id="5l1CINTVFBp" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFBq" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBr" role="jymVt">
@@ -2946,7 +2946,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFBw" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBz" role="jymVt">
@@ -2964,7 +2964,7 @@
       </node>
       <node concept="3clFbS" id="5l1CINTVFBE" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFBF" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBG" role="jymVt">
@@ -2982,7 +2982,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFBM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBP" role="jymVt">
@@ -3000,7 +3000,7 @@
       </node>
       <node concept="3clFbS" id="5l1CINTVFBW" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFBX" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFBY" role="jymVt">
@@ -3018,7 +3018,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFC4" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFC7" role="jymVt">
@@ -3033,7 +3033,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFCc" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCf" role="jymVt">
@@ -3046,7 +3046,7 @@
       </node>
       <node concept="3clFbS" id="5l1CINTVFCl" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFCm" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCn" role="jymVt">
@@ -3055,7 +3055,7 @@
       <node concept="3cqZAl" id="5l1CINTVFCq" role="3clF45" />
       <node concept="3clFbS" id="5l1CINTVFCr" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFCs" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCt" role="jymVt">
@@ -3064,7 +3064,7 @@
       <node concept="3cqZAl" id="5l1CINTVFCw" role="3clF45" />
       <node concept="3clFbS" id="5l1CINTVFCx" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFCy" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCz" role="jymVt">
@@ -3077,7 +3077,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFCC" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCF" role="jymVt">
@@ -3095,7 +3095,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFCL" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCO" role="jymVt">
@@ -3113,7 +3113,7 @@
       </node>
       <node concept="3clFbS" id="5l1CINTVFCV" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFCW" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFCX" role="jymVt">
@@ -3126,7 +3126,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFD2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFD5" role="jymVt">
@@ -3139,7 +3139,7 @@
       </node>
       <node concept="3clFbS" id="5l1CINTVFDb" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFDc" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFDd" role="jymVt">
@@ -3151,7 +3151,7 @@
       </node>
       <node concept="3clFbS" id="5l1CINTVFDi" role="3clF47" />
       <node concept="2AHcQZ" id="5l1CINTVFDj" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFDk" role="jymVt">
@@ -3164,7 +3164,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFDp" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5l1CINTVFDs" role="jymVt">
@@ -3177,7 +3177,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFDx" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
@@ -1586,7 +1586,7 @@
     </node>
   </node>
   <node concept="LiM7Y" id="6_MbJkvF2UL">
-    <property role="TrG5h" value="UpdateAllRelatedConfigurations" />
+    <property role="TrG5h" value="UpdateAllRelatedConfigurationsApplicable" />
     <property role="3YCmrE" value="Once feature model is edited, offer the intention to update all configurations for that feature model." />
     <node concept="1qefOq" id="6_MbJkvF3IT" role="25YQCW">
       <node concept="12icEM" id="6_MbJkvF3Vs" role="1qenE9">
@@ -3178,6 +3178,269 @@
       </node>
       <node concept="2AHcQZ" id="5l1CINTVFDx" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2FiNa4PQ$n5">
+    <property role="TrG5h" value="UpdateAllRelatedConfigurations" />
+    <property role="3YCmrE" value="Once feature model is edited, offer the intention to update all configurations for that feature model." />
+    <node concept="1qefOq" id="2FiNa4PQ$n6" role="25YQCW">
+      <node concept="12icEM" id="2FiNa4PQ$n7" role="1qenE9">
+        <property role="TrG5h" value="V" />
+        <node concept="12iwZl" id="2FiNa4PQ$n9" role="12i2BX">
+          <property role="bVyBI" value="1780820942" />
+          <node concept="12iwV3" id="2FiNa4PQ$na" role="12iwV8">
+            <property role="TrG5h" value="SomeRoot" />
+            <node concept="12iwV3" id="2FiNa4PQ$nz" role="12iwVe">
+              <property role="TrG5h" value="F" />
+            </node>
+          </node>
+          <node concept="LIFWc" id="2FiNa4PQ$nc" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="ReadOnlyModelAccessor_1lfgks_a0a1a" />
+          </node>
+          <node concept="3xLA65" id="2FiNa4PR2v4" role="lGtFl">
+            <property role="TrG5h" value="fm" />
+          </node>
+        </node>
+        <node concept="12i7jc" id="2FiNa4PQ$nd" role="12i2BX" />
+        <node concept="rqKB5" id="2FiNa4PQ$nl" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="828279390" />
+          <property role="bROok" value="-1465961555" />
+          <property role="1nQUAq" value="true" />
+          <property role="TrG5h" value="C1" />
+          <ref role="rqKBe" node="2FiNa4PQ$na" resolve="SomeRoot" />
+          <node concept="rqCGG" id="2FiNa4PQ$no" role="rqCGo" />
+        </node>
+        <node concept="rqKB5" id="2FiNa4PQ$nH" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="828279390" />
+          <property role="bROok" value="-1465961555" />
+          <property role="1nQUAq" value="true" />
+          <property role="TrG5h" value="C2" />
+          <ref role="rqKBe" node="2FiNa4PQ$na" resolve="SomeRoot" />
+          <node concept="rqCGG" id="2FiNa4PQ$nI" role="rqCGo" />
+        </node>
+        <node concept="3xLA65" id="2FiNa4PQ$nO" role="lGtFl">
+          <property role="TrG5h" value="chunkIn" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2FiNa4PQ$nf" role="LjaKd">
+      <node concept="1QHqEM" id="2FiNa4PQ$p0" role="3cqZAp">
+        <node concept="1QHqEC" id="2FiNa4PQ$p1" role="1QHqEI">
+          <node concept="3clFbS" id="2FiNa4PQ$p2" role="1bW5cS">
+            <node concept="3clFbF" id="2FiNa4PQZMs" role="3cqZAp">
+              <node concept="2OqwBi" id="2FiNa4PR3HR" role="3clFbG">
+                <node concept="2ShNRf" id="2FiNa4PQZMo" role="2Oq$k0">
+                  <node concept="1pGfFk" id="2FiNa4PR0lg" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="lte6:5BtXES5l600" resolve="UpdateAllConfigsTask" />
+                    <node concept="1jxXqW" id="2FiNa4PR0LR" role="37wK5m" />
+                    <node concept="1jGwE1" id="2FiNa4PR1Az" role="37wK5m" />
+                    <node concept="3xONca" id="2FiNa4PR2vh" role="37wK5m">
+                      <ref role="3xOPvv" node="2FiNa4PR2v4" resolve="fm" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="2FiNa4PR6X$" role="2OqNvi">
+                  <ref role="37wK5l" to="lte6:5szxK3gIZzC" resolve="run" />
+                  <node concept="2ShNRf" id="2FiNa4PR83$" role="37wK5m">
+                    <node concept="HV5vD" id="2FiNa4PR83_" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="HV5vE" node="5szxK3gIrkz" resolve="DummyIndicator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="2FiNa4PQ$pd" role="3cqZAp">
+              <node concept="1PaTwC" id="2FiNa4PQ$pe" role="1aUNEU">
+                <node concept="3oM_SD" id="2FiNa4PQ$pf" role="1PaTwD">
+                  <property role="3oM_SC" value="Make" />
+                </node>
+                <node concept="3oM_SD" id="2FiNa4PQ$pg" role="1PaTwD">
+                  <property role="3oM_SC" value="sure" />
+                </node>
+                <node concept="3oM_SD" id="2FiNa4PQ$ph" role="1PaTwD">
+                  <property role="3oM_SC" value="hash" />
+                </node>
+                <node concept="3oM_SD" id="2FiNa4PQ$pi" role="1PaTwD">
+                  <property role="3oM_SC" value="values" />
+                </node>
+                <node concept="3oM_SD" id="2FiNa4PQ$pj" role="1PaTwD">
+                  <property role="3oM_SC" value="are" />
+                </node>
+                <node concept="3oM_SD" id="2FiNa4PQ$pk" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="2FiNa4PQ$pl" role="1PaTwD">
+                  <property role="3oM_SC" value="compared" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2FiNa4PQ$pm" role="3cqZAp">
+              <node concept="2OqwBi" id="2FiNa4PQ$pn" role="3clFbG">
+                <node concept="2OqwBi" id="2FiNa4PQ$po" role="2Oq$k0">
+                  <node concept="2ShNRf" id="2FiNa4PQ$pp" role="2Oq$k0">
+                    <node concept="Tc6Ow" id="2FiNa4PQ$pq" role="2ShVmc">
+                      <node concept="2YIFZM" id="2FiNa4PQ$pr" role="I$8f6">
+                        <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...)" resolve="asList" />
+                        <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
+                        <node concept="3xONca" id="2FiNa4PQ$ps" role="37wK5m">
+                          <ref role="3xOPvv" node="2FiNa4PQ$nO" resolve="chunkIn" />
+                        </node>
+                        <node concept="3xONca" id="2FiNa4PQ$pt" role="37wK5m">
+                          <ref role="3xOPvv" node="2FiNa4PQ$nP" resolve="chunkOut" />
+                        </node>
+                        <node concept="3Tqbb2" id="2FiNa4PQ$pu" role="3PaCim">
+                          <ref role="ehGHo" to="vs0r:6clJcrJYOUA" resolve="Chunk" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3goQfb" id="2FiNa4PQ$pv" role="2OqNvi">
+                    <node concept="1bVj0M" id="2FiNa4PQ$pw" role="23t8la">
+                      <node concept="3clFbS" id="2FiNa4PQ$px" role="1bW5cS">
+                        <node concept="3clFbF" id="2FiNa4PQ$py" role="3cqZAp">
+                          <node concept="2OqwBi" id="2FiNa4PQ$pz" role="3clFbG">
+                            <node concept="37vLTw" id="2FiNa4PQ$p$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2FiNa4PQ$pC" resolve="chunk" />
+                            </node>
+                            <node concept="2Rf3mk" id="2FiNa4PQ$p_" role="2OqNvi">
+                              <node concept="1xMEDy" id="2FiNa4PQ$pA" role="1xVPHs">
+                                <node concept="chp4Y" id="2FiNa4PQ$pB" role="ri$Ld">
+                                  <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="2FiNa4PQ$pC" role="1bW2Oz">
+                        <property role="TrG5h" value="chunk" />
+                        <node concept="2jxLKc" id="2FiNa4PQ$pD" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="2FiNa4PQ$pE" role="2OqNvi">
+                  <node concept="1bVj0M" id="2FiNa4PQ$pF" role="23t8la">
+                    <node concept="3clFbS" id="2FiNa4PQ$pG" role="1bW5cS">
+                      <node concept="3clFbF" id="2FiNa4PQ$pH" role="3cqZAp">
+                        <node concept="37vLTI" id="2FiNa4PQ$pI" role="3clFbG">
+                          <node concept="2OqwBi" id="2FiNa4PQ$pJ" role="37vLTJ">
+                            <node concept="37vLTw" id="2FiNa4PQ$pK" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2FiNa4PQ$pZ" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="2FiNa4PQ$pL" role="2OqNvi">
+                              <ref role="3TsBF5" to="4ndm:2XyYtG$JrZf" resolve="__adaptHash" />
+                            </node>
+                          </node>
+                          <node concept="3cmrfG" id="2FiNa4PQ$pM" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2FiNa4PQ$pN" role="3cqZAp">
+                        <node concept="37vLTI" id="2FiNa4PQ$pO" role="3clFbG">
+                          <node concept="3cmrfG" id="2FiNa4PQ$pP" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="2FiNa4PQ$pQ" role="37vLTJ">
+                            <node concept="37vLTw" id="2FiNa4PQ$pR" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2FiNa4PQ$pZ" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="2FiNa4PQ$pS" role="2OqNvi">
+                              <ref role="3TsBF5" to="4kwy:6MJy$PGsrHL" resolve="__hash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2FiNa4PQ$pT" role="3cqZAp">
+                        <node concept="37vLTI" id="2FiNa4PQ$pU" role="3clFbG">
+                          <node concept="3cmrfG" id="2FiNa4PQ$pV" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="2FiNa4PQ$pW" role="37vLTJ">
+                            <node concept="37vLTw" id="2FiNa4PQ$pX" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2FiNa4PQ$pZ" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="2FiNa4PQ$pY" role="2OqNvi">
+                              <ref role="3TsBF5" to="s6b7:2XyYtG$zd0P" resolve="__updateHash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="2FiNa4PQ$pZ" role="1bW2Oz">
+                      <property role="TrG5h" value="fmc" />
+                      <node concept="2jxLKc" id="2FiNa4PQ$q0" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="2FiNa4PQ$q1" role="ukAjM">
+          <node concept="2JrnkZ" id="2FiNa4PQ$q2" role="2Oq$k0">
+            <node concept="1jGwE1" id="2FiNa4PQ$q3" role="2JrQYb" />
+          </node>
+          <node concept="liA8E" id="2FiNa4PQ$q4" role="2OqNvi">
+            <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2FiNa4PQ$np" role="25YQFr">
+      <node concept="12icEM" id="2FiNa4PQ$nr" role="1qenE9">
+        <property role="TrG5h" value="V" />
+        <node concept="12iwZl" id="2FiNa4PQ$nt" role="12i2BX">
+          <property role="bVyBI" value="1780820942" />
+          <node concept="12iwV3" id="2FiNa4PQ$nu" role="12iwV8">
+            <property role="TrG5h" value="SomeRoot" />
+            <node concept="12iwV3" id="2FiNa4PQ$n$" role="12iwVe">
+              <property role="TrG5h" value="F" />
+            </node>
+          </node>
+        </node>
+        <node concept="12i7jc" id="2FiNa4PQ$nw" role="12i2BX" />
+        <node concept="rqKB5" id="2FiNa4PQ$nA" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="-1130776460" />
+          <property role="bROok" value="-279218143" />
+          <property role="1nQUAq" value="true" />
+          <property role="TrG5h" value="C1" />
+          <ref role="rqKBe" node="2FiNa4PQ$nu" resolve="SomeRoot" />
+          <node concept="rqCGG" id="2FiNa4PQ$nD" role="rqCGo">
+            <node concept="rqKBd" id="2FiNa4PQ$nE" role="rqKBa">
+              <ref role="rqKBe" node="2FiNa4PQ$n$" resolve="F" />
+              <node concept="rqCGG" id="2FiNa4PQ$nF" role="rqCGo" />
+            </node>
+          </node>
+        </node>
+        <node concept="rqKB5" id="2FiNa4PQ$nK" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="-1130776460" />
+          <property role="bROok" value="-279218143" />
+          <property role="1nQUAq" value="true" />
+          <property role="TrG5h" value="C2" />
+          <ref role="rqKBe" node="2FiNa4PQ$nu" resolve="SomeRoot" />
+          <node concept="rqCGG" id="2FiNa4PQ$nL" role="rqCGo">
+            <node concept="rqKBd" id="2FiNa4PQ$nM" role="rqKBa">
+              <ref role="rqKBe" node="2FiNa4PQ$n$" resolve="F" />
+              <node concept="rqCGG" id="2FiNa4PQ$nN" role="rqCGo" />
+            </node>
+          </node>
+        </node>
+        <node concept="3xLA65" id="2FiNa4PQ$nP" role="lGtFl">
+          <property role="TrG5h" value="chunkOut" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
@@ -24,9 +24,12 @@
     <import index="xygl" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.progress(MPS.IDEA/)" />
     <import index="lte6" ref="r:dedd19c9-9ff3-4f30-aa73-ce61203b2296(org.iets3.variability.configuration.base.behavior)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
-    <import index="s6b7" ref="r:a7e2f963-3e46-49e0-a385-e8c7f33c91b7(org.iets3.variability.featuremodel.base.structure)" implicit="true" />
-    <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
+    <import index="s6b7" ref="r:a7e2f963-3e46-49e0-a385-e8c7f33c91b7(org.iets3.variability.featuremodel.base.structure)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="gr5k" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.intellij.ide.plugins.newui(MPS.ThirdParty/)" />
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -98,9 +101,6 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
-        <child id="1068431790190" name="initializer" index="33vP2m" />
-      </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
@@ -122,18 +122,12 @@
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
-        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
-      </concept>
-      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
-      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
-        <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -270,6 +264,9 @@
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -296,6 +293,11 @@
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237731803878" name="copyFrom" index="I$8f6" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
     </language>
   </registry>
   <node concept="1lH9Xt" id="2NjwOUW7Fv">
@@ -2621,109 +2623,155 @@
       </node>
     </node>
     <node concept="3clFbS" id="64l_37Qr4eb" role="LjaKd">
-      <node concept="3cpWs8" id="6WUl45aPMd0" role="3cqZAp">
-        <node concept="3cpWsn" id="6WUl45aPMd1" role="3cpWs9">
-          <property role="TrG5h" value="task" />
-          <node concept="3uibUv" id="6WUl45aPMd2" role="1tU5fm">
-            <ref role="3uigEE" to="lte6:5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
-          </node>
-          <node concept="2ShNRf" id="6WUl45aPMd3" role="33vP2m">
-            <node concept="1pGfFk" id="6WUl45aPZbF" role="2ShVmc">
-              <property role="373rjd" value="true" />
-              <ref role="37wK5l" to="lte6:6WUl45aDBqz" resolve="UpadteAllExtendingConfigs" />
-              <node concept="1jxXqW" id="64l_37QDY07" role="37wK5m" />
-              <node concept="1jGwE1" id="64l_37QDi7U" role="37wK5m" />
-              <node concept="3xONca" id="64l_37QDibv" role="37wK5m">
-                <ref role="3xOPvv" node="64l_37QDfeG" resolve="conf" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbF" id="6WUl45aPMd8" role="3cqZAp">
-        <node concept="2OqwBi" id="6WUl45aPMd9" role="3clFbG">
-          <node concept="2YIFZM" id="6WUl45aPMda" role="2Oq$k0">
-            <ref role="37wK5l" to="xygl:~ProgressManager.getInstance()" resolve="getInstance" />
-            <ref role="1Pybhc" to="xygl:~ProgressManager" resolve="ProgressManager" />
-          </node>
-          <node concept="liA8E" id="6WUl45aPMdb" role="2OqNvi">
-            <ref role="37wK5l" to="xygl:~ProgressManager.run(com.intellij.openapi.progress.Task)" resolve="run" />
-            <node concept="37vLTw" id="6WUl45aPMdc" role="37wK5m">
-              <ref role="3cqZAo" node="6WUl45aPMd1" resolve="task" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbH" id="64l_37QDbSA" role="3cqZAp" />
       <node concept="1QHqEM" id="64l_37Qu5t3" role="3cqZAp">
         <node concept="1QHqEC" id="64l_37Qu5t4" role="1QHqEI">
           <node concept="3clFbS" id="64l_37Qu5t5" role="1bW5cS">
-            <node concept="3clFbF" id="64l_37Qu5xX" role="3cqZAp">
-              <node concept="2OqwBi" id="64l_37QucPD" role="3clFbG">
-                <node concept="2OqwBi" id="64l_37Qu5OP" role="2Oq$k0">
-                  <node concept="3xONca" id="64l_37Qu5xW" role="2Oq$k0">
-                    <ref role="3xOPvv" node="64l_37Qu5k5" resolve="chunkIn" />
+            <node concept="3clFbF" id="5l1CINTT5WH" role="3cqZAp">
+              <node concept="2OqwBi" id="5l1CINTT793" role="3clFbG">
+                <node concept="2ShNRf" id="5l1CINTUwWJ" role="2Oq$k0">
+                  <node concept="1pGfFk" id="5l1CINTUwWK" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="lte6:6WUl45aDBqz" resolve="UpdateAllExtendingConfigs" />
+                    <node concept="1jxXqW" id="5l1CINTUwWL" role="37wK5m" />
+                    <node concept="1jGwE1" id="5l1CINTUwWM" role="37wK5m" />
+                    <node concept="3xONca" id="5l1CINTUwWN" role="37wK5m">
+                      <ref role="3xOPvv" node="64l_37QDfeG" resolve="conf" />
+                    </node>
                   </node>
-                  <node concept="2Rf3mk" id="64l_37Qu83q" role="2OqNvi">
-                    <node concept="1xMEDy" id="64l_37Qu83s" role="1xVPHs">
-                      <node concept="chp4Y" id="64l_37Qu843" role="ri$Ld">
-                        <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                </node>
+                <node concept="liA8E" id="5l1CINTT9oy" role="2OqNvi">
+                  <ref role="37wK5l" to="lte6:5szxK3gIZzC" resolve="run" />
+                  <node concept="2ShNRf" id="5l1CINTUyN1" role="37wK5m">
+                    <node concept="1pGfFk" id="5l1CINTUyN2" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="gr5k:~OneLineProgressIndicator.&lt;init&gt;()" resolve="OneLineProgressIndicator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="3uevuIl55KG" role="3cqZAp">
+              <node concept="1PaTwC" id="3uevuIl55KH" role="1aUNEU">
+                <node concept="3oM_SD" id="3uevuIl55KI" role="1PaTwD">
+                  <property role="3oM_SC" value="Make" />
+                </node>
+                <node concept="3oM_SD" id="3uevuIl561a" role="1PaTwD">
+                  <property role="3oM_SC" value="sure" />
+                </node>
+                <node concept="3oM_SD" id="3uevuIl56u5" role="1PaTwD">
+                  <property role="3oM_SC" value="hash" />
+                </node>
+                <node concept="3oM_SD" id="3uevuIl57aK" role="1PaTwD">
+                  <property role="3oM_SC" value="values" />
+                </node>
+                <node concept="3oM_SD" id="3uevuIl57qy" role="1PaTwD">
+                  <property role="3oM_SC" value="are" />
+                </node>
+                <node concept="3oM_SD" id="3uevuIl57Ek" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="3uevuIl57U6" role="1PaTwD">
+                  <property role="3oM_SC" value="compared" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="67Mt2MCf5lk" role="3cqZAp">
+              <node concept="2OqwBi" id="67Mt2MCfNdW" role="3clFbG">
+                <node concept="2OqwBi" id="67Mt2MCfq1C" role="2Oq$k0">
+                  <node concept="2ShNRf" id="67Mt2MCf5lg" role="2Oq$k0">
+                    <node concept="Tc6Ow" id="67Mt2MCfbE5" role="2ShVmc">
+                      <node concept="2YIFZM" id="67Mt2MCfhcZ" role="I$8f6">
+                        <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...)" resolve="asList" />
+                        <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
+                        <node concept="3xONca" id="67Mt2MCfhxg" role="37wK5m">
+                          <ref role="3xOPvv" node="64l_37Qu5k5" resolve="chunkIn" />
+                        </node>
+                        <node concept="3xONca" id="67Mt2MCfioo" role="37wK5m">
+                          <ref role="3xOPvv" node="64l_37QrLBa" resolve="chunkOut" />
+                        </node>
+                        <node concept="3Tqbb2" id="67Mt2MCfjuy" role="3PaCim">
+                          <ref role="ehGHo" to="vs0r:6clJcrJYOUA" resolve="Chunk" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3goQfb" id="67Mt2MCfEdW" role="2OqNvi">
+                    <node concept="1bVj0M" id="67Mt2MCfEdY" role="23t8la">
+                      <node concept="3clFbS" id="67Mt2MCfEdZ" role="1bW5cS">
+                        <node concept="3clFbF" id="67Mt2MCfFgT" role="3cqZAp">
+                          <node concept="2OqwBi" id="67Mt2MCfG9u" role="3clFbG">
+                            <node concept="37vLTw" id="67Mt2MCfFgS" role="2Oq$k0">
+                              <ref role="3cqZAo" node="67Mt2MCfEe0" resolve="chunk" />
+                            </node>
+                            <node concept="2Rf3mk" id="67Mt2MCfKKp" role="2OqNvi">
+                              <node concept="1xMEDy" id="67Mt2MCfKKr" role="1xVPHs">
+                                <node concept="chp4Y" id="67Mt2MCfLqE" role="ri$Ld">
+                                  <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="67Mt2MCfEe0" role="1bW2Oz">
+                        <property role="TrG5h" value="chunk" />
+                        <node concept="2jxLKc" id="67Mt2MCfEe1" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="2es0OD" id="64l_37QuqT0" role="2OqNvi">
-                  <node concept="1bVj0M" id="64l_37QuqT2" role="23t8la">
-                    <node concept="3clFbS" id="64l_37QuqT3" role="1bW5cS">
-                      <node concept="3clFbF" id="64l_37Qur4R" role="3cqZAp">
-                        <node concept="37vLTI" id="64l_37QxI6X" role="3clFbG">
-                          <node concept="2OqwBi" id="64l_37Qurr1" role="37vLTJ">
-                            <node concept="37vLTw" id="64l_37Qur4Q" role="2Oq$k0">
-                              <ref role="3cqZAo" node="64l_37QuqT4" resolve="fmc" />
+                <node concept="2es0OD" id="67Mt2MCfNFd" role="2OqNvi">
+                  <node concept="1bVj0M" id="67Mt2MCfNFe" role="23t8la">
+                    <node concept="3clFbS" id="67Mt2MCfNFf" role="1bW5cS">
+                      <node concept="3clFbF" id="67Mt2MCfNFg" role="3cqZAp">
+                        <node concept="37vLTI" id="67Mt2MCfNFh" role="3clFbG">
+                          <node concept="2OqwBi" id="67Mt2MCfNFi" role="37vLTJ">
+                            <node concept="37vLTw" id="67Mt2MCfNFj" role="2Oq$k0">
+                              <ref role="3cqZAo" node="67Mt2MCfNFy" resolve="fmc" />
                             </node>
-                            <node concept="3TrcHB" id="64l_37QuufP" role="2OqNvi">
+                            <node concept="3TrcHB" id="67Mt2MCfNFk" role="2OqNvi">
                               <ref role="3TsBF5" to="4ndm:2XyYtG$JrZf" resolve="__adaptHash" />
                             </node>
                           </node>
-                          <node concept="3cmrfG" id="64l_37QxLlT" role="37vLTx">
+                          <node concept="3cmrfG" id="67Mt2MCfNFl" role="37vLTx">
                             <property role="3cmrfH" value="0" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="64l_37QyeRN" role="3cqZAp">
-                        <node concept="37vLTI" id="64l_37QymG4" role="3clFbG">
-                          <node concept="3cmrfG" id="64l_37Qyn5k" role="37vLTx">
+                      <node concept="3clFbF" id="67Mt2MCfNFm" role="3cqZAp">
+                        <node concept="37vLTI" id="67Mt2MCfNFn" role="3clFbG">
+                          <node concept="3cmrfG" id="67Mt2MCfNFo" role="37vLTx">
                             <property role="3cmrfH" value="0" />
                           </node>
-                          <node concept="2OqwBi" id="64l_37Qygm$" role="37vLTJ">
-                            <node concept="37vLTw" id="64l_37QyeRL" role="2Oq$k0">
-                              <ref role="3cqZAo" node="64l_37QuqT4" resolve="fmc" />
+                          <node concept="2OqwBi" id="67Mt2MCfNFp" role="37vLTJ">
+                            <node concept="37vLTw" id="67Mt2MCfNFq" role="2Oq$k0">
+                              <ref role="3cqZAo" node="67Mt2MCfNFy" resolve="fmc" />
                             </node>
-                            <node concept="3TrcHB" id="64l_37QyiGx" role="2OqNvi">
+                            <node concept="3TrcHB" id="67Mt2MCfNFr" role="2OqNvi">
                               <ref role="3TsBF5" to="4kwy:6MJy$PGsrHL" resolve="__hash" />
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="64l_37Qyoou" role="3cqZAp">
-                        <node concept="37vLTI" id="64l_37QyuSL" role="3clFbG">
-                          <node concept="3cmrfG" id="64l_37QyvP6" role="37vLTx">
+                      <node concept="3clFbF" id="67Mt2MCfNFs" role="3cqZAp">
+                        <node concept="37vLTI" id="67Mt2MCfNFt" role="3clFbG">
+                          <node concept="3cmrfG" id="67Mt2MCfNFu" role="37vLTx">
                             <property role="3cmrfH" value="0" />
                           </node>
-                          <node concept="2OqwBi" id="64l_37QypRG" role="37vLTJ">
-                            <node concept="37vLTw" id="64l_37Qyoos" role="2Oq$k0">
-                              <ref role="3cqZAo" node="64l_37QuqT4" resolve="fmc" />
+                          <node concept="2OqwBi" id="67Mt2MCfNFv" role="37vLTJ">
+                            <node concept="37vLTw" id="67Mt2MCfNFw" role="2Oq$k0">
+                              <ref role="3cqZAo" node="67Mt2MCfNFy" resolve="fmc" />
                             </node>
-                            <node concept="3TrcHB" id="64l_37Qyr_E" role="2OqNvi">
+                            <node concept="3TrcHB" id="67Mt2MCfNFx" role="2OqNvi">
                               <ref role="3TsBF5" to="s6b7:2XyYtG$zd0P" resolve="__updateHash" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="gl6BB" id="64l_37QuqT4" role="1bW2Oz">
+                    <node concept="gl6BB" id="67Mt2MCfNFy" role="1bW2Oz">
                       <property role="TrG5h" value="fmc" />
-                      <node concept="2jxLKc" id="64l_37QuqT5" role="1tU5fm" />
+                      <node concept="2jxLKc" id="67Mt2MCfNFz" role="1tU5fm" />
                     </node>
                   </node>
                 </node>
@@ -2731,93 +2779,12 @@
             </node>
           </node>
         </node>
-        <node concept="2OqwBi" id="64l_37Qu5t6" role="ukAjM">
-          <node concept="1jxXqW" id="64l_37Qu5t7" role="2Oq$k0" />
-          <node concept="liA8E" id="64l_37Qu5t8" role="2OqNvi">
-            <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+        <node concept="2OqwBi" id="3uevuIl4ObV" role="ukAjM">
+          <node concept="2JrnkZ" id="3uevuIl4NFo" role="2Oq$k0">
+            <node concept="1jGwE1" id="3uevuIl4KhJ" role="2JrQYb" />
           </node>
-        </node>
-      </node>
-      <node concept="1QHqEM" id="64l_37QsqPl" role="3cqZAp">
-        <node concept="1QHqEC" id="64l_37QsqPn" role="1QHqEI">
-          <node concept="3clFbS" id="64l_37QsqPp" role="1bW5cS">
-            <node concept="3clFbF" id="64l_37Quz4C" role="3cqZAp">
-              <node concept="2OqwBi" id="64l_37Quz4D" role="3clFbG">
-                <node concept="2OqwBi" id="64l_37Quz4E" role="2Oq$k0">
-                  <node concept="3xONca" id="64l_37Quz4F" role="2Oq$k0">
-                    <ref role="3xOPvv" node="64l_37QrLBa" resolve="chunkOut" />
-                  </node>
-                  <node concept="2Rf3mk" id="64l_37Quz4G" role="2OqNvi">
-                    <node concept="1xMEDy" id="64l_37Quz4H" role="1xVPHs">
-                      <node concept="chp4Y" id="64l_37Quz4I" role="ri$Ld">
-                        <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2es0OD" id="64l_37Quz4J" role="2OqNvi">
-                  <node concept="1bVj0M" id="64l_37Quz4K" role="23t8la">
-                    <node concept="3clFbS" id="64l_37Quz4L" role="1bW5cS">
-                      <node concept="3clFbF" id="64l_37Quz4M" role="3cqZAp">
-                        <node concept="37vLTI" id="64l_37QvEUc" role="3clFbG">
-                          <node concept="3cmrfG" id="64l_37QvFi$" role="37vLTx">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="64l_37Quz4O" role="37vLTJ">
-                            <node concept="37vLTw" id="64l_37Quz4P" role="2Oq$k0">
-                              <ref role="3cqZAo" node="64l_37Quz4S" resolve="fmc" />
-                            </node>
-                            <node concept="3TrcHB" id="64l_37Quz4Q" role="2OqNvi">
-                              <ref role="3TsBF5" to="4ndm:2XyYtG$JrZf" resolve="__adaptHash" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="64l_37QvnQo" role="3cqZAp">
-                        <node concept="37vLTI" id="64l_37Qv_ge" role="3clFbG">
-                          <node concept="3cmrfG" id="64l_37Qv_Cu" role="37vLTx">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="64l_37Qvpk5" role="37vLTJ">
-                            <node concept="37vLTw" id="64l_37QvnQm" role="2Oq$k0">
-                              <ref role="3cqZAo" node="64l_37Quz4S" resolve="fmc" />
-                            </node>
-                            <node concept="3TrcHB" id="64l_37Qvthy" role="2OqNvi">
-                              <ref role="3TsBF5" to="4kwy:6MJy$PGsrHL" resolve="__hash" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="64l_37QvHcI" role="3cqZAp">
-                        <node concept="37vLTI" id="64l_37QvNh5" role="3clFbG">
-                          <node concept="3cmrfG" id="64l_37QvNSR" role="37vLTx">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="64l_37QvI5Y" role="37vLTJ">
-                            <node concept="37vLTw" id="64l_37QvHcG" role="2Oq$k0">
-                              <ref role="3cqZAo" node="64l_37Quz4S" resolve="fmc" />
-                            </node>
-                            <node concept="3TrcHB" id="64l_37QvKzN" role="2OqNvi">
-                              <ref role="3TsBF5" to="s6b7:2XyYtG$zd0P" resolve="__updateHash" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gl6BB" id="64l_37Quz4S" role="1bW2Oz">
-                      <property role="TrG5h" value="fmc" />
-                      <node concept="2jxLKc" id="64l_37Quz4T" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2OqwBi" id="64l_37QsrmH" role="ukAjM">
-          <node concept="1jxXqW" id="64l_37QsqSV" role="2Oq$k0" />
-          <node concept="liA8E" id="64l_37QsslD" role="2OqNvi">
-            <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+          <node concept="liA8E" id="3uevuIl4QMn" role="2OqNvi">
+            <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
@@ -10,15 +10,23 @@
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
   </languages>
   <imports>
     <import index="urik" ref="r:791971f5-b094-4342-a75c-0ce6c1b43e9d(org.iets3.variability.configuration.base.typesystem)" />
     <import index="nzwl" ref="r:dfaa2422-aef5-456d-a8cd-942c81b870e6(org.iets3.variability.configuration.base.intentions)" />
+    <import index="4ndm" ref="r:a9fe59d7-0b4f-42b0-925a-71cc04f93df1(org.iets3.variability.configuration.base.structure)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="xygl" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.progress(MPS.IDEA/)" />
+    <import index="lte6" ref="r:dedd19c9-9ff3-4f30-aa73-ce61203b2296(org.iets3.variability.configuration.base.behavior)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
-    <import index="4ndm" ref="r:a9fe59d7-0b4f-42b0-925a-71cc04f93df1(org.iets3.variability.configuration.base.structure)" implicit="true" />
     <import index="s6b7" ref="r:a7e2f963-3e46-49e0-a385-e8c7f33c91b7(org.iets3.variability.featuremodel.base.structure)" implicit="true" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
-    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -55,6 +63,7 @@
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -69,15 +78,39 @@
       <concept id="5266358701722203952" name="jetbrains.mps.lang.test.structure.ApplyQuickFix" flags="ng" index="1MTqDA" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -85,10 +118,21 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -113,6 +157,7 @@
     </language>
     <language id="71226ee2-bbc4-45d2-a41d-20b97237156c" name="org.iets3.variability.configuration.base">
       <concept id="6179108019278301564" name="org.iets3.variability.configuration.base.structure.FeatureWithCardinalityConfiguration" flags="ng" index="06ldX" />
+      <concept id="3632605611355345979" name="org.iets3.variability.configuration.base.structure.FMCInheritanceCheck" flags="ng" index="2jx8YP" />
       <concept id="6698472021570833404" name="org.iets3.variability.configuration.base.structure.InlineFeatureConfigurationContent" flags="ng" index="rqCGG">
         <child id="6698472021570799898" name="subfeatureConfigurations" index="rqKBa" />
         <child id="3470763221647207955" name="attributeAssignments" index="3HVKVh" />
@@ -123,10 +168,14 @@
         <property id="5050560734055387940" name="abstract" index="33ZQ4u" />
         <property id="4791626744562666548" name="initiallyChecked" index="1n_0Gn" />
         <property id="4791626744558055097" name="complete" index="1nQUAq" />
+        <child id="5050560734061908085" name="extendedFMC" index="30ne9f" />
       </concept>
       <concept id="6698472021570799901" name="org.iets3.variability.configuration.base.structure.FeatureConfiguration" flags="ng" index="rqKBd" />
       <concept id="6698472021570809194" name="org.iets3.variability.configuration.base.structure.FeatureModelConfigurationRef" flags="ng" index="rqMQU">
         <reference id="6698472021570809195" name="config" index="rqMQV" />
+      </concept>
+      <concept id="5050560734061908022" name="org.iets3.variability.configuration.base.structure.ExtendedFeatureModelConfigurationRef" flags="ng" index="30ne8c">
+        <reference id="5050560734061908041" name="config" index="30ne9N" />
       </concept>
       <concept id="3329517093767171467" name="org.iets3.variability.configuration.base.structure.FeatureModelConfigurationBase" flags="ng" index="3hCpYG" />
       <concept id="3470763221645494592" name="org.iets3.variability.configuration.base.structure.AbstractFeatureConfiguration" flags="ng" index="3HwiA2">
@@ -148,7 +197,9 @@
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
@@ -202,12 +253,22 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
         <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
         <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
+      </concept>
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
@@ -229,6 +290,12 @@
       <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
     </language>
   </registry>
   <node concept="1lH9Xt" id="2NjwOUW7Fv">
@@ -2460,6 +2527,358 @@
           </node>
         </node>
         <node concept="12i7jc" id="6p08gUDCquy" role="12i2BX" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="64l_37Qr4e1">
+    <property role="TrG5h" value="UpdateAllExtendingConfigurations" />
+    <property role="3YCmrE" value="Once feature model is edited, offer the intention to update all configurations for that feature model." />
+    <node concept="1qefOq" id="64l_37Qr4e2" role="25YQCW">
+      <node concept="12icEM" id="64l_37Qr4e3" role="1qenE9">
+        <property role="TrG5h" value="V" />
+        <node concept="12iwZl" id="64l_37Qr4e5" role="12i2BX">
+          <property role="bVyBI" value="1807182281" />
+          <node concept="12iwV3" id="64l_37Qr4e6" role="12iwV8">
+            <property role="TrG5h" value="SomeRoot" />
+            <node concept="12iwV3" id="64l_37Qr4e7" role="12iwVe">
+              <property role="TrG5h" value="F1" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="64l_37QDfpg" role="lGtFl">
+            <property role="TrG5h" value="feat" />
+          </node>
+        </node>
+        <node concept="rqKB5" id="64l_37Qr4ei" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="0" />
+          <property role="bROok" value="0" />
+          <property role="TrG5h" value="C1" />
+          <property role="33ZQ4u" value="true" />
+          <property role="0Rz4W" value="0" />
+          <property role="1nQUAq" value="true" />
+          <ref role="rqKBe" node="64l_37Qr4e6" resolve="SomeRoot" />
+          <node concept="rqCGG" id="64l_37Qr4el" role="rqCGo">
+            <node concept="rqKBd" id="64l_37Qr4em" role="rqKBa">
+              <property role="3BMj5M" value="5QKr2dW9gE1/userFalse" />
+              <ref role="rqKBe" node="64l_37Qr4e7" resolve="F1" />
+              <node concept="rqCGG" id="64l_37Qr4en" role="rqCGo" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="64l_37QDfeG" role="lGtFl">
+            <property role="TrG5h" value="conf" />
+          </node>
+          <node concept="LIFWc" id="64l_37QEByL" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="flag_abstract" />
+          </node>
+        </node>
+        <node concept="rqKB5" id="64l_37Qr4eq" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="0" />
+          <property role="1nQUAq" value="true" />
+          <property role="TrG5h" value="C2" />
+          <property role="33ZQ4u" value="true" />
+          <property role="bROok" value="0" />
+          <property role="0Rz4W" value="0" />
+          <ref role="rqKBe" node="64l_37Qr4e6" resolve="SomeRoot" />
+          <node concept="rqCGG" id="64l_37Qr4et" role="rqCGo">
+            <node concept="rqKBd" id="64l_37Qr4eu" role="rqKBa">
+              <ref role="rqKBe" node="64l_37Qr4e7" resolve="F1" />
+              <node concept="rqCGG" id="64l_37Qr4ev" role="rqCGo" />
+            </node>
+          </node>
+          <node concept="30ne8c" id="64l_37Qr4ex" role="30ne9f">
+            <ref role="30ne9N" node="64l_37Qr4ei" resolve="C1" />
+          </node>
+          <node concept="2jx8YP" id="64l_37Qr4ey" role="lGtFl" />
+        </node>
+        <node concept="rqKB5" id="64l_37Qr4KB" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="0" />
+          <property role="bROok" value="0" />
+          <property role="TrG5h" value="C3" />
+          <property role="0Rz4W" value="0" />
+          <property role="1nQUAq" value="true" />
+          <ref role="rqKBe" node="64l_37Qr4e6" resolve="SomeRoot" />
+          <node concept="rqCGG" id="64l_37Qr4KE" role="rqCGo">
+            <node concept="rqKBd" id="64l_37Qr4KF" role="rqKBa">
+              <property role="3BMj5M" value="5QKr2dW9gDW/userTrue" />
+              <ref role="rqKBe" node="64l_37Qr4e7" resolve="F1" />
+              <node concept="rqCGG" id="64l_37Qr4KG" role="rqCGo" />
+            </node>
+          </node>
+          <node concept="30ne8c" id="64l_37Qr4KJ" role="30ne9f">
+            <ref role="30ne9N" node="64l_37Qr4eq" resolve="C2" />
+          </node>
+          <node concept="2jx8YP" id="64l_37Qr4KK" role="lGtFl" />
+        </node>
+        <node concept="3xLA65" id="64l_37Qu5k5" role="lGtFl">
+          <property role="TrG5h" value="chunkIn" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="64l_37Qr4eb" role="LjaKd">
+      <node concept="3cpWs8" id="6WUl45aPMd0" role="3cqZAp">
+        <node concept="3cpWsn" id="6WUl45aPMd1" role="3cpWs9">
+          <property role="TrG5h" value="task" />
+          <node concept="3uibUv" id="6WUl45aPMd2" role="1tU5fm">
+            <ref role="3uigEE" to="lte6:5szxK3gIrkz" resolve="AbstractUpdateConfigsTask" />
+          </node>
+          <node concept="2ShNRf" id="6WUl45aPMd3" role="33vP2m">
+            <node concept="1pGfFk" id="6WUl45aPZbF" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="lte6:6WUl45aDBqz" resolve="UpadteAllExtendingConfigs" />
+              <node concept="1jxXqW" id="64l_37QDY07" role="37wK5m" />
+              <node concept="1jGwE1" id="64l_37QDi7U" role="37wK5m" />
+              <node concept="3xONca" id="64l_37QDibv" role="37wK5m">
+                <ref role="3xOPvv" node="64l_37QDfeG" resolve="conf" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="6WUl45aPMd8" role="3cqZAp">
+        <node concept="2OqwBi" id="6WUl45aPMd9" role="3clFbG">
+          <node concept="2YIFZM" id="6WUl45aPMda" role="2Oq$k0">
+            <ref role="37wK5l" to="xygl:~ProgressManager.getInstance()" resolve="getInstance" />
+            <ref role="1Pybhc" to="xygl:~ProgressManager" resolve="ProgressManager" />
+          </node>
+          <node concept="liA8E" id="6WUl45aPMdb" role="2OqNvi">
+            <ref role="37wK5l" to="xygl:~ProgressManager.run(com.intellij.openapi.progress.Task)" resolve="run" />
+            <node concept="37vLTw" id="6WUl45aPMdc" role="37wK5m">
+              <ref role="3cqZAo" node="6WUl45aPMd1" resolve="task" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="64l_37QDbSA" role="3cqZAp" />
+      <node concept="1QHqEM" id="64l_37Qu5t3" role="3cqZAp">
+        <node concept="1QHqEC" id="64l_37Qu5t4" role="1QHqEI">
+          <node concept="3clFbS" id="64l_37Qu5t5" role="1bW5cS">
+            <node concept="3clFbF" id="64l_37Qu5xX" role="3cqZAp">
+              <node concept="2OqwBi" id="64l_37QucPD" role="3clFbG">
+                <node concept="2OqwBi" id="64l_37Qu5OP" role="2Oq$k0">
+                  <node concept="3xONca" id="64l_37Qu5xW" role="2Oq$k0">
+                    <ref role="3xOPvv" node="64l_37Qu5k5" resolve="chunkIn" />
+                  </node>
+                  <node concept="2Rf3mk" id="64l_37Qu83q" role="2OqNvi">
+                    <node concept="1xMEDy" id="64l_37Qu83s" role="1xVPHs">
+                      <node concept="chp4Y" id="64l_37Qu843" role="ri$Ld">
+                        <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="64l_37QuqT0" role="2OqNvi">
+                  <node concept="1bVj0M" id="64l_37QuqT2" role="23t8la">
+                    <node concept="3clFbS" id="64l_37QuqT3" role="1bW5cS">
+                      <node concept="3clFbF" id="64l_37Qur4R" role="3cqZAp">
+                        <node concept="37vLTI" id="64l_37QxI6X" role="3clFbG">
+                          <node concept="2OqwBi" id="64l_37Qurr1" role="37vLTJ">
+                            <node concept="37vLTw" id="64l_37Qur4Q" role="2Oq$k0">
+                              <ref role="3cqZAo" node="64l_37QuqT4" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="64l_37QuufP" role="2OqNvi">
+                              <ref role="3TsBF5" to="4ndm:2XyYtG$JrZf" resolve="__adaptHash" />
+                            </node>
+                          </node>
+                          <node concept="3cmrfG" id="64l_37QxLlT" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="64l_37QyeRN" role="3cqZAp">
+                        <node concept="37vLTI" id="64l_37QymG4" role="3clFbG">
+                          <node concept="3cmrfG" id="64l_37Qyn5k" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="64l_37Qygm$" role="37vLTJ">
+                            <node concept="37vLTw" id="64l_37QyeRL" role="2Oq$k0">
+                              <ref role="3cqZAo" node="64l_37QuqT4" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="64l_37QyiGx" role="2OqNvi">
+                              <ref role="3TsBF5" to="4kwy:6MJy$PGsrHL" resolve="__hash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="64l_37Qyoou" role="3cqZAp">
+                        <node concept="37vLTI" id="64l_37QyuSL" role="3clFbG">
+                          <node concept="3cmrfG" id="64l_37QyvP6" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="64l_37QypRG" role="37vLTJ">
+                            <node concept="37vLTw" id="64l_37Qyoos" role="2Oq$k0">
+                              <ref role="3cqZAo" node="64l_37QuqT4" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="64l_37Qyr_E" role="2OqNvi">
+                              <ref role="3TsBF5" to="s6b7:2XyYtG$zd0P" resolve="__updateHash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="64l_37QuqT4" role="1bW2Oz">
+                      <property role="TrG5h" value="fmc" />
+                      <node concept="2jxLKc" id="64l_37QuqT5" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="64l_37Qu5t6" role="ukAjM">
+          <node concept="1jxXqW" id="64l_37Qu5t7" role="2Oq$k0" />
+          <node concept="liA8E" id="64l_37Qu5t8" role="2OqNvi">
+            <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+          </node>
+        </node>
+      </node>
+      <node concept="1QHqEM" id="64l_37QsqPl" role="3cqZAp">
+        <node concept="1QHqEC" id="64l_37QsqPn" role="1QHqEI">
+          <node concept="3clFbS" id="64l_37QsqPp" role="1bW5cS">
+            <node concept="3clFbF" id="64l_37Quz4C" role="3cqZAp">
+              <node concept="2OqwBi" id="64l_37Quz4D" role="3clFbG">
+                <node concept="2OqwBi" id="64l_37Quz4E" role="2Oq$k0">
+                  <node concept="3xONca" id="64l_37Quz4F" role="2Oq$k0">
+                    <ref role="3xOPvv" node="64l_37QrLBa" resolve="chunkOut" />
+                  </node>
+                  <node concept="2Rf3mk" id="64l_37Quz4G" role="2OqNvi">
+                    <node concept="1xMEDy" id="64l_37Quz4H" role="1xVPHs">
+                      <node concept="chp4Y" id="64l_37Quz4I" role="ri$Ld">
+                        <ref role="cht4Q" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="64l_37Quz4J" role="2OqNvi">
+                  <node concept="1bVj0M" id="64l_37Quz4K" role="23t8la">
+                    <node concept="3clFbS" id="64l_37Quz4L" role="1bW5cS">
+                      <node concept="3clFbF" id="64l_37Quz4M" role="3cqZAp">
+                        <node concept="37vLTI" id="64l_37QvEUc" role="3clFbG">
+                          <node concept="3cmrfG" id="64l_37QvFi$" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="64l_37Quz4O" role="37vLTJ">
+                            <node concept="37vLTw" id="64l_37Quz4P" role="2Oq$k0">
+                              <ref role="3cqZAo" node="64l_37Quz4S" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="64l_37Quz4Q" role="2OqNvi">
+                              <ref role="3TsBF5" to="4ndm:2XyYtG$JrZf" resolve="__adaptHash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="64l_37QvnQo" role="3cqZAp">
+                        <node concept="37vLTI" id="64l_37Qv_ge" role="3clFbG">
+                          <node concept="3cmrfG" id="64l_37Qv_Cu" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="64l_37Qvpk5" role="37vLTJ">
+                            <node concept="37vLTw" id="64l_37QvnQm" role="2Oq$k0">
+                              <ref role="3cqZAo" node="64l_37Quz4S" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="64l_37Qvthy" role="2OqNvi">
+                              <ref role="3TsBF5" to="4kwy:6MJy$PGsrHL" resolve="__hash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="64l_37QvHcI" role="3cqZAp">
+                        <node concept="37vLTI" id="64l_37QvNh5" role="3clFbG">
+                          <node concept="3cmrfG" id="64l_37QvNSR" role="37vLTx">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="64l_37QvI5Y" role="37vLTJ">
+                            <node concept="37vLTw" id="64l_37QvHcG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="64l_37Quz4S" resolve="fmc" />
+                            </node>
+                            <node concept="3TrcHB" id="64l_37QvKzN" role="2OqNvi">
+                              <ref role="3TsBF5" to="s6b7:2XyYtG$zd0P" resolve="__updateHash" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="64l_37Quz4S" role="1bW2Oz">
+                      <property role="TrG5h" value="fmc" />
+                      <node concept="2jxLKc" id="64l_37Quz4T" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="64l_37QsrmH" role="ukAjM">
+          <node concept="1jxXqW" id="64l_37QsqSV" role="2Oq$k0" />
+          <node concept="liA8E" id="64l_37QsslD" role="2OqNvi">
+            <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="64l_37Qr4KU" role="25YQFr">
+      <node concept="12icEM" id="64l_37Qr4KS" role="1qenE9">
+        <property role="TrG5h" value="V" />
+        <node concept="12iwZl" id="64l_37Qr4KV" role="12i2BX">
+          <property role="bVyBI" value="1807182281" />
+          <node concept="12iwV3" id="64l_37Qr4KW" role="12iwV8">
+            <property role="TrG5h" value="SomeRoot" />
+            <node concept="12iwV3" id="64l_37Qr4KX" role="12iwVe">
+              <property role="TrG5h" value="F1" />
+            </node>
+          </node>
+        </node>
+        <node concept="rqKB5" id="64l_37Qr54F" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="-1734977384" />
+          <property role="bROok" value="0" />
+          <property role="0Rz4W" value="-527928529" />
+          <property role="TrG5h" value="C1" />
+          <property role="33ZQ4u" value="true" />
+          <property role="1nQUAq" value="true" />
+          <ref role="rqKBe" node="64l_37Qr4KW" resolve="SomeRoot" />
+          <node concept="rqCGG" id="64l_37Qr54I" role="rqCGo">
+            <node concept="rqKBd" id="64l_37Qr54J" role="rqKBa">
+              <property role="3BMj5M" value="5QKr2dW9gE1/userFalse" />
+              <ref role="rqKBe" node="64l_37Qr4KX" resolve="F1" />
+              <node concept="rqCGG" id="64l_37Qr54K" role="rqCGo" />
+            </node>
+          </node>
+        </node>
+        <node concept="rqKB5" id="64l_37Qr5vm" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bROok" value="0" />
+          <property role="TrG5h" value="C2" />
+          <property role="33ZQ4u" value="true" />
+          <property role="1nQUAq" value="true" />
+          <ref role="rqKBe" node="64l_37Qr4KW" resolve="SomeRoot" />
+          <node concept="rqCGG" id="64l_37Qr5vp" role="rqCGo" />
+          <node concept="30ne8c" id="64l_37Qr5GI" role="30ne9f">
+            <ref role="30ne9N" node="64l_37Qr54F" resolve="C1" />
+          </node>
+        </node>
+        <node concept="rqKB5" id="64l_37Qr5Xn" role="12i2BX">
+          <property role="26YOJW" value="" />
+          <property role="bVyBI" value="1558435336" />
+          <property role="bROok" value="0" />
+          <property role="0Rz4W" value="200330400" />
+          <property role="TrG5h" value="C3" />
+          <property role="1nQUAq" value="true" />
+          <ref role="rqKBe" node="64l_37Qr4KW" resolve="SomeRoot" />
+          <node concept="rqCGG" id="64l_37Qr5Xq" role="rqCGo" />
+          <node concept="30ne8c" id="64l_37Qr6aJ" role="30ne9f">
+            <ref role="30ne9N" node="64l_37Qr5vm" resolve="C2" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="64l_37QrLBa" role="lGtFl">
+          <property role="TrG5h" value="chunkOut" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/test.org.iets3.variability.configuration.base.msd
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/test.org.iets3.variability.configuration.base.msd
@@ -46,8 +46,10 @@
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />


### PR DESCRIPTION
## Summary

Implements #1948: on an **abstract** feature model configuration, all configurations that extend it — directly or transitively — can now be reconciled in one step, instead of applying the single-config fix *"Adapt this Configuration to the extended Configuration"* one by one along the `extends` chain.

## Changes

- **Intention** — new `adaptExtendingFMCs` [(node url)](http://127.0.0.1:63320/node?ref=r%3Adfaa2422-aef5-456d-a8cd-942c81b870e6%28org.iets3.variability.configuration.base.intentions%29%2F8014811126264422850) *"Adapt Extending Configurations to Changes"* on `FeatureModelConfiguration`, visible only when the configuration is `abstract`. It runs the batch task in a modal progress dialog and refreshes the affected editors afterwards. The language therefore now depends on `com.mbeddr.mpsutil.intentions`.

- **Batch task** — `UpdateAllExtendingConfigs` [(node url)](http://127.0.0.1:63320/node?ref=r%3Adedd19c9-9ff3-4f30-aa73-ce61203b2296%28org.iets3.variability.configuration.base.behavior%29%2F8014811126261165998) collects the transitive closure of extending configurations level by level over `FeatureModelConfiguration.extendedFMC.config`, restricted to the `ConfigurationScopeProvider.configurationsScope(...)` of the abstract configuration's feature model, so the chain is processed top-down. Each configuration is reconciled through the existing `FixAdaptToExtendedFMC.run(config)`, so intention, quickfix and batch run stay behaviourally identical.

- **Shared machinery** — `AbstractUpdateConfigsTask` [(node url)](http://127.0.0.1:63320/node?ref=r%3Adedd19c9-9ff3-4f30-aa73-ce61203b2296%28org.iets3.variability.configuration.base.behavior%29%2F6279010743056184611) was generalized: which configurations to update, how to propagate, the progress text and the final log message are now hooks. The feature-model defaults (`ConfigUpdateHelper.propagateFeatureModelChangesToConfig`, *"Updating structure according to feature model…"*) moved into the new intermediate class `ConfigFromFeatureModelUpdater` [(node url)](http://127.0.0.1:63320/node?ref=r%3Adedd19c9-9ff3-4f30-aa73-ce61203b2296%28org.iets3.variability.configuration.base.behavior%29%2F6995660538504659200), which `UpdateAllConfigsTask`, `UpdateOneConfigTask` and `UpdateAllExtendingConfigs` extend. Modal progress, strictly sequential execution, postponed event handling, timing logs and the cancel semantics established in #1536 / #1571 are unchanged.

- **Read-only models** — the dirty-marking at the end of the task is now skipped for models with a read-only data source (`SModelBase.isReadOnly()`). Otherwise `setChanged(true)` logs *"Attempt to change a model with read-only data source"*, which fails the node tests in the packaged Gradle test run while passing in the IDE.

- **Test** — node test `UpdateAllExtendingConfigurations` in `test.org.iets3.variability.configuration.base.checking_rules` covering an `extends` chain of three configurations; it drives the task with a `DummyIndicator` so it can run without a progress dialog.

Resolves #1948. The base branch is `maintenance/mps20241`, so the ticket needs to be closed manually.
